### PR TITLE
Add a link to 'View Only Wallets' in 'Securely purchasing and storing Monero' page

### DIFF
--- a/_i18n/en/resources/user-guides/securely_purchase.md
+++ b/_i18n/en/resources/user-guides/securely_purchase.md
@@ -73,7 +73,7 @@ When the Shapehift.io webpage says your transaction has been completed, you shou
 #### Notes and How to Verify Funds
 Because the Monero blockchain is private and untraceable, you won't be able to lookup your Monero Public Address and confirm that the funds have arrived like you might with Bitcoin.  This is good for privacy, but bad for convenience.
 
-To securely verify the funds have arrived at your wallet, you will need to setup a View Only wallet.  This is where that view-key comes in.  To create a view-only wallet see the entry: @view-only
+To securely verify the funds have arrived at your wallet, you will need to setup a View Only wallet.  This is where that view-key comes in.  To create a view-only wallet see the entry: [View Only Wallets]({{site.baseurl}}/resources/user-guides/view_only.html)
 
 To verify the funds are *still in* your wallet and have not been spent you need to create a Cold Wallet with your mnemonic key (all your funds) on an airgapped computer with an up-to-date copy of the Monero Blockchain. When finished you will have to securely erase the wallet or connect it to the internet and it becomes a Hot Wallet.
 

--- a/_i18n/es/resources/user-guides/securely_purchase.md
+++ b/_i18n/es/resources/user-guides/securely_purchase.md
@@ -74,7 +74,7 @@ When the Shapehift.io webpage says your transaction has been completed, you shou
 #### Notes and How to Verify Funds
 Because the Monero blockchain is private and untraceable, you won't be able to lookup your Monero Public Address and confirm that the funds have arrived like you might with Bitcoin.  This is good for privacy, but bad for convenience.
 
-To securely verify the funds have arrived at your wallet, you will need to setup a View Only wallet.  This is where that view-key comes in.  To create a view-only wallet see the entry: @view-only
+To securely verify the funds have arrived at your wallet, you will need to setup a View Only wallet.  This is where that view-key comes in.  To create a view-only wallet see the entry: [View Only Wallets]({{site.baseurl}}/resources/user-guides/view_only.html)
 
 To verify the funds are *still in* your wallet and have not been spent you need to create a Cold Wallet with your mnemonic key (all your funds) on an airgapped computer with an up-to-date copy of the Monero Blockchain. When finished you will have to securely erase the wallet or connect it to the internet and it becomes a Hot Wallet.
 

--- a/_i18n/template/resources/user-guides/securely_purchase.md
+++ b/_i18n/template/resources/user-guides/securely_purchase.md
@@ -74,7 +74,7 @@ When the Shapehift.io webpage says your transaction has been completed, you shou
 #### Notes and How to Verify Funds
 Because the Monero blockchain is private and untraceable, you won't be able to lookup your Monero Public Address and confirm that the funds have arrived like you might with Bitcoin.  This is good for privacy, but bad for convenience.
 
-To securely verify the funds have arrived at your wallet, you will need to setup a View Only wallet.  This is where that view-key comes in.  To create a view-only wallet see the entry: @view-only
+To securely verify the funds have arrived at your wallet, you will need to setup a View Only wallet.  This is where that view-key comes in.  To create a view-only wallet see the entry: [View Only Wallets]({{site.baseurl}}/resources/user-guides/view_only.html)
 
 To verify the funds are *still in* your wallet and have not been spent you need to create a Cold Wallet with your mnemonic key (all your funds) on an airgapped computer with an up-to-date copy of the Monero Blockchain. When finished you will have to securely erase the wallet or connect it to the internet and it becomes a Hot Wallet.
 


### PR DESCRIPTION
I think this part (`@view-only`) shouldn't be a normal text but an actual link to the page.

https://getmonero.org/resources/user-guides/securely_purchase.html
