### PR TITLE
Fix missing protocol upgrade tag

### DIFF
--- a/blog/tags/protocol upgrade.md
+++ b/blog/tags/protocol upgrade.md
@@ -1,0 +1,3 @@
+---
+layout: blog_by_tag
+---


### PR DESCRIPTION
Clicking on the protocol upgrade tag link on the bottom of [this blog post](https://getmonero.org/2017/09/13/september-15-2017-protocol-upgrade-hard-fork.html) results in 404.

edit: Somehow I forgot it in my last PR https://github.com/monero-project/monero-site/pull/500 as this directory was ignored by the `.gitignore` file.