### PR TITLE
Downloads: clarify that checksum is SHA256

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -61,7 +61,7 @@ Note: the SHA256 hashes are listed by the downloads for convenience, but a GPG-s
 </h4>
 
 <strong>Current Version:</strong> {{ data_downloads.version }} <em>{{ data_downloads.tag }}</em><br>
-<strong>SHA Hash:</strong> {{ data_downloads.hash }}<br>
+<strong>SHA256 Hash:</strong> {{ data_downloads.hash }}<br>
 <hr>
 
 </div>


### PR DESCRIPTION
Despite the obviousness of the length of the hash, and the fact that
there is a small note on the page noting the type of hash, the point
should be made clearly and quickly.