### PR TITLE
Add missing protocol upgrade tag

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -75,3 +75,6 @@
 
 - slug: releases
   name: Monero Software Releases
+
+- slug: protocol upgrade
+  name: Protocol Upgrade


### PR DESCRIPTION
The tag `protocol upgrade` was first used in this [blog post](https://getmonero.org/2017/09/13/september-15-2017-protocol-upgrade-hard-fork.html), but never added to the tag list.