### PR TITLE
Remove BitMEX from merchants list

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -11,8 +11,6 @@
       url: https://www.bitfinex.com/
     - name: Bisq; decentralized exchange (previously Bitsquare)
       url: https://bisq.io/
-    - name: BitMEX
-      url: https://www.bitmex.com/app/trade/XMR7D
     - name: Bittrex
       url: https://www.bittrex.com/Market/Index?MarketName=BTC-XMR
     - name: Bter


### PR DESCRIPTION
BitMEX no longer offer an XMR contract, and previously settled their Monero contract in Bitcoin anyway.