### PR TITLE
Create missing Dev Meeting Post for Posterity (2016-03-05)

### DIFF
--- a/_posts/2016-03-05-overview-and-logs-for-the-dev-meeting-held-on-2016-03-05.md
+++ b/_posts/2016-03-05-overview-and-logs-for-the-dev-meeting-held-on-2016-03-05.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: Overview for the Dev Meeting Held on 2016-03-05
+summary: 0.9.2 Discussion, db fixes, unit test fixes, threading fixes, RingCT development discussion.
+tags: [dev diaries, core, crypto]
+author: gingeropolous
+---
+
+*March 5th, 2016*
+
+# Overview
+
+Open pull requests mostly just DB stuff by warptangent and hyc, and will be merged within next couple of hours. In the last couple of weeks, unit test fixes, threading fixes, "lots of little things". Hyc had some readtxn changes. Hyc's performance changes need to wait until some kind of migration system is implemented / developed.
+
+Fees are fine. Too soon for adjustment. Talk of "magic number automation" - fees will autoadjust one day! ArcticMine takes on researching / developing a proposal for automatically adjusting fees.
+
+Dev Branch - the buck stops here. Moneromoo is waiting for 0.9.2 to be tagged "so that no new patches go there". So once we have 0.9.2, dev branch goes upstream (to master).
+
+We need a library that plays well with HTTPS and support authentication and is compatible with our license.
+
+RingCT - WarpTangent becoming familiar with what needs to be done, and RingCT development will go on newer database branch. There's some "floating point or fixed" issue that needs to be decided. Forum threads will be opened for that. Warptanget steps up to the plate to make the thread.
+
+Changing mixin to something else is a thing that might happen, but "its a community thing, not a dev thing"
+
+Everybody shakes hands, gives themselves pats on the back and "attaboys", and venture off into the night to go meditate on the metaphysics of mixin 0 transactions.
+
+# Logs
+
+Logs for this dev meeting no longer exist or were lost.


### PR DESCRIPTION
closes #111 

If anyone still has the logs, it'd be great if we could add them, but it's better to have the post and no logs than to have no post IMO.