### PR TITLE
Add KoDDoS.net to merchants.yml

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -140,6 +140,8 @@
       url: http://www.guitartheoryrevolution.info/blog/guitar-theory-revolution-store/
     - name: Infield Loan Services - Atlanta, Construction Consulting, Contract review, Feasibility, Funds Escrow
       url: mailto:info@loandraw.com
+    - name: KoDDoS.net - DDoS Protection
+      url: https://koddos.net
     - name: MSvB Hardware Design (using a secure element)
       url: mailto:monerodev+sitesvcs@encambio.com?subject=Monero%20Services%20Hardware%20Design%20Request
     - name: MyMonero Web-based Wallet


### PR DESCRIPTION
Fix #449 

Site was previously removed because it didn't mention Monero as a payment method, but is [added now](https://koddos.net/payment-methods.html).