### PR TITLE
Fix formatting on copyright page

### DIFF
--- a/legal/copyright.md
+++ b/legal/copyright.md
@@ -1,6 +1,12 @@
 ---
-layout: custom
-title: Legal
+layout: static_page
+title: "Copyright"
+title-pre-kick: "Copyright "
+title-kick: "Copyright"
+title-post-kick: ""
+kick-class: "green-kicks"
+icon: "icon_copyright"
+attribution: ""
 ---
 
 ### The Monero Project


### PR DESCRIPTION
The content on the copyright page isn't inside a container and looks a bit awkward.

###### Before
![Before](https://i.imgur.com/WLoog5A.png)

###### After
![After](https://i.imgur.com/jrdbI99.png)