### PR TITLE
Describe "do_not_relay" flag and the strange default

### DIFF
--- a/_i18n/en/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/en/resources/developer-guides/daemon-rpc.md
@@ -717,6 +717,7 @@ Broadcast a raw transaction to the network.
 Inputs:
 
 * *tx_as_hex* - string; Full transaction information as hexidecimal string.
+* *do_not_relay* - boolean; Stop relaying transaction to other nodes (default is `false` now; in versions 0.11.1 it was `true`).
 
 Outputs:
 
@@ -737,7 +738,7 @@ Example (No return information included here.):
 
 
 ```
-$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3..."}' -H 'Content-Type: application/json'
+$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3...", "do_not_relay":false}' -H 'Content-Type: application/json'
 ```
 
 

--- a/_i18n/es/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/es/resources/developer-guides/daemon-rpc.md
@@ -718,6 +718,7 @@ Broadcast a raw transaction to the network.
 Inputs:
 
 * *tx_as_hex* - string; Full transaction information as hexidecimal string.
+* *do_not_relay* - boolean; Stop relaying transaction to other nodes (default is `false` now; in versions 0.11.1 it was `true`).
 
 Outputs:
 
@@ -738,7 +739,7 @@ Example (No return information included here.):
 
 
 ```
-$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3..."}' -H 'Content-Type: application/json'
+$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3...", "do_not_relay":false}' -H 'Content-Type: application/json'
 ```
 
 

--- a/_i18n/template/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/template/resources/developer-guides/daemon-rpc.md
@@ -718,6 +718,7 @@ Broadcast a raw transaction to the network.
 Inputs:
 
 * *tx_as_hex* - string; Full transaction information as hexidecimal string.
+* *do_not_relay* - boolean; Stop relaying transaction to other nodes (default is `false` now; in versions 0.11.1 it was `true`).
 
 Outputs:
 
@@ -738,7 +739,7 @@ Example (No return information included here.):
 
 
 ```
-$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3..."}' -H 'Content-Type: application/json'
+$ curl -X POST http://127.0.0.1:18081/sendrawtransaction -d '{"tx_as_hex":"de6a3...", "do_not_relay":false}' -H 'Content-Type: application/json'
 ```
 
 


### PR DESCRIPTION
This important flag was not documented. What's worse, the default value stops tx propagation, which definitely need mentioning.