### PR TITLE
CoinCut service - Buying Monero with fiat (GBP)

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -8,6 +8,8 @@
       url: https://www.bittrex.com/Market/Index?MarketName=BTC-XMR
     - name: Bter
       url: https://bter.com/
+    - name: CoinCut (OTC)
+      url: https://www.coincut.com
     - name: Cryptopia
       url: https://www.cryptopia.co.nz/Exchange?market=XMR_BTC
     - name: Poloniex


### PR DESCRIPTION
Related blog post: http://blog.coincut.com/2016/08/17/buy-dash-ethereum-monero-gbp-wallets