### PR TITLE
Update python package - pymonero to MoneroPy

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -58,8 +58,8 @@
       url: https://github.com/PsychicCat/monero-nodejs
     - name: python-monero (Python)
       url: https://github.com/tippero/python-monero
-    - name: pymonero (Python)
-      url: https://github.com/Monero-Monitor/pymonero
+    - name: MoneroPy (Python)
+      url: https://github.com/bigreddmachine/MoneroPy
     - name: moneronjs (NodeJS)
       url: https://github.com/netmonk/moneronjs
     - name: MoneroApi.Net (.NET)


### PR DESCRIPTION
I've deprecated `pymonero` and have began merging the functionality of it into `MoneroPy`, which is actively maintained and undergoing development. `pymonero` therefore should not be listed anymore.