### PR TITLE
Wrong link in one stackexchange Question/Answer

### DIFF
--- a/_i18n/template/community/hangouts.md
+++ b/_i18n/template/community/hangouts.md
@@ -83,7 +83,7 @@ The Monero community is diverse and varied. We come from all over, but we defini
                                 <a href="https://monero.stackexchange.com/questions/4335/what-does-moneros-scaling-roadmap-look-like">What does Monero's scaling roadmap look like?</a>
                                 <a href="https://monero.stackexchange.com/questions/4302/what-cryptography-primitives-concepts-other-than-the-basic-ones-does-monero-us">What cryptography primitives/concepts, other than the basic ones, does Monero use?</a>
                                 <a href="https://monero.stackexchange.com/questions/4242/how-to-extract-data-from-local-blockchain">How to extract data from local blockchain?</a>
-                                <a href="https://monero.stackexchange.com/questions/4302/what-cryptography-primitives-concepts-other-than-the-basic-ones-does-monero-us">Hiding TCP traffic for Monero miners?</a>
+                                <a href="https://monero.stackexchange.com/questions/4377/hiding-tcp-traffic-for-monero-miners">Hiding TCP traffic for Monero miners?</a>
                             </div>  
                             <div class="row center-xs">
                                 <p><a href="https://monero.stackexchange.com" class="btn-link btn-auto">Visit Stack Exchange</a></p>


### PR DESCRIPTION
Hiding TCP traffic for Monero miners was incorectly linked to the cryptography primitives & concepts one.