### PR TITLE
Jekyll3 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 ietemplates/
-
+_site/*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pages and formats should be based off existing pages to maintain a consistent lo
 
 ## Deployment
 
-Deploying this website requires Jekyll (2.5+) and the following ruby gems: builder, rubysl-rexml
+Deploying this website requires Jekyll (3.0+) and the following ruby gems: builder, rubysl-rexml, jekyll-paginate
 
 Multiple language support will be added soon.
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ kramdown:
     smart_quotes: ["apos", "apos", "quot", "quot"]
 
 exclude: ["README.md"]
-
+gems: [jekyll-paginate]
 paginate: 10
 paginate_path: blog/page:num/
 

--- a/_plugins/plugin.rb
+++ b/_plugins/plugin.rb
@@ -39,7 +39,7 @@ module Jekyll
       
       # If we have an @, pass the string through the markdown converter, so that we hit the Moneropedia plugin
       if translation.include? '@'
-        converter = site.getConverterImpl(::Jekyll::Converters::Markdown)
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         translation = converter.convert(translation)[3..-6]
       end
 

--- a/_plugins/sitemap_generator.rb
+++ b/_plugins/sitemap_generator.rb
@@ -10,49 +10,33 @@
 # Site: http://www.kinnetica.com
 # Distributed Under A Creative Commons License
 #   - http://creativecommons.org/licenses/by/3.0/
-
+require 'jekyll/document'
 require 'rexml/document'
 
 module Jekyll
 
-  class Post
+  class Jekyll::Document
     attr_accessor :name
 
-    def full_path_to_source
-      File.join(@base, @name)
-    end
-    
     def path_to_source
-      File.join(@name)
+      File.join(*[@name].compact)
     end
 
     def location_on_server(my_url)
-      location = "#{my_url}#{url}"
-      location.gsub(/index.html$/, "")
+      "#{my_url}#{url}"
     end
   end
 
   class Page
     attr_accessor :name
 
-    def full_path_to_source
-      File.join(@base, @dir, @name)
-    end
-    
     def path_to_source
-      File.join(@dir, @name)
+      File.join(*[@dir, @name].compact)
     end
 
     def location_on_server(my_url)
       location = "#{my_url}#{url}"
       location.gsub(/index.html$/, "")
-    end
-  end
-
-
-  class Layout
-    def full_path_to_source
-      File.join(@base, @name)
     end
   end
 
@@ -120,15 +104,15 @@ module Jekyll
     #
     # Returns last_modified_date of latest post
     def fill_posts(site, urlset)
+
       last_modified_date = nil
-      site.posts.each do |post|
+      site.collections["posts"].docs.each do |post|
         if !excluded?(site, post.name)
           url = fill_url(site, post)
           urlset.add_element(url)
         end
 
-        path = post.full_path_to_source
-        date = File.mtime(path)
+        date = File.mtime(post.path)
         last_modified_date = date if last_modified_date == nil or date > last_modified_date
       end
 
@@ -142,8 +126,7 @@ module Jekyll
     def fill_pages(site, urlset)
       site.pages.each do |page|
         if !excluded?(site, page.path_to_source)
-          path = page.full_path_to_source
-          if File.exists?(path)
+          if File.exists?(page.path)
             url = fill_url(site, page)
             urlset.add_element(url)
           end
@@ -151,7 +134,7 @@ module Jekyll
       end
     end
 
-    # Fill data of each URL element: location, last modified, 
+    # Fill data of each URL element: location, last modified,
     # change frequency (optional), and priority.
     #
     # Returns url REXML::Element
@@ -199,9 +182,7 @@ module Jekyll
     def fill_location(site, page_or_post)
       loc = REXML::Element.new "loc"
       url = site.config['url'] + site.config['baseurl']
-
-      # the Monero site is served "extensionless", so lose the extensions
-      loc.text = page_or_post.location_on_server(url).gsub('.html', '').gsub('.php', '')
+      loc.text = page_or_post.location_on_server(url)
 
       loc
     end
@@ -210,10 +191,8 @@ module Jekyll
     #
     # Returns lastmod REXML::Element or nil
     def fill_last_modified(site, page_or_post)
-      path = page_or_post.full_path_to_source
-
       lastmod = REXML::Element.new "lastmod"
-      date = File.mtime(path)
+      date = File.mtime(page_or_post.path)
       latest_date = find_latest_date(date, site, page_or_post)
 
       if @last_modified_post_date == nil
@@ -240,8 +219,7 @@ module Jekyll
       layouts = site.layouts
       layout = layouts[page_or_post.data["layout"]]
       while layout
-        path = layout.full_path_to_source
-        date = File.mtime(path)
+        date = File.mtime(layout.path)
 
         latest_date = date if (date > latest_date)
 


### PR DESCRIPTION
Site is now compatible with Jekyll 3+ . The plugins had a lot that wasn't compatible anymore so I updated the jekyll-live-titles and sitemap_generator plugins with the latest version I found on their respective repos. I noticed that there were some customizations made in the history on live tiles, so I can go back and try and add/fix anything if I overwrote something.