### PR TITLE
Fix remaining broken links in RPC documentation

### DIFF
--- a/resources/developer-guides/daemon-rpc.md
+++ b/resources/developer-guides/daemon-rpc.md
@@ -37,10 +37,10 @@ Note: "atomic units" refer to the smallest fraction of 1 XMR according to the mo
 
 * [/getheight](#getheight)
 * [/gettransactions](#gettransactions)
-* [/is_key_image_spent](#iskeyimagespent)
+* [/is_key_image_spent](#is_key_image_spent)
 * [/sendrawtransaction](#sendrawtransaction)
-* [/get_transaction_pool](#gettransactionpool)
-* [/stop_daemon](#stopdaemon)
+* [/get_transaction_pool](#get_transaction_pool)
+* [/stop_daemon](#stop_daemon)
 
 
 ---


### PR DESCRIPTION
The links were partially fixed recently in https://github.com/monero-project/monero-site/pull/402 but these 3 links were forgotten.