### PR TITLE
Removing broken link to rocket.xmrnation.com

### DIFF
--- a/community/hangouts/index.md
+++ b/community/hangouts/index.md
@@ -41,9 +41,6 @@ The Monero community is diverse and varied. We come from all over, but we defini
                             </div>
                             <div class="row relays around-xs">
                                 <div class="col-md-4 col-sm-4 col-xs-4">
-                                    <p><a href="https://rocket.xmrnation.com/" class="btn-link btn-fixed">Rocket</a></p>
-                                </div>
-                                <div class="col-md-4 col-sm-4 col-xs-4">
                                     <p><a href="https://monero.slack.com/" class="btn-link btn-fixed">Slack</a></p>
                                 </div>
                                 <div class="col-md-4 col-sm-4 col-xs-4">


### PR DESCRIPTION
The other links will automatically re-center themselves.

Screenshot:

![remove-rocket-xmrnation](https://user-images.githubusercontent.com/5115470/27889193-183b026a-61eb-11e7-86e6-d300201f90bd.png)
