### PR TITLE
Update view_only.md

### DIFF
--- a/knowledge-base/user-guides/view_only.md
+++ b/knowledge-base/user-guides/view_only.md
@@ -11,13 +11,12 @@ attribution: "<!-- Icon is based on work by Freepik (http://www.freepik.com) and
 
 ### Operating Systems:  Ubuntu
 
-Note : In order to create a viewonly wallet you need first to compile the last source available on [Github](https://github.com/monero-project/bitmonero) as this functionality is not yet included in the official binaries (Sept. 2015).
 
 - To create a view only wallet you will need to first create a "normal" wallet and get the associated viewkey and address. You can get them once logged in monero-wallet-cli by typing "*viewkey*" and "*address*". Note each of them carefully and exit monero-wallet-cli.
 
-- Launch a new instance of monero-wallet-cli by typing "`./monero-wallet-cli --generate-from-view-key yourAddress:yourViewKey:nameOfTheViewOnlyWallet`" where *yourViewKey* is the view key you got from step 1 and *yourAddress* the associated address. The last part of the command is the name you want to give to you view only portfolio.
+- Launch a new instance of monero-wallet-cli by typing "`./monero-wallet-cli --generate-from-view-key nameOfTheViewOnlyWallet`" where nameOfTheViewOnlyWallet is any name of your choice.
 
-- Follow the instructions from the terminal. To see the balance of your portfolio type "*refresh*" (monerod need to be synchronised with the network first). 
+- Follow the instructions from the terminal. The system will then prompt you to enter your address, viewkey, and finally your desired password. To see the balance of your portfolio type "*refresh*" (monerod need to be synchronised with the network first). 
 
 - You now have a view only wallet.
 


### PR DESCRIPTION
The method for making the view only wallet in Ubuntu is now simpler than before.  The only argument after --generate-from-view-key is now the wallet name.  The program will prompt for the other fields.