### PR TITLE
Add wdm gem on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'jekyll'
 gem 'jekyll-paginate'
 gem 'builder'
 gem 'rubysl-rexml'
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
Source: Jekyll complaining at me

```
 Please add the following to your Gemfile to avoid polling for changes:
     gem 'wdm', '>= 0.1.0' if Gem.win_platform?
```