### PR TITLE
Add Living Room of Satoshi to Merchants page

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -48,6 +48,8 @@
       url: http://explore.moneroworld.com/
 - category: Payment Gateways
   merchants:  
+    - name: Living Room of Satoshi
+      url: https://www.livingroomofsatoshi.com/?sc=xmr  
     - name: Monero Merchants
       url: https://monero-merchants.com
     - name: Paybee (Private Beta)


### PR DESCRIPTION
Living Room of Satoshi, allows payment of any bill or bank account in Australia with Bitcoin. The URL in the pull request includes a parameter that takes you directly to the monero payment option.