### PR TITLE
Fix 'Open Sans' @font-face declaration

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -29,7 +29,7 @@
 }
 
 @font-face {
-  font-family: 'Open Sans', sans-serif;
+  font-family: 'Open Sans';
   font-weight: 400;
   font-style: normal;
   src: url('../fonts/Open-Sans-regular.eot');
@@ -43,7 +43,7 @@
 }
 
 @font-face {
-  font-family: 'Open Sans', sans-serif;
+  font-family: 'Open Sans';
   font-weight: 800;
   font-style: normal;
   src: url('../fonts/Open-Sans-800.eot');


### PR DESCRIPTION
The @font-face declaration has an erroneous `sans-serif` which prevents the font from being displayed (if you don't have the font installed locally).