### PR TITLE
Fix image width

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -989,8 +989,6 @@ h1, h2, h3, h4, h5, h6, p {margin: 0; padding: 0;}
 
 img, video {max-width: 100%;}
 
-img, video {width: 100%;}
-
 ::-webkit-input-placeholder {
   color: #AAA;
 }


### PR DESCRIPTION
Fix the large MyMonero logo on downloads page. The default width shouldn't be set to 100% of the page width.

![mymonero large](https://user-images.githubusercontent.com/7271470/32011763-f90e8736-b9b5-11e7-8d21-6c930845875e.png)
