### PR TITLE
rm MoneroWorld explorer and add two others

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -44,8 +44,10 @@
       url: http://moneroblocks.info
     - name: MoneroExplorer
       url: https://explorer.xmr.my/
-    - name: Moneroworld Blockchain Explorer
-      url: http://explore.moneroworld.com/
+    - name: MoneroHash Explorer
+      url: https://monerohash.com/explorer/
+    - name: xmrchain.net
+      url: https://xmrchain.net/
 - category: Payment Gateways
   merchants:  
     - name: Monero Merchants


### PR DESCRIPTION
MoneroWorld no longer hosts an explorer, but two other are now maintained based off the same onion explorer source.