### PR TITLE
Fix blog pagination and add contribute page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,6 +25,7 @@
           <ul class="dropdown-menu" role="menu">
             <li><a href="/getting-started/choose">{% t menu.choose %}</a></li>
             <li><a href="/getting-started/running">{% t menu.running %}</a></li>
+            <li><a href="/getting-started/contribute">{% t menu.contribute %}</a></li>
             <li><a href="/getting-started/donate">{% t menu.donations %}</a></li>
             <li class="divider"></li>
             <li><a href="/downloads">{% t menu.downloads %}</a></li>

--- a/_strings_en.yml
+++ b/_strings_en.yml
@@ -28,6 +28,7 @@ menu:
   choose: How to Choose a Monero Client
   running: How to Run a Monero Node
   donations: Donating and Sponsorships
+  contribute: Contributing to Monero
   downloads: All Monero Downloads
   merchants: Merchants and Services Directory
   accepting: Accepting Monero Payments

--- a/blog/index.html
+++ b/blog/index.html
@@ -33,9 +33,9 @@ title: All Blog Posts
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ '/index.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ '/blog' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
-      <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
+      <a href="{{ site.paginate_path | prepend: '/' | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}
   {% endfor %}
 

--- a/getting-started/contribute.md
+++ b/getting-started/contribute.md
@@ -23,10 +23,10 @@ Know how to compile some code? Then it helps for others if you test out builds o
 If you have an IT or CS background and can code, go to [#monero-dev](irc://chat.freenode.net/#monero-dev) on freenode and ask around to see if anything needs doing. You can also simply go to the [Monero Project on GitHub](https://github.com/monero-project) and see what issues need help.
 
 ### Run a node 
-Secure the network and help keep Monero decentralized, it's simple to do, and only requires some bandwidth. Learn [how to set up a monero node here.](/getting-started/running) You can also run a node onf a VPS, [guide on how to do that is here.](/knowledge-base/user-guides/vps_run_node)
+Secure the network and help keep Monero decentralized, it's simple to do, and only requires some bandwidth. Learn [how to set up a monero node here.](/getting-started/running) You can also run a node on a VPS, [guide on how to do that is here.](/knowledge-base/user-guides/vps_run_node)
 
 ### Mine 
-It is still possible to mine, even on a cpu. If you have some spare hardware, you are actively adding to it's decentralisation.
+It is still possible to mine, even on a cpu. If you have some spare hardware, you are actively adding to it's decentralisation. Find more information on mining Monero in [this thread on Bitcointalk.](https://bitcointalk.org/index.php?topic=653467)
 
 ### Spread the word
 The size of the Monero community is very very small in the grand scheme of things. Even beyond that, bitcoin itself is still a very niche thing in the wider world. Talk to the friends you know who might be interested in this kind of thing and get more people involved.

--- a/getting-started/contribute.md
+++ b/getting-started/contribute.md
@@ -1,0 +1,23 @@
+---
+layout: static_page
+title: "Contributing To Monero"
+title-pre-kick: "Contributing "
+title-kick: "to "
+title-post-kick: "Monero"
+kick-class: "kicks"
+icon: "icon_people"
+attribution: "<!-- Icon is based on work by Freepik (http://www.freepik.com) and is licensed under Creative Commons BY 3.0 -->"
+---
+
+### Contributing To Monero
+
+Some text about contributing.
+
+- Way 1
+Bla bla
+- Way 2
+Bla bla 
+
+### End
+
+This is the end.

--- a/getting-started/contribute.md
+++ b/getting-started/contribute.md
@@ -9,15 +9,29 @@ icon: "icon_people"
 attribution: "<!-- Icon is based on work by Freepik (http://www.freepik.com) and is licensed under Creative Commons BY 3.0 -->"
 ---
 
-### Contributing To Monero
+### Contributing to The Monero Project
 
-Some text about contributing.
+There are lots of ways for newcomers to contribute to The Monero Project.
 
-- Way 1
-Bla bla
-- Way 2
-Bla bla 
+### Documenting 
+Asking questions and helping on [Stack Exchange](http://monero.stackexchange.com) and [Reddit](https://www.reddit.com/r/Monero/) is actually quite useful. Working on and improving the [Moneropedia](/knowledge-base/moneropedia/) is important as well. 
 
-### End
+### Testing / bug reports 
+Know how to compile some code? Then it helps for others if you test out builds or run software on various version to catch any errors that slip through. Report bugs and security issues.
 
-This is the end.
+### Code
+If you have an IT or CS background and can code, go to [#monero-dev](irc://chat.freenode.net/#monero-dev) on freenode and ask around to see if anything needs doing. You can also simply go to the [Monero Project on GitHub](https://github.com/monero-project) and see what issues need help.
+
+### Run a node 
+Secure the network and help keep Monero decentralized, it's simple to do, and only requires some bandwidth. Learn [how to set up a monero node here.](/getting-started/running) You can also run a node onf a VPS, [guide on how to do that is here.](/knowledge-base/user-guides/vps_run_node)
+
+### Mine 
+It is still possible to mine, even on a cpu. If you have some spare hardware, you are actively adding to it's decentralisation.
+
+### Spread the word
+The size of the Monero community is very very small in the grand scheme of things. Even beyond that, bitcoin itself is still a very niche thing in the wider world. Talk to the friends you know who might be interested in this kind of thing and get more people involved.
+
+Sharings news about Monero on social media is useful as well. You can find Monero on [Facebook](https://www.facebook.com/monerocurrency), [Twitter](https://twitter.com/monerocurrency) and [Reddit.](https://www.reddit.com/r/Monero/)
+
+### Donations 
+Ongoing development of the Monero Project is solely supported by [donations and sponsors.](/getting-started/donate/) At this time the project is vastly underfunded, and thus donations are greatly appreciated. You can also donate for bounties in the forum funding section, or if theres a feature you're passionate about, you could get it posted.

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -19,6 +19,8 @@ attribution: "<!-- Icon is based on work by Freepik (http://www.freepik.com) and
 
 <div class="text-center" style="padding-bottom: 15px;"><a style="color: #505050;" href="/getting-started/running"><img src="//static.getmonero.org/images/icon_node.svg" class="title-icon"><h2 class="inline">How to Run a <span class="yellow-kicks">Monero Node</span></h2></a></div>
 
+<div class="text-center" style="padding-bottom: 15px;"><a style="color: #505050;" href="/getting-started/contribute"><img src="//static.getmonero.org/images/icon_people.svg" class="title-icon"><h2 class="inline">Contributing to <span class="yellow-kicks">Monero</span></h2></a></div>
+
 
 <div class="text-center" style="padding-bottom: 15px;"><a style="color: #505050;" href="/getting-started/donate"><img src="//static.getmonero.org/images/icon_donations.svg" class="title-icon"><h2 class="inline">Donating and <span class="kicks">Sponsorships</span></h2></a></div>
 


### PR DESCRIPTION
The numeric pagination on the blog page leads to `https://getmonero.org/blog/page3/blog/page4/404` etc now, this has been fixed.

I saw all the views and answers this question got on Stack Exchange: http://monero.stackexchange.com/questions/1647/for-newcomers-to-the-monero-community-what-can-we-do-to-help-the-project

I was not able to find any place on the Monero website where this was explained so I made a page. I'm also a newcomer so please add or edit the content if needed. The content is mostly based on the answers to the question on Stack Exchange.