### PR TITLE
Replaced Google Analytics with Matomo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,21 +35,25 @@
                 </div>
             </div>
 </footer>
-
-
-    <!-- JS -->
-    <script src="//static.getmonero.org/scripts.js"></script>
-    <script type="text/javascript">
-        $(document).ready(function(){
-            $('[data-toggle="tooltip"]').tooltip();
-        });
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-		ga('create', 'UA-53312765-1', 'auto');
-		ga('require', 'linkid', 'linkid.js');
-		ga('send', 'pageview');
-	</script>
-    
-    {% include hostflag.html %}
+<!-- Matomo -->
+<script type="text/javascript">
+    var _paq = _paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u = "//analytics.getmonero.org/";
+        _paq.push(['setTrackerUrl', u + 'piwik.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document,
+            g = d.createElement('script'),
+            s = d.getElementsByTagName('script')[0];
+        g.type = 'text/javascript';
+        g.async = true;
+        g.defer = true;
+        g.src = u + 'piwik.js';
+        s.parentNode.insertBefore(g, s);
+    })();
+</script>
+<!-- End Matomo Code -->
+{% include hostflag.html %}

--- a/language.php
+++ b/language.php
@@ -71,15 +71,5 @@ if (isset($_COOKIE["MONERO_LANG"]))
 
     <!-- JS -->
     <script src="//static.getmonero.org/scripts.js"></script>
-	<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-		ga('create', 'UA-53312765-1', 'auto');
-		ga('require', 'linkid', 'linkid.js');
-		ga('send', 'pageview');
-	</script>
   </body>
 </html>

--- a/legal/index.md
+++ b/legal/index.md
@@ -158,11 +158,11 @@ Certain logos, such as those for the operating systems and platforms we support 
 <div class="col" markdown="1">
 ### What We Collect
 
-The Monero Project uses Google Analytics to collect usage and visitor data for this website. This is enabled via a small piece of JavaScript code, and will not run if you have JavaScript disabled. We also collect standard server logs from our webserver.
+The Monero Project uses [Matomo](https://matomo.org/) to collect usage and visitor data for this website. This is enabled via a small piece of JavaScript code, and will not run if you have JavaScript disabled. We also collect standard server logs from our webserver.
 
 ### What We Use the Data For
 
-The Google Analytics data is used to provide statistics on the website and help us to improve the content and the information flow.
+The Matomo data is used to provide statistics on the website and help us to improve the content and the information flow.
 
 Server logs are used to analyze errors and diagnose requests to dead links. A portion of the server logs are used to gather statistics on Monero downloads in order to help us better understand our user's needs.
 </div>


### PR DESCRIPTION
Replaced Google Analytics with an open-source, self-hosted alternative: Matomo.

Some cleanup in the footer include also.