### PR TITLE
Updating README info on static content repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Copyright (c) 2014-2017, The Monero Project
 
 ## Development Resources
 
-Web: [getmonero.org](http://getmonero.org)  
-Mail: [dev@getmonero.org](mailto:dev@getmonero.org)  
+Web: [getmonero.org](http://getmonero.org)
+Mail: [dev@getmonero.org](mailto:dev@getmonero.org)
 IRC: [#monero-dev on Freenode](irc://chat.freenode.net/#monero-dev)
 
 ## About this Project
@@ -20,7 +20,7 @@ Pages and formats should be based off existing pages to maintain a consistent lo
 
 - changes made to _layouts, _includes, and home.php will need to use {% t x.x %} translation tags to pull in the YAML tag from _strings_en.yml, as this is required for multi-language support later on
 - with the exception of something like blog/index.html (that is required to be a .html file for Jekyll's pagination to work) all pages should be .md files
-- since all static content (CSS/JS/images) is hosted in a separate, non-public repository, changes can be suggested via Github issues and we will cross-apply them to that repo, crediting you in the commit message
+- static content (CSS/JS/images) can be found in the [monero-forum](https://github.com/monero-project/monero-forum) repo
 - SVG should be used in header icons and diagrams, and FontAwesome icons can be used in text
 - Moneropedia entries require nothing more than creating the .md file in knowledge-base/moneropedia/, please use the 00-base-00 file as a boilerplate
 - To create a CLI screen shot, prefix the text block with {:.cli-code}, and use span elements for the colours; see getting-started/running.md, getting-started/accepting.md, and the account.md Moneropedia entry


### PR DESCRIPTION
Static content is now available in GitHub, but in a different repo.
@fluffypony mentioned in issue #247 
