### PR TITLE
Added in Tuxcon web + mail hosting

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -166,6 +166,8 @@
       url: https://rootbox.host/
     - name: TheBigCoin - Spend Monero Anywhere
       url: https://www.thebigcoin.io
+    - name: Tuxcon Hosting - Mail and Web Hosting
+      url: https://tuxcon.com
     - name: Web Developer - Python with Django web framework
       url: http://www.voteforrodneylewis.com
     - name: Web Developer - Stefanos


### PR DESCRIPTION
Tuxcon accepts Monero as payment for web and mail hosting services