### PR TITLE
Typo in developer-guides.md

### DIFF
--- a/_i18n/en/resources/developer-guides.md
+++ b/_i18n/en/resources/developer-guides.md
@@ -6,7 +6,7 @@
 
 <section class="container full">
     <div class="info-block">
-        <h2>RPC Documetation</h2>
+        <h2>RPC Documentation</h2>
 <div markdown="1">
 
 [Daemon RPC Documentation](daemon-rpc.html)

--- a/_i18n/es/resources/developer-guides.md
+++ b/_i18n/es/resources/developer-guides.md
@@ -7,7 +7,7 @@
 
 <section class="container full">
     <div class="info-block">
-        <h2>RPC Documetation</h2>
+        <h2>RPC Documentation</h2>
 <div markdown="1">
 
 [Daemon RPC Documentation](daemon-rpc.html)

--- a/_i18n/it/resources/developer-guides.md
+++ b/_i18n/it/resources/developer-guides.md
@@ -7,7 +7,7 @@
 
 <section class="container full">
     <div class="info-block">
-        <h2>RPC Documetation</h2>
+        <h2>RPC Documentation</h2>
 <div markdown="1">
 
 [Daemon RPC Documentation](daemon-rpc.html)

--- a/_i18n/template/resources/developer-guides.md
+++ b/_i18n/template/resources/developer-guides.md
@@ -7,7 +7,7 @@
 
 <section class="container full">
     <div class="info-block">
-        <h2>RPC Documetation</h2>
+        <h2>RPC Documentation</h2>
 <div markdown="1">
 
 [Daemon RPC Documentation](daemon-rpc.html)


### PR DESCRIPTION
Small typo to correct in the English file (as well as the template, and other unfinished translations).