### PR TITLE
Improve Developer Guides layout & code blocks

### DIFF
--- a/resources/developer-guides/daemon-rpc.md
+++ b/resources/developer-guides/daemon-rpc.md
@@ -49,18 +49,20 @@ Note: "atomic units" refer to the smallest fraction of 1 XMR according to the mo
 
 The majority of monerod RPC calls use the daemon's `json_rpc` interface to request various bits of information. These methods all follow a similar structure, for example:
 
-    IP=127.0.0.1
-    PORT=18081
-    METHOD='getblockheaderbyheight'
-	PARAMS='{"height":912345}'
-	curl \
-		-X POST http://$IP:$PORT/json_rpc \
-		-d '{"jsonrpc":"2.0","id":"0","method":"'$METHOD'","params":'$PARAMS'}' \
-		-H 'Content-Type: application/json'
+```
+IP=127.0.0.1
+PORT=18081
+METHOD='getblockheaderbyheight'
+PARAMS='{"height":912345}'
+curl \
+    -X POST http://$IP:$PORT/json_rpc \
+    -d '{"jsonrpc":"2.0","id":"0","method":"'$METHOD'","params":'$PARAMS'}' \
+    -H 'Content-Type: application/json'
+```
 
 Some methods include parameters, while others do not. Examples of each JSON RPC method follow.
 
-### getblockcount
+### **getblockcount**
 
 Look up how many blocks are in the longest chain known to the node.
 
@@ -73,19 +75,21 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblockcount"}' -H 'Content-Type: application/json'
-{
-  "id": "0",
-  "jsonrpc": "2.0",
-  "result": {
-    "count": 993163,
-    "status": "OK"
-  }
-}
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblockcount"}' -H 'Content-Type: application/json'  
+
+{  
+  "id": "0",  
+  "jsonrpc": "2.0",  
+  "result": {  
+    "count": 993163,  
+    "status": "OK"  
+  }  
+}  
+```
 
 
-### on_getblockhash
+### **on_getblockhash**
 
 Look up a block's hash by its height.
 
@@ -99,16 +103,18 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"on_getblockhash","params":[912345]}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"on_getblockhash","params":[912345]}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
   "result": "e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6"
 }
+```
 
 
-### getblocktemplate
+### **getblocktemplate**
 
 Inputs:
 
@@ -126,8 +132,9 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblocktemplate","params":{"wallet_address":"44GBHzv6ZyQdJkjqZje6KLZ3xSyN1hBSFAnLP6EAqJtCRVzMzZmeXTC2AHKDS9aEDTRKmo6a6o9r9j86pYfhCWDkKjbtcns","reserve_size":60}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblocktemplate","params":{"wallet_address":"44GBHzv6ZyQdJkjqZje6KLZ3xSyN1hBSFAnLP6EAqJtCRVzMzZmeXTC2AHKDS9aEDTRKmo6a6o9r9j86pYfhCWDkKjbtcns","reserve_size":60}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -140,8 +147,10 @@ Example:
     "status": "OK"
   }
 }
+```
 
-### submitblock
+
+### **submitblock**
 
 Submit a mined block to the network.
 
@@ -154,7 +163,7 @@ Outputs:
 * *status* - string; Block submit status.
 
 
-### getlastblockheader
+### **getlastblockheader**
 
 Block header information for the most recent block is easily retrieved with this method. No inputs are needed.
 
@@ -178,8 +187,9 @@ Outputs:
 
 In this example, the most recent block (990793 at the time) is returned:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getlastblockheader"}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getlastblockheader"}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -200,9 +210,10 @@ In this example, the most recent block (990793 at the time) is returned:
     "status": "OK"
   }
 }
+```
 
 
-### getblockheaderbyhash
+### **getblockheaderbyhash**
 
 Block header information can be retrieved using either a block's hash or height. This method includes a block's hash as an input parameter to retrieve basic information about the block.
 
@@ -216,8 +227,9 @@ Outputs:
 
 In this example, block 912345 is looked up by its hash:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblockheaderbyhash","params":{"hash":"e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6"}}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblockheaderbyhash","params":{"hash":"e22cf75f39ae720e8b71b3d120a5ac03f0db50bba6379e2850975b4859190bc6"}}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -238,9 +250,10 @@ In this example, block 912345 is looked up by its hash:
     "status": "OK"
   }
 }
+```
 
 
-### getblockheaderbyheight
+### **getblockheaderbyheight**
 
 Similar to `getblockheaderbyhash` above, this method includes a block's height as an input parameter to retrieve basic information about the block.
 
@@ -254,8 +267,9 @@ Outputs:
 
 In this example, block 912345 is looked up by its height (notice that the returned information is the save as in the previous example):
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblockheaderbyheight","params":{"height":912345}}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblockheaderbyheight","params":{"height":912345}}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -276,9 +290,10 @@ In this example, block 912345 is looked up by its height (notice that the return
     "status": "OK"
   }
 }
+```
 
 
-### getblock
+### **getblock**
 
 Full block information can be retrieved by either block height or hash, like with the above block header calls. For full block information, both lookups use the same method, but with different input parameters.
 
@@ -316,8 +331,9 @@ Outputs:
 
 In the following example, block 912345 is looked up by its height. Note that block 912345 does not have any non-coinbase transactions. (See the next example for a block with extra transactions):
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblock","params":{"height":912345}}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblock","params":{"height":912345}}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -340,13 +356,15 @@ In the following example, block 912345 is looked up by its height. Note that blo
     "status": "OK"
   }
 }
+```
 
 **Look up by hash:**
 
 In the following example, block 993056 is looked up by its hash. Note that block 993056 has 3 non-coinbase transactions:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblock","params":{"hash":"510ee3c4e14330a7b96e883c323a60ebd1b5556ac1262d0bc03c24a3b785516f"}}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getblock","params":{"hash":"510ee3c4e14330a7b96e883c323a60ebd1b5556ac1262d0bc03c24a3b785516f"}}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -370,9 +388,10 @@ In the following example, block 993056 is looked up by its hash. Note that block
     "tx_hashes": ["79c6b9f00db027bde151705aafe85c495883aae2597d5cb8e1adb2e0f3ae1d07","d715db73331abc3ec588ef07c7bb195786a4724b08dff431b51ffa32a4ce899b","b197066426c0ed89f0b431fe171f7fd62bc95dd29943daa7cf3585cf1fdfc99d"]
   }
 }
+```
 
 
-### get_connections
+### **get_connections**
 
 Retrieve information about incoming and outgoing connections to your node.
 
@@ -400,8 +419,9 @@ Outputs:
 
 Following is an example of `get_connections` and it's return:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_connections"}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_connections"}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -429,9 +449,10 @@ Following is an example of `get_connections` and it's return:
     "status": "OK"
   }
 }
+```
 
 
-### get_info
+### **get_info**
 
 Retrieve general information about the state of your node and the network.
 
@@ -456,8 +477,9 @@ Outputs:
 
 Following is an example `get_info` call and its return:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -478,9 +500,10 @@ Following is an example `get_info` call and its return:
     "white_peerlist_size": 529
   }
 }
+```
 
 
-### hard_fork_info
+### **hard_fork_info**
 
 Look up information regarding hard fork voting and readiness.
 
@@ -500,8 +523,9 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"hard_fork_info"}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"hard_fork_info"}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -517,9 +541,10 @@ Example:
     "window": 10080
   }
 }
+```
 
 
-### setbans
+### **setbans**
 
 Ban another node by IP.
 
@@ -536,8 +561,9 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"setbans","params":{"bans":[{"ip":838969536,"ban":true,"seconds":30}]}}' -H  'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"setbans","params":{"bans":[{"ip":838969536,"ban":true,"seconds":30}]}}' -H  'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -545,9 +571,10 @@ Example:
     "status": "OK"
   }
 }
+```
 
 
-### getbans
+### **getbans**
 
 Inputs: *None*.
 
@@ -560,8 +587,9 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getbans"}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getbans"}' -H 'Content-Type: application/json'
+
 {
   "id": "0",
   "jsonrpc": "2.0",
@@ -573,6 +601,7 @@ Example:
     "status": "OK"
   }
 }
+```
 
 
 ---
@@ -595,7 +624,7 @@ The data structure for these calls is different than the JSON RPC calls. Whereas
 Note: It is recommended to use JSON RPC where such alternatives exist, rather than the following methods. For example, the recommended way to get a node's height is via the JSON RPC methods [get_info](#getinfo) or [getlastblockheader](#getlastblockheader), rather than [getheight](#getheight) below.
 
 
-### /getheight
+### **/getheight**
 
 Get the node's current height.
 
@@ -605,15 +634,17 @@ Outputs:
 
 * *height* - unsigned int; Current length of longest chain known to daemon. 
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/getheight -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/getheight -H 'Content-Type: application/json'
+
 {
   "height": 993488,
   "status": "OK"
 }
+```
 
 
-### /gettransactions
+### **/gettransactions**
 
 Look up one or more transactions by hash.
 
@@ -642,25 +673,30 @@ Outputs:
   * *signatures* - List of ignatures used in ring signature to hide the true origin of the transaction.
 Example 1: Return transaction information in binary format.
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/gettransactions -d '{"txs_hashes":["d6e48158472848e6687173a91ae6eebfa3e1d778e65252ee99d7515d63090408"]}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/gettransactions -d '{"txs_hashes":["d6e48158472848e6687173a91ae6eebfa3e1d778e65252ee99d7515d63090408"]}' -H 'Content-Type: application/json'
+
 {
   "status": "OK",
   "txs_as_hex": ["..."]
 }
+```
+
 
 Example 2: Decode returned transaction information in JSON format. Note: the "vout" list has been truncated in the displayed return for space considerations.
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/gettransactions -d '{"txs_hashes":["d6e48158472848e6687173a91ae6eebfa3e1d778e65252ee99d7515d63090408"],"decode_as_json":true}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/gettransactions -d '{"txs_hashes":["d6e48158472848e6687173a91ae6eebfa3e1d778e65252ee99d7515d63090408"],"decode_as_json":true}' -H 'Content-Type: application/json'
+
 {
   "status": "OK",
   "txs_as_hex": ["..."],
   "txs_as_json": ["{\n  \"version\": 1, \n  \"unlock_time\": 0, \n  \"vin\": [ {\n      \"key\": {\n        \"amount\": 70000000, \n        \"key_offsets\": [ 35952\n        ], \n        \"k_image\": \"d16908468dff9438a9814fe96bdaa575f06fe8da85772b72e54926428712293d\"\n      }\n    }, {\n      \"key\": {\n        \"amount\": 400000000000000, \n        \"key_offsets\": [ 6830\n        ], \n        \"k_image\": \"c7a7024b763df1181ae6fe821b70669735e38a68162ac02362e33acbe829b605\"\n      }\n    }\n  ], \n  \"vout\": [ {\n      \"amount\": 50000, \n      \"target\": {\n        \"key\": \"f6be43f7be4f06adcb1d06f4a07c637c7359e009cf3e57bb32b8c9ea636509c3\"\n      }\n    }, {\n      \"amount\": 200000, \n      \"target\": {\n        \"key\": \"b0a7a8e32f2b5302552bcd8d85112c62838b1f56cccd844eb9b63e0a732d0353\"\n      }\n    },  ...  \n  ], \n  \"extra\": [ 1, 225, 240, 98, 34, 169, 73, 47, 237, 117, 192, 30, 192, 60, 155, 47, 4, 115, 20, 21, 11, 13, 252, 219, 129, 13, 174, 37, 36, 78, 191, 141, 109\n  ], \n  \"signatures\": [ \"e6a3be8003d481d2855c8127f56871de3d28a4fb52385b999eb986c831c5cc08361c126b0db24a21b6c4299b438ee2be201d44d57a371230b9cd04395ab8c400\", \"8309851abaf2cf2a7091e0cdb9c83704fa7d68838a7a8ef8c178bb55a1e93a038dd18bb4a7549dc056b7a70e037cabd80911a03f427e36f712756d4c00f38f0b\"]\n}"]
 }
+```
 
 
-### /is_key_image_spent
+### **/is_key_image_spent**
 
 Check if outputs have been spent using the key image associated with the output.
 
@@ -675,15 +711,17 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/is_key_image_spent -d '{"key_images":["8d1bd8181bf7d857bdb281e0153d84cd55a3fcaa57c3e570f4a49f935850b5e3","7319134bfc50668251f5b899c66b005805ee255c136f0e1cecbb0f3a912e09d4"]}' -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/is_key_image_spent -d '{"key_images":["8d1bd8181bf7d857bdb281e0153d84cd55a3fcaa57c3e570f4a49f935850b5e3","7319134bfc50668251f5b899c66b005805ee255c136f0e1cecbb0f3a912e09d4"]}' -H 'Content-Type: application/json'
+
 {
   "spent_status": [1,2],
   "status": "OK"
 }
+```
 
 
-### /sendrawtransaction
+### **/sendrawtransaction**
 
 Broadcast a raw transaction to the network.
 
@@ -697,11 +735,13 @@ Outputs:
 
 Example (No return information included here.):
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3..."}' -H 'Content-Type: application/json'
+
+```
+$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3..."}' -H 'Content-Type: application/json'
+```
 
 
-### /get_transaction_pool
+### **/get_transaction_pool**
 
 Show information about valid transactions seen by the node but not yet mined into a block, as well as spent key image information in the node's memory.
 
@@ -740,8 +780,9 @@ Outputs:
 
 Example (Note: Some lists in the returned information have been truncated for display reasons):
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/get_transaction_pool -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/get_transaction_pool -H 'Content-Type: application/json'
+
 {
   "spent_key_images": [{
     "id_hash": "1edb9ecc39602040282d326070ad22cb473c952c0d6280c9c4c3b853fb34f3bc",
@@ -766,9 +807,10 @@ Example (Note: Some lists in the returned information have been truncated for di
   },
   ...]
 }
+```
 
 
-### /stop_daemon
+### **/stop_daemon**
 
 Send a command to the daemon to safely disconnect and shut down.
 
@@ -780,9 +822,11 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-<span style="color: cyan;">[ monero->~ ]$</span> curl -X POST http://127.0.0.1:18081/stop_daemon -H 'Content-Type: application/json'
+```
+$ curl -X POST http://127.0.0.1:18081/stop_daemon -H 'Content-Type: application/json'
+
 {
   "status": "OK"
 }
+```
 

--- a/resources/developer-guides/wallet-rpc.md
+++ b/resources/developer-guides/wallet-rpc.md
@@ -15,26 +15,30 @@ This is a list of the monero-wallet-rpc calls, their inputs and outputs, and exa
 
 All monero-wallet-rpc methods use the same JSON RPC interface. For example:
 
-    IP=127.0.0.1
-    PORT=18082
-    METHOD="make_integrated_address"
-    PARAMS="{\"payment_id\":\"1234567890123456789012345678900012345678901234567890123456789000\"}"
-    curl \
-        -X POST http://$IP:$PORT/json_rpc \
-        -d '{"jsonrpc":"2.0","id":"0","method":"'$METHOD'","params":'"$PARAMS"'}' \
-        -H 'Content-Type: application/json'
+```
+IP=127.0.0.1
+PORT=18082
+METHOD="make_integrated_address"
+PARAMS="{\"payment_id\":\"1234567890123456789012345678900012345678901234567890123456789000\"}"
+curl \
+    -X POST http://$IP:$PORT/json_rpc \
+    -d '{"jsonrpc":"2.0","id":"0","method":"'$METHOD'","params":'"$PARAMS"'}' \
+    -H 'Content-Type: application/json'
+```
 
 If the monero-wallet-rpc was executed with the `--rpc-login` argument as `username:password`, then follow this example:
 
-    IP=127.0.0.1
-    PORT=18082
-    METHOD="make_integrated_address"
-    PARAMS="{\"payment_id\":\"1234567890123456789012345678900012345678901234567890123456789000\"}"
-    curl \
-        -u username:password --digest \
-        -X POST http://$IP:$PORT/json_rpc \
-        -d '{"jsonrpc":"2.0","id":"0","method":"'$METHOD'","params":'"$PARAMS"'}' \
-        -H 'Content-Type: application/json'
+```
+IP=127.0.0.1
+PORT=18082
+METHOD="make_integrated_address"
+PARAMS="{\"payment_id\":\"1234567890123456789012345678900012345678901234567890123456789000\"}"
+curl \
+    -u username:password --digest \
+    -X POST http://$IP:$PORT/json_rpc \
+    -d '{"jsonrpc":"2.0","id":"0","method":"'$METHOD'","params":'"$PARAMS"'}' \
+    -H 'Content-Type: application/json'
+```
 
 Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
 
@@ -80,7 +84,7 @@ Note: "atomic units" refer to the smallest fraction of 1 XMR according to the mo
 
 ## JSON RPC Methods:
 
-### getbalance
+### **getbalance**
 
 Return the wallet's balance.
 
@@ -93,19 +97,21 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getbalance"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "balance": 140000000000,
-        "unlocked_balance": 50000000000
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getbalance"}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "balance": 140000000000,
+    "unlocked_balance": 50000000000
+  }
+}
+```
 
 
-### getaddress
+### **getaddress**
 
 Return the wallet's address.
 
@@ -117,18 +123,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getaddress"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "address": "427ZuEhNJQRXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQGaDsaBA"
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getaddress"}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "address": "427ZuEhNJQRXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQGaDsaBA"
+  }
+}
+```
 
 
-### getheight
+### **getheight**
 
 Returns the wallet's current block height.
 
@@ -140,18 +148,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getheight"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "height": 994310
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"getheight"}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "height": 994310
+  }
+}
+```
 
 
-### transfer
+### **transfer**
 
 Send monero to a number of recipients.
 
@@ -180,20 +190,22 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"transfer","params":{"destinations":[{"amount":100000000,"address":"9wNgSYy2F9qPZu7KBjvsFgZLTKE2TZgEpNFbGka9gA5zPmAXS35QzzYaLKJRkYTnzgArGNX7TvSqZC87tBLwtaC5RQgJ8rm"},{"amount":200000000,"address":"9vH5D7Fv47mbpCpdcthcjU34rqiiAYRCh1tYywmhqnEk9iwCE9yppgNCXAyVHG5qJt2kExa42TuhzQfJbmbpeGLkVbg8xit"}],"mixin":4,"get_tx_key": true}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "fee": 48958481211,
-        "tx_hash": "985180f468637bc6d2f72ee054e1e34b8d5097988bb29a2e0cb763e4464db23c",
-        "tx_key": "8d62e5637f1fcc9a8904057d6bed6c697618507b193e956f77c31ce662b2ee07"
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"transfer","params":{"destinations":[{"amount":100000000,"address":"9wNgSYy2F9qPZu7KBjvsFgZLTKE2TZgEpNFbGka9gA5zPmAXS35QzzYaLKJRkYTnzgArGNX7TvSqZC87tBLwtaC5RQgJ8rm"},{"amount":200000000,"address":"9vH5D7Fv47mbpCpdcthcjU34rqiiAYRCh1tYywmhqnEk9iwCE9yppgNCXAyVHG5qJt2kExa42TuhzQfJbmbpeGLkVbg8xit"}],"mixin":4,"get_tx_key": true}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "fee": 48958481211,
+    "tx_hash": "985180f468637bc6d2f72ee054e1e34b8d5097988bb29a2e0cb763e4464db23c",
+    "tx_key": "8d62e5637f1fcc9a8904057d6bed6c697618507b193e956f77c31ce662b2ee07"
+  }
+}
+```
 
 
-### transfer_split
+### **transfer_split**
 
 Same as transfer, but can split into more than one tx if necessary.
 
@@ -222,19 +234,21 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"transfer_split","params":{"destinations":[{"amount":100000000,"address":"9wNgSYy2F9qPZu7KBjvsFgZLTKE2TZgEpNFbGka9gA5zPmAXS35QzzYaLKJRkYTnzgArGNX7TvSqZC87tBwtaC5RQgJ8rm"},{"amount":200000000,"address":"9vH5D7Fv47mbpCpdcthcjU34rqiiAYRCh1tYywmhqnEk9iwCE9yppgNCXAyVHG5qJt2kExa42TuhzQfJbmbpeGLkVbg8xit"},{"amount":200000000,"address":"9vC5Q25cR1d3WzKX6dpTaLJaqZyDrtTnfadTmVuB1Wue2tyFGxUhiE4RGa74pEDJv7gSySzcd1Ao6G1nzSaqp78vLfP6MPj"},{"amount":200000000,"address":"A2MSrn49ziBPJBh8ZNEhhbfyLMou6mao4C1F5TLGUatmUnCxZArDYkcbAnVkVEopWVeak2rKDrmc8JpoS7n5dvfN9YDPBTG"},{"amount":200000000,"address":"9tEDyVQ8zgRQbDYiykTdpw5kZ6qWQWcKfExEj9eQshjpGb3sdr3UyWE2AHWzUGzJjaH9HN1DdGBdyQQ4AqGMc7rr5xYwZWW"}],"mixin":4,"get_tx_key": true, "new_algorithm": true}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "fee_list": [97916962422],
-        "tx_hash_list": ["c5c389846e701c27aaf1f7ab8b9dc457b471fcea5bc9710e8020d51275afbc54"]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"transfer_split","params":{"destinations":[{"amount":100000000,"address":"9wNgSYy2F9qPZu7KBjvsFgZLTKE2TZgEpNFbGka9gA5zPmAXS35QzzYaLKJRkYTnzgArGNX7TvSqZC87tBwtaC5RQgJ8rm"},{"amount":200000000,"address":"9vH5D7Fv47mbpCpdcthcjU34rqiiAYRCh1tYywmhqnEk9iwCE9yppgNCXAyVHG5qJt2kExa42TuhzQfJbmbpeGLkVbg8xit"},{"amount":200000000,"address":"9vC5Q25cR1d3WzKX6dpTaLJaqZyDrtTnfadTmVuB1Wue2tyFGxUhiE4RGa74pEDJv7gSySzcd1Ao6G1nzSaqp78vLfP6MPj"},{"amount":200000000,"address":"A2MSrn49ziBPJBh8ZNEhhbfyLMou6mao4C1F5TLGUatmUnCxZArDYkcbAnVkVEopWVeak2rKDrmc8JpoS7n5dvfN9YDPBTG"},{"amount":200000000,"address":"9tEDyVQ8zgRQbDYiykTdpw5kZ6qWQWcKfExEj9eQshjpGb3sdr3UyWE2AHWzUGzJjaH9HN1DdGBdyQQ4AqGMc7rr5xYwZWW"}],"mixin":4,"get_tx_key": true, "new_algorithm": true}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "fee_list": [97916962422],
+    "tx_hash_list": ["c5c389846e701c27aaf1f7ab8b9dc457b471fcea5bc9710e8020d51275afbc54"]
+  }
+}
+```
 
 
-### sweep_dust
+### **sweep_dust**
 
 Send all dust outputs back to the wallet's, to make them easier to spend (and mix).
 
@@ -246,18 +260,21 @@ Outputs:
 
 Example (In this example, `sweep_dust` returns an error due to insufficient funds to sweep):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"sweep_dust"}' -H 'Content-Type: application/json'
-    {
-      "error": {
-        "code": -4,
-        "message": "not enough money"
-      },
-      "id": "0",
-      "jsonrpc": "2.0"
-    }
 
-### sweep_all
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"sweep_dust"}' -H 'Content-Type: application/json'
+
+{
+  "error": {
+    "code": -4,
+    "message": "not enough money"
+  },
+  "id": "0",
+  "jsonrpc": "2.0"
+}
+```
+
+### **sweep_all**
 
 Send all unlocked balance to an address.
 
@@ -281,18 +298,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"sweep_all","params":{"address":"9sS8eRU2b5ZbN2FPSrpkiab1bjbHE5XtL6Ti6We3Fhw5aQPudRfVVypjgzKDNkxtvTQSPs122NKggb2mqcqkKSeMNVu59S","mixin":2,"unlock_time":0,"get_tx_keys":true}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "tx_hash_list": ["53a3648797d5524dd037d4105e067fa61468faecab41927fc43adbb26c202d22"],
-        "tx_key_list": ["e83b3b78235e36cd7e4d9695efd81a3b3e64c7d1f1ebd61892f0a7add6a50301"]
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"sweep_all","params":{"address":"9sS8eRU2b5ZbN2FPSrpkiab1bjbHE5XtL6Ti6We3Fhw5aQPudRfVVypjgzKDNkxtvTQSPs122NKggb2mqcqkKSeMNVu59S","mixin":2,"unlock_time":0,"get_tx_keys":true}}' -H 'Content-Type: application/json'
 
-### store
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "tx_hash_list": ["53a3648797d5524dd037d4105e067fa61468faecab41927fc43adbb26c202d22"],
+    "tx_key_list": ["e83b3b78235e36cd7e4d9695efd81a3b3e64c7d1f1ebd61892f0a7add6a50301"]
+  }
+}
+```
+
+### **store**
 
 Save the blockchain.
 
@@ -302,17 +321,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"store"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"store"}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
 
 
-### get_payments
+### **get_payments**
 
 Get a list of incoming payments using a given payment id.
 
@@ -331,24 +352,26 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_payments","params":{"payment_id":"4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "payments": [{
-          "amount": 10350000000000,
-          "block_height": 994327,
-          "payment_id": "4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030",
-          "tx_hash": "c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1",
-          "unlock_time": 0
-        }]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_payments","params":{"payment_id":"4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "payments": [{
+      "amount": 10350000000000,
+      "block_height": 994327,
+      "payment_id": "4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030",
+      "tx_hash": "c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1",
+      "unlock_time": 0
+    }]
+  }
+}
+```
 
 
-### get_bulk_payments
+### **get_bulk_payments**
 
 Get a list of incoming payments using a given payment id, or a list of payments ids, from a given height. This method is the preferred method over `get_payments` because it has the same functionality but is more extendable. Either is fine for looking up transactions by a single payment ID.
 
@@ -368,23 +391,26 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_bulk_payments","params":{"payment_ids":["4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030"],"min_block_height":990000}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "payments": [{
-          "amount": 10350000000000,
-          "block_height": 994327,
-          "payment_id": "4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030",
-          "tx_hash": "c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1",
-          "unlock_time": 0
-        }]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_bulk_payments","params":{"payment_ids":["4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030"],"min_block_height":990000}}' -H 'Content-Type: application/json'
 
-### get_transfers
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "payments": [{
+      "amount": 10350000000000,
+      "block_height": 994327,
+      "payment_id": "4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030",
+      "tx_hash": "c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1",
+      "unlock_time": 0
+    }]
+  }
+}
+```
+
+
+### **get_transfers**
 
 Returns a list of transfers.
 
@@ -419,26 +445,28 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfers","params":{"pool":true}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "pool": [{
-          "amount": 500000000000,
-          "fee": 0,
-          "height": 0,
-          "note": "",
-          "payment_id": "758d9b225fda7b7f",
-          "timestamp": 1488312467,
-          "txid": "da7301d5423efa09fabacb720002e978d114ff2db6a1546f8b820644a1b96208",
-          "type": "pool"
-        }]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfers","params":{"pool":true}}' -H 'Content-Type: application/json'
 
-### get_transfer_by_txid
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "pool": [{
+      "amount": 500000000000,
+      "fee": 0,
+      "height": 0,
+      "note": "",
+      "payment_id": "758d9b225fda7b7f",
+      "timestamp": 1488312467,
+      "txid": "da7301d5423efa09fabacb720002e978d114ff2db6a1546f8b820644a1b96208",
+      "type": "pool"
+    }]
+  }
+}
+```
+
+### **get_transfer_by_txid**
 
 Show information about a transfer to/from this address.
 
@@ -460,26 +488,29 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfer_by_txid","params":{"txid":"f2d33ba969a09941c6671e6dfe7e9456e5f686eca72c1a94a3e63ac6d7f27baf"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "transfer": {
-          "amount": 10000000000000,
-          "fee": 0,
-          "height": 1316388,
-          "note": "",
-          "payment_id": "0000000000000000",
-          "timestamp": 1495539310,
-          "txid": "f2d33ba969a09941c6671e6dfe7e9456e5f686eca72c1a94a3e63ac6d7f27baf",
-          "type": "in"
-        }
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfer_by_txid","params":{"txid":"f2d33ba969a09941c6671e6dfe7e9456e5f686eca72c1a94a3e63ac6d7f27baf"}}' -H 'Content-Type: application/json'
 
-### incoming_transfers
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "transfer": {
+      "amount": 10000000000000,
+      "fee": 0,
+      "height": 1316388,
+      "note": "",
+      "payment_id": "0000000000000000",
+      "timestamp": 1495539310,
+      "txid": "f2d33ba969a09941c6671e6dfe7e9456e5f686eca72c1a94a3e63ac6d7f27baf",
+      "type": "in"
+    }
+  }
+}
+```
+
+
+### **incoming_transfers**
 
 Return a list of incoming transfers to the wallet.
 
@@ -498,77 +529,83 @@ Outputs:
 
 Example (Return "all" transaction types):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"incoming_transfers","params":{"transfer_type":"all"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "transfers": [{
-          "amount": 10000000000000,
-          "global_index": 711506,
-          "spent": false,
-          "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
-          "tx_size": 5870
-        },{
-          "amount": 300000000000,
-          "global_index": 794232,
-          "spent": false,
-          "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
-          "tx_size": 5870
-        },{
-          "amount": 50000000000,
-          "global_index": 213659,
-          "spent": false,
-          "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
-          "tx_size": 5870
-        }]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"incoming_transfers","params":{"transfer_type":"all"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "transfers": [{
+      "amount": 10000000000000,
+      "global_index": 711506,
+      "spent": false,
+      "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
+      "tx_size": 5870
+    },{
+      "amount": 300000000000,
+      "global_index": 794232,
+      "spent": false,
+      "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
+      "tx_size": 5870
+    },{
+      "amount": 50000000000,
+      "global_index": 213659,
+      "spent": false,
+      "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
+      "tx_size": 5870
+    }]
+  }
+}
+```
 
 Example (Return "available" transactions):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"incoming_transfers","params":{"transfer_type":"available"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "transfers": [{
-          "amount": 10000000000000,
-          "global_index": 711506,
-          "spent": false,
-          "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
-          "tx_size": 5870
-        },{
-          "amount": 300000000000,
-          "global_index": 794232,
-          "spent": false,
-          "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
-          "tx_size": 5870
-        },{
-          "amount": 50000000000,
-          "global_index": 213659,
-          "spent": false,
-          "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
-          "tx_size": 5870
-        }]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"incoming_transfers","params":{"transfer_type":"available"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "transfers": [{
+      "amount": 10000000000000,
+      "global_index": 711506,
+      "spent": false,
+      "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
+      "tx_size": 5870
+    },{
+      "amount": 300000000000,
+      "global_index": 794232,
+      "spent": false,
+      "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
+      "tx_size": 5870
+    },{
+      "amount": 50000000000,
+      "global_index": 213659,
+      "spent": false,
+      "tx_hash": "&lt;c391089f5b1b02067acc15294e3629a463412af1f1ed0f354113dd4467e4f6c1&gt;",
+      "tx_size": 5870
+    }]
+  }
+}
+```
 
 Example (Return "unavailable" transaction. Note that this particular example returns 0 unavailable transactions):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"incoming_transfers","params":{"transfer_type":"unavailable"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"incoming_transfers","params":{"transfer_type":"unavailable"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
 
 
-### query_key
+### **query_key**
 
 Return the spend or view private key.
 
@@ -582,30 +619,34 @@ Outputs:
 
 Example (Query view key):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"query_key","params":{"key_type":"view_key"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "key": "7e341d..."
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"query_key","params":{"key_type":"view_key"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "key": "7e341d..."
+  }
+}
+```
 
 Example (Query mnemonic key):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"query_key","params":{"key_type":"mnemonic"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "key": "adapt adapt nostril ..."
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"query_key","params":{"key_type":"mnemonic"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "key": "adapt adapt nostril ..."
+  }
+}
+```
 
 
-### make_integrated_address
+### **make_integrated_address**
 
 Make an integrated address from the wallet address and a payment id.
 
@@ -619,18 +660,20 @@ Outputs:
 
 Example (Payment ID is empty, use a random ID):
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"make_integrated_address","params":{"payment_id":""}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "integrated_address": "4BpEv3WrufwXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQQ8H2RRJveAtUeiFs6J"
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"make_integrated_address","params":{"payment_id":""}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "integrated_address": "4BpEv3WrufwXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQQ8H2RRJveAtUeiFs6J"
+  }
+}
+```
 
 
-### split_integrated_address
+### **split_integrated_address**
 
 Retrieve the standard address and payment id corresponding to an integrated address.
 
@@ -645,19 +688,21 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"split_integrated_address","params":{"integrated_address": "4BpEv3WrufwXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQQ8H2RRJveAtUeiFs6J"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "payment_id": "&lt;420fa29b2d9a49f5&gt;",
-        "standard_address": "427ZuEhNJQRXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQGaDsaBA"
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"split_integrated_address","params":{"integrated_address": "4BpEv3WrufwXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQQ8H2RRJveAtUeiFs6J"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "payment_id": "&lt;420fa29b2d9a49f5&gt;",
+    "standard_address": "427ZuEhNJQRXoyJAeEoBaNW56ScQaLXyyQWgxeRL9KgAUhVzkvfiELZV7fCPBuuB2CGuJiWFQjhnhhwiH1FsHYGQGaDsaBA"
+  }
+}
+```
 
 
-### stop_wallet
+### **stop_wallet**
 
 Stops the wallet, storing the current state.
 
@@ -667,17 +712,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"stop_wallet"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"stop_wallet"}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
 
 
-### make_uri
+### **make_uri**
 
 Create a payment URI using the official URI spec.
 
@@ -695,18 +742,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"make_uri","params":{"address":"44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A","amount":10,"payment_id":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","tx_description":"Testing out the make_uri function.","recipient_name":"Monero Project donation address"}}'  -H 'Content-Type: application/json'
-    {
-      "id": 0,
-      "jsonrpc": "2.0",
-      "result": {
-        "uri": "monero:44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A?tx_payment_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef&tx_amount=0.000000000010&recipient_name=Monero%20Project%20donation%20address&tx_description=Testing%20out%20the%20make_uri%20function."
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"make_uri","params":{"address":"44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A","amount":10,"payment_id":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","tx_description":"Testing out the make_uri function.","recipient_name":"Monero Project donation address"}}'  -H 'Content-Type: application/json'
+
+{
+  "id": 0,
+  "jsonrpc": "2.0",
+  "result": {
+    "uri": "monero:44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A?tx_payment_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef&tx_amount=0.000000000010&recipient_name=Monero%20Project%20donation%20address&tx_description=Testing%20out%20the%20make_uri%20function."
+  }
+}
+```
 
 
-### parse_uri
+### **parse_uri**
 
 Parse a payment URI to get payment information.
 
@@ -725,23 +774,26 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"parse_uri","params":{"uri":"monero:44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A?tx_payment_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef&tx_amount=0.000000000010&recipient_name=Monero%20Project%20donation%20address&tx_description=Testing%20out%20the%20make_uri%20function."}}' -H 'Content-Type: application/json'
-    {
-      "id": 0,
-      "jsonrpc": "2.0",
-      "result": {
-        "uri": {
-          "address": "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A",
-          "amount": 10,
-          "payment_id": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-          "recipient_name": "Monero Project donation address",
-          "tx_description": "Testing out the make_uri function."
-        }
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"parse_uri","params":{"uri":"monero:44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A?tx_payment_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef&tx_amount=0.000000000010&recipient_name=Monero%20Project%20donation%20address&tx_description=Testing%20out%20the%20make_uri%20function."}}' -H 'Content-Type: application/json'
 
-### rescan_blockchain
+{
+  "id": 0,
+  "jsonrpc": "2.0",
+  "result": {
+    "uri": {
+      "address": "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A",
+      "amount": 10,
+      "payment_id": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "recipient_name": "Monero Project donation address",
+      "tx_description": "Testing out the make_uri function."
+    }
+  }
+}
+```
+
+
+### **rescan_blockchain**
 
 Rescan blockchain from scratch.
 
@@ -751,16 +803,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"rescan_blockchain" -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"rescan_blockchain" -H 'Content-Type: application/json'
 
-### set_tx_notes
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+
+
+### **set_tx_notes**
 
 Set arbitrary string notes for transactions.
 
@@ -773,16 +828,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"set_tx_notes","params":{"txids":["6a1a100c079c236e2cbf36f7760e8ef1a9e8357c434aa790a8c78de653ec4cf2"],"notes":["This is an example"]}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"set_tx_notes","params":{"txids":["6a1a100c079c236e2cbf36f7760e8ef1a9e8357c434aa790a8c78de653ec4cf2"],"notes":["This is an example"]}}' -H 'Content-Type: application/json'
 
-### get_tx_notes
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+
+
+### **get_tx_notes**
 
 Get string notes for transactions.
 
@@ -796,17 +854,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_tx_notes","params":{"txids":["6a1a100c079c236e2cbf36f7760e8ef1a9e8357c434aa790a8c78de653ec4cf2"]}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "notes": ["This is an example"]
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_tx_notes","params":{"txids":["6a1a100c079c236e2cbf36f7760e8ef1a9e8357c434aa790a8c78de653ec4cf2"]}}' -H 'Content-Type: application/json'
 
-### sign
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "notes": ["This is an example"]
+  }
+}
+```
+
+
+### **sign**
 
 Sign a string.
 
@@ -820,17 +881,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"sign","params":{"data":"This is sample data to be signed"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "signature": "SigV1Xp61ZkGguxSCHpkYEVw9eaWfRfSoAf36PCsSCApx4DUrKWHEqM9CdNwjeuhJii6LHDVDFxvTPijFsj3L8NDQp1TV"
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"sign","params":{"data":"This is sample data to be signed"}}' -H 'Content-Type: application/json'
 
-### verify
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "signature": "SigV1Xp61ZkGguxSCHpkYEVw9eaWfRfSoAf36PCsSCApx4DUrKWHEqM9CdNwjeuhJii6LHDVDFxvTPijFsj3L8NDQp1TV"
+  }
+}
+```
+
+
+### **verify**
 
 Verify a signature on a string.
 
@@ -846,17 +910,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"verify","params":{"data":"This is sample data to be signed","address":"9sS8eRU2b5ZbN2FPSrpkiab1bjbHE5XtL6Ti6We3Fhw5aQPudRfVVypjgzKDNkxtvTQZSPs122NKggb2mqcqkKSeMNVu59S","signature":"SigV1Xp61ZkGguxSCHpkYEVw9eaWfRfSoAf36PCsSCApx4DUrKWHEqM9CdNwjeuhJii6LHDVDFxvTPijFsj3L8NDQp1TV"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "good": true
-      }
-    }
+```
+$ curl -X POST http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"verify","params":{"data":"This is sample data to be signed","address":"9sS8eRU2b5ZbN2FPSrpkiab1bjbHE5XtL6Ti6We3Fhw5aQPudRfVVypjgzKDNkxtvTQZSPs122NKggb2mqcqkKSeMNVu59S","signature":"SigV1Xp61ZkGguxSCHpkYEVw9eaWfRfSoAf36PCsSCApx4DUrKWHEqM9CdNwjeuhJii6LHDVDFxvTPijFsj3L8NDQp1TV"}}' -H 'Content-Type: application/json'
 
-### export_key_images
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "good": true
+  }
+}
+```
+
+
+### **export_key_images**
 
 Export a signed set of key images.
 
@@ -870,20 +937,23 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"export_key_images"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "signed_key_images": [{
-          "key_image": "62b83df78baad99e23b5ad3f667bc6f8d388a13d9e84c7bb6c223a556dfd34af",
-          "signature": "b87b7e989aa85aa3a2a7cd8adcb3a848d3512ff718b168e15217ff3e5da29c0183c0328b97cc052fcb5ee3548aa5e41e530ba9d854199ea19d7ddaf6a54a4c0a"
-        }]
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"export_key_images"}' -H 'Content-Type: application/json'
 
-### import_key_images
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "signed_key_images": [{
+      "key_image": "62b83df78baad99e23b5ad3f667bc6f8d388a13d9e84c7bb6c223a556dfd34af",
+      "signature": "b87b7e989aa85aa3a2a7cd8adcb3a848d3512ff718b168e15217ff3e5da29c0183c0328b97cc052fcb5ee3548aa5e41e530ba9d854199ea19d7ddaf6a54a4c0a"
+    }]
+  }
+}
+```
+
+
+### **import_key_images**
 
 Import signed key images list and verify their spent status.
 
@@ -901,19 +971,22 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"import_key_images", "params":{"signed_key_images":[{"key_image":"63b83df78cafd99e23b5ad3f667bc6f8d38813d9e84c7bb6c223a556dfd34af","signature":"b87b7e989aa86aa2a7a7cd8adcb3a848d3512ff718b168e15217ff3e5da29c0183c0328b97cc052fcb5ee3548aa5e41e530ba9d854199ea19d7ddaf6a54a4c0a"},{"key_image":"44ec12fbc56c533a30b09de8ae26febd515528c4957dfe875430377a7e212b4e","signature":"91105f15be0b25bc2a94bd78a7e261608974d6d888080b9f1815655b98af190340325ea1a0840a5951dacf913d4de1b2bd33ea59c1cb7bce1b6648afa7133d03"}]}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "height": 986050,
-        "spent": 10000100000000,
-        "unspent": 4979852760000
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"import_key_images", "params":{"signed_key_images":[{"key_image":"63b83df78cafd99e23b5ad3f667bc6f8d38813d9e84c7bb6c223a556dfd34af","signature":"b87b7e989aa86aa2a7a7cd8adcb3a848d3512ff718b168e15217ff3e5da29c0183c0328b97cc052fcb5ee3548aa5e41e530ba9d854199ea19d7ddaf6a54a4c0a"},{"key_image":"44ec12fbc56c533a30b09de8ae26febd515528c4957dfe875430377a7e212b4e","signature":"91105f15be0b25bc2a94bd78a7e261608974d6d888080b9f1815655b98af190340325ea1a0840a5951dacf913d4de1b2bd33ea59c1cb7bce1b6648afa7133d03"}]}}' -H 'Content-Type: application/json'
 
-### get_address_book
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "height": 986050,
+    "spent": 10000100000000,
+    "unspent": 4979852760000
+  }
+}
+```
+
+
+### **get_address_book**
 
 Retrieves entries from the address book.
 
@@ -931,27 +1004,30 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_address_book","params":{"entries":[1,2]}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "entries": [{
-          "address": "A135xq3GVMdU5qtAm4hN7zjPgz8bRaiSUQmtuDdjZ6CgXayvQruJy3WPe95qj873JhK4YdTQjoR39Leg6esznQk8PckhjRN",
-          "description": "",
-          "index": 1,
-          "payment_id": "0000000000000000000000000000000000000000000000000000000000000000"
-        },{
-          "address": "A135xq3GVMdU5qtAm4hN7zjPgz8bRaiSUQmtuDdjZ6CgXayvQruJy3WPe95qj873JhK4YdTQjoR39Leg6esznQk8PckhjRN",
-          "description": "",
-          "index": 2,
-          "payment_id": "0000000000000000000000000000000000000000000000000000000000000000"
-        }]
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_address_book","params":{"entries":[1,2]}}' -H 'Content-Type: application/json'
 
-### add_address_book
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "entries": [{
+      "address": "A135xq3GVMdU5qtAm4hN7zjPgz8bRaiSUQmtuDdjZ6CgXayvQruJy3WPe95qj873JhK4YdTQjoR39Leg6esznQk8PckhjRN",
+      "description": "",
+      "index": 1,
+      "payment_id": "0000000000000000000000000000000000000000000000000000000000000000"
+    },{
+      "address": "A135xq3GVMdU5qtAm4hN7zjPgz8bRaiSUQmtuDdjZ6CgXayvQruJy3WPe95qj873JhK4YdTQjoR39Leg6esznQk8PckhjRN",
+      "description": "",
+      "index": 2,
+      "payment_id": "0000000000000000000000000000000000000000000000000000000000000000"
+    }]
+  }
+}
+```
+
+
+### **add_address_book**
 
 Add an entry to the address book.
 
@@ -967,17 +1043,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"add_address_book","params":{"address":"44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A","description":"Donation address for the Monero project"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "index": 2
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"add_address_book","params":{"address":"44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A","description":"Donation address for the Monero project"}}' -H 'Content-Type: application/json'
 
-### delete_address_book
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "index": 2
+  }
+}
+```
+
+
+### **delete_address_book**
 
 Delete an entry from the address book.
 
@@ -989,16 +1068,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"delete_address_book","params":{"index":0}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"delete_address_book","params":{"index":0}}' -H 'Content-Type: application/json'
 
-### rescan_spent
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+    
+
+### **rescan_spent**
 
 Rescan the blockchain for spent outputs.
 
@@ -1008,16 +1090,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"rescan_spent"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"rescan_spent"}' -H 'Content-Type: application/json'
 
-### start_mining
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+
+
+### **start_mining**
 
 Start mining in the Monero daemon.
 
@@ -1031,15 +1116,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"start_mining","params":{"threads_count":1,"do_background_mining":true,"ignore_battery":true}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
-### stop_mining
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"start_mining","params":{"threads_count":1,"do_background_mining":true,"ignore_battery":true}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+
+
+### **stop_mining**
 
 Stop mining in the Monero daemon.
 
@@ -1049,16 +1138,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"stop_mining"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"stop_mining"}' -H 'Content-Type: application/json'
 
-### get_languages
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+
+
+### **get_languages**
 
 Get a list of available languages for your wallet's seed.
 
@@ -1070,17 +1162,20 @@ Outputs:
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_languages"}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-        "languages": ["Deutsch","English","Español","Français","Italiano","Nederlands","Português","русский язык","日本語","简体中文 (中国)","Esperanto"]
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_languages"}' -H 'Content-Type: application/json'
 
-### create_wallet
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "languages": ["Deutsch","English","Español","Français","Italiano","Nederlands","Português","русский язык","日本語","简体中文 (中国)","Esperanto"]
+  }
+}
+```
+
+
+### **create_wallet**
 
 Create a new wallet. You need to have set the argument "--wallet-dir" when launching monero-wallet-rpc to make this work.
 
@@ -1094,16 +1189,19 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"create_wallet","params":{"filename":"mytestwallet","password":"mytestpassword","language":"English"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"create_wallet","params":{"filename":"mytestwallet","password":"mytestpassword","language":"English"}}' -H 'Content-Type: application/json'
 
-### open_wallet
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```
+
+
+### **open_wallet**
 
 Open a wallet. You need to have set the argument "--wallet-dir" when launching monero-wallet-rpc to make this work.
 
@@ -1116,11 +1214,13 @@ Outputs: *None*.
 
 Example:
 
-{:.cli-code}
-    [ monero->~ ]$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"open_wallet","params":{"filename":"mytestwallet","password":"mytestpassword"}}' -H 'Content-Type: application/json'
-    {
-      "id": "0",
-      "jsonrpc": "2.0",
-      "result": {
-      }
-    }
+```
+$ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"open_wallet","params":{"filename":"mytestwallet","password":"mytestpassword"}}' -H 'Content-Type: application/json'
+
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+  }
+}
+```

--- a/resources/moneropedia/account.md
+++ b/resources/moneropedia/account.md
@@ -31,28 +31,43 @@ The private keys for both of these must be protected by you in order to retain y
 
 When you manage your own Monero Account with the private @spend-key, you are solely responsible for the security of your funds. Thankfully, Monero makes it very easy to backup your account. When creating a Monero account for the first time you will be given a unique @mnemonic-seed for your account that consists of 13 or 25 words in the language of your choosing. **This seed is the only thing you need to backup for your account**, and so it is imperative that it is written down and stored securely.  Never store this seed in a form or location that would allow someone else to see it!
 
-{:.cli-code}
+```
 List of available languages for your wallet's seed:
-0 : English
-1 : Spanish
-2 : Portuguese
-3 : Japanese
-Enter the number corresponding to the language of your choice: 0
+0 : Deutsch
+1 : English
+2 : Español
+3 : Français
+4 : Italiano
+5 : Nederlands
+6 : Português
+7 : русский язык
+8 : 日本語
+9 : 简体中文 (中国)
+10 : Esperanto
+Enter the number corresponding to the language of your choice: 1
 Generated new wallet: 4B15ZjveuttEaTmfZjLVioPVw7bfSmRLpSgB33CJbuC6BoGtZrug9TDAmhZEWD6XoFDGz55bgzisT9Dnv61sbsA6Sa47TYu
 view key: 4130fa26463d9451781771a8baa5d0b8085c47c4500cefe4746bab48f1d15903
-\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+**********************************************************************
 Your wallet has been generated.
-To start synchronizing with the daemon use "refresh" command.
+To start synchronizing with the daemon, use "refresh" command.
 Use "help" command to see the list of available commands.
-Always use "exit" command when closing monero-wallet-cli to save
-current session's state. Otherwise, you will possibly need to synchronize 
-your wallet again. Your wallet key is NOT under risk anyway.<br>
-<span style="color: lime;">PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.</span><br>
+Always use "exit" command when closing monero-wallet-cli to save your
+current session's state. Otherwise, you might need to synchronize 
+your wallet again (your wallet keys are NOT at risk in any case).
+
+PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
+
 aunt knuckle italics moisture hawk thorn iris abort
 chlorine smog uphill glass aptitude nowhere sewage plywood
 dual relic fierce divers anvil nodes bubble cabin abort
-\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
-<span style="color: yellow;">[wallet 4B15Zj]: </span> <span style="color: gray;">█</span><br>
+**********************************************************************
+Starting refresh...
+Refresh done, blocks received: 21939                            
+Balance: 0.000000000000, unlocked balance: 0.000000000000
+Background refresh thread started
+[wallet 4B15Zj]: █
+
+```
 
 As the example above indicates, it is incredibly important to store these words in safe locations. If you are concerned about the risk of critical loss at your home, for instance, you may want to store a second copy of your seed with your attorney or in a safety deposit box. It is also recommended that it is stored in a way that does not make it obvious that it is your seed, so writing it into a letter or as part of other notes is advisable.
 

--- a/resources/moneropedia/base64-address.md
+++ b/resources/moneropedia/base64-address.md
@@ -12,8 +12,10 @@ A @base64-address is a 516-character [Base64 encoded](https://en.wikipedia.org/w
 
 Example:
 
-{:.cli-code}
+```
 AQZGLAMpI9Q0l0kmMj1vpJJYK3CjLp~fE3MfvE-e7KMKjI5cPOH6EN8m794uHJ6b09qM8mb9VEv1lVLEov~usVliTSXCSHuRBOCIwIOuDNU0AbVa4BpIx~2sU4TxKhoaA3zQ6VzINoduTdR2IJhPvI5xzezp7dR21CEQGGTbenDslXeQ4iLHFA2~bzp1f7etSl9T2W9RID-KH78sRQmzWnv7dbhNodMbpO6xsf1vENf6bMRzqD5vgHEHZu2aSoNuPyYxDU1eM6--61b2xp9mt1k3ud-5WvPVg89RaU9ugU5cxaHgR927lHMCAEU2Ax~zUb3DbrvgQBOTHnJEx2Fp7pOK~PnP6ylkYKQMfLROosLDXinxOoSKP0UYCh2WgIUPwE7WzJH3PiJVF0~WZ1dZ9mg00c~gzLgmkOxe1NpFRNg6XzoARivNVB5NuWqNxr5WKWMLBGQ9YHvHO1OHhUJTowb9X90BhtHnLK2AHwO6fV-iHWxRJyDabhSMj1kuYpVUBQAEAAcAAA==
+```
+
 
 ### In-depth Information
 

--- a/resources/moneropedia/jump-service.md
+++ b/resources/moneropedia/jump-service.md
@@ -23,8 +23,9 @@ Then, you'll have two options:
 
 For example, entering `pinkpaste.i2p` into the *Hostname lookup* box (and then submitting) will return:
 
-{:.cli-code}
+```
 pinkpaste.i2p=m-HrPrIAsdxts0WM~P4mE8mt9P7g-QTaBvu7Gc6Nl0UX7Vwck-i~RvOPfK6W~kfdRvwhNTqevkBL2UF5l36We02Aiywu7kB2xOHRkze68h-Tg2ewvRVwokohguCD2G3wwAEz~7FVda2avYDCb9-N6TfuzxKLnmhPMvbNSjGL7ZsD2p-h207R3-2kvuMV9bfu-K~w9NI9XJhIyufvUnFYc2jnTVg8PbaR4UP57cNaOO2YIMPkbr6~yTcIu9B1sUfHK6-N~6virQDOxW4M-62rjnZkLpaCtkOsXslmCwZI--TkZ6hKi1kXZvNmJRE1rYfffYRFn38zhaqszeETX8HiIvahZhXF5fNumBziYdmLdw8hkuN1A~emU6Xz9g~a1Ixfsq1Qr~guYoOtaw-0rOFxNRS9yMehE-2LCb8c-cAg6z5OdlN4qJDl~ZHgru4d~EHp~BpAK3v7u2Gi-8l1ygVW-1CHVna~fwnbOPN3ANPwh6~~yUit0Cx1f54XiNRn6-nPBQAEAAcAAA==
+```
 
 Copy/paste this host=@base64-address pairing into your **private** @subscription.
 

--- a/resources/moneropedia/subscription.md
+++ b/resources/moneropedia/subscription.md
@@ -18,8 +18,9 @@ More specifically, a subscription pairs a @locally-unique-host to @base64-addres
 
 Example:
 
-{:.cli-code}
+```
 anonimal.i2p=AQZGLAMpI9Q0l0kmMj1vpJJYK3CjLp~fE3MfvE-e7KMKjI5cPOH6EN8m794uHJ6b09qM8mb9VEv1lVLEov~usVliTSXCSHuRBOCIwIOuDNU0AbVa4BpIx~2sU4TxKhoaA3zQ6VzINoduTdR2IJhPvI5xzezp7dR21CEQGGTbenDslXeQ4iLHFA2~bzp1f7etSl9T2W9RID-KH78sRQmzWnv7dbhNodMbpO6xsf1vENf6bMRzqD5vgHEHZu2aSoNuPyYxDU1eM6--61b2xp9mt1k3ud-5WvPVg89RaU9ugU5cxaHgR927lHMCAEU2Ax~zUb3DbrvgQBOTHnJEx2Fp7pOK~PnP6ylkYKQMfLROosLDXinxOoSKP0UYCh2WgIUPwE7WzJH3PiJVF0~WZ1dZ9mg00c~gzLgmkOxe1NpFRNg6XzoARivNVB5NuWqNxr5WKWMLBGQ9YHvHO1OHhUJTowb9X90BhtHnLK2AHwO6fV-iHWxRJyDabhSMj1kuYpVUBQAEAAcAAA==
+```
 
 1. `anonimal.i2p` is the @locally-unique-host
 2. `=` is the separator


### PR DESCRIPTION
This PR includes the following:
- Fix issue with daemon-rpc example styling.
- Remove references to deprecated class “cli-code” and replace with
code blocks where necessary.
- Add new line between all RPC calls and outputs.
- Use 3-apostrophe code blocks instead of indent for all curl examples
for markdown neatness and to enable future syntax highlighting.