### PR TITLE
Add link to GitHub from menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,6 +29,7 @@
             <li><a href="/getting-started/donate">{% t menu.donations %}</a></li>
             <li class="divider"></li>
             <li><a href="/downloads">{% t menu.downloads %}</a></li>
+            <li><a href="https://github.com/monero-project">{% t menu.github %}</a></li>
             <li class="divider"></li>
             <li><a href="/getting-started/accepting">{% t menu.accepting %}</a></li>
             <li><a href="/getting-started/merchants">{% t menu.merchants %}</a></li>

--- a/_strings_en.yml
+++ b/_strings_en.yml
@@ -30,6 +30,7 @@ menu:
   donations: Donating and Sponsorships
   contribute: Contributing to Monero
   downloads: All Monero Downloads
+  github: GitHub
   merchants: Merchants and Services Directory
   accepting: Accepting Monero Payments
   about: About Monero


### PR DESCRIPTION
Currently, the link is inside the "Contributing To Monero" page, but that isn't very easily accessible. So I added it to the menus.

I'd even argue that maybe it should be a section on the homepage instead. Let me if there is a better place for it then the menu where I put it.