### PR TITLE
Developer-guides, "Atomic units" replacement with "Piconero(j)"

### DIFF
--- a/_i18n/en/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/en/resources/developer-guides/daemon-rpc.md
@@ -4,7 +4,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -170,7 +170,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new piconeroj generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 piconeroj.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -308,7 +308,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in piconero(j).
       * *target* - 
         * *key* - 
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -651,11 +651,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in piconero(j).
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in piconero(j).
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -756,7 +756,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in piconero(j).
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -769,11 +769,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in piconero(j).
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in piconero(j).
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/en/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/en/resources/developer-guides/wallet-rpc.md
@@ -29,7 +29,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### Index of JSON RPC Methods:
 
@@ -157,7 +157,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -201,7 +201,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/es/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/es/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new piconeroj generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 piconeroj.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in piconero(j).
       * *target* - 
         * *key* - 
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in piconero(j).
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in piconero(j).
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -757,7 +757,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in piconero(j).
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -770,11 +770,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in piconero(j).
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in piconero(j).
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/es/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/es/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/fr/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/fr/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new piconeroj generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 piconeroj.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in piconero(j).
       * *target* -
         * *key* -
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in piconero(j).
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in piconero(j).
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -757,7 +757,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in piconero(j).
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -770,11 +770,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in piconero(j).
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in piconero(j).
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/fr/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/fr/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -284,7 +284,7 @@ Outputs:
 
 * *tx_hash_list* - array of string;
 * *tx_key_list* - array of string;
-* *tx_blob_list* - array of string; 
+* *tx_blob_list* - array of string;
 
 Example:
 
@@ -1068,7 +1068,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/it/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/it/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new piconeroj generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 piconeroj.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in piconero(j).
       * *target* - 
         * *key* - 
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in piconero(j).
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in piconero(j).
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -756,7 +756,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in piconero(j).
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -769,11 +769,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in piconero(j).
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in piconero(j).
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/it/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/it/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/pl/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/pl/resources/developer-guides/daemon-rpc.md
@@ -4,7 +4,7 @@ Poniżej znajduje się lista funkcji RPC demona monerod, ich wejścia i wyników
 
 Wiele funkcji RPC korzysta z interfejsu demona JSON RPC, podczas gdy inne używają własnego interfejsu, jak przedstawiono poniżej.
 
-Uwaga: "jednostki atomowe" dotyczą najmniejszego ułamka 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 jednostek atomowych.**
+Uwaga: "@piconero" dotyczą najmniejszego ułamka 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 piconeroj.**
 
 ### [Metody JSON RPC](#json-rpc-methods):
 
@@ -85,7 +85,7 @@ Wyszukuje hasz bloku za pomocą jego wysokości.
 Wejście:
 
 * wysokość bloku (liczba całkowita szeregu o długości 1)
-  
+
 Wynik:
 
 * hasz bloku (ciąg)
@@ -170,7 +170,7 @@ Wynik:
   * *nonce* - niepodpisana liczba całkowita; losowy i jednorazowy numer kryptograficzny użyty do wydobycia bloku Monero.
   * *orphan_status* - logiczny typ danych; zazwyczaj `false`. Jeśli `true`, dany blok nie jest częścią najdłuższego łańcucha.
   * *prev_hash* - ciąg; hasz bloku bezpośrednio poprzedzającego dany blok w łańcuchu.
-  * *reward* - niepodpisana liczba całkowita; liczba nowych jednostek atomowych wytworzonych w danym bloku i przyznanych górnikowi. 	Zauważ: 1 XMR = 1e12 jednostek atomowych.
+  * *reward* - niepodpisana liczba całkowita; liczba nowych piconeroj wytworzonych w danym bloku i przyznanych górnikowi. 	Zauważ: 1 XMR = 1e12 piconeroj.
   * *timestamp* - niepodpisana liczba całkowita; czas, kiedy blok został zapisany w łańcuchu.
 * *status* - ciąg; kod generalnego błędu RPC. "OK" oznacza, że wszystko jest w porządku.
 
@@ -308,9 +308,9 @@ Wynik:
       * *gen* - transakcje górnika są transakcjami coinbase, inaczej "gen".
         * *height* - wysokość danego bloku, czyli kiedy coinbase został wygenerowany.
     * *vout* - lista wyjść transakcji. Każde wyjście zawiera:
-      * *amount* - kwotę wyjścia w jednostkach atomowych.
-      * *target* - 
-        * *key* - 
+      * *amount* - kwotę wyjścia w piconero(j).
+      * *target* -
+        * *key* -
     * *extra* - zazwyczaj nazywane "numerem identyfikacyjnym transakcji", może być użyte do zawarcia jakiegokolwiek ciągu 32-		bajtowego/64-znakowego heksadecymalnego.
     * *signatures* - zawiera podpisy uczestników transakcji. Transakcje coinbase nie posiadają podpisów.
   * *tx_hashes* - lista haszy transakcji nie-coinbase w bloku. Jeśli nie było takich transakcji, lista będzie pusta.
@@ -543,7 +543,7 @@ Wejście:
   * *ip* - niepodpisana liczba całkowita; adres IP do zbanowania w formacie numerycznym.
   * *ban* - logiczny typ danych; ustaw `true`, aby zbanować.
   * *seconds* - niepodpisana liczba całkowita; liczba sekund do zbanowania węzła.
-  
+
 Wynik:
 
 * *status* - ciąg; kod generalnego błędu RPC. "OK" oznacza, że wszystko jest w porządku.
@@ -651,11 +651,11 @@ Wynik:
   * *unlock_time* - jeśli różne od 0, informuje o czasie, kiedy wyjście transakcji będzie gotowe do wydania.
   * *vin* - lista wkładów do transakcji:
     * *key* - publiczny klucz poprzedniego wyjścia, wydanego w tej transakcji.
-      * *amount* - kwota wkładu w jednostkach atomowych.
+      * *amount* - kwota wkładu w piconero(j).
       * *key_offsets* - lista numerycznych offsetów wkładu.
       * *k_image* - obraz klucza danego wkładu.
   * *vout* - lista wyjść transakcji:
-    * *amount* - kwota wyjścia transakcji w jednostkach atomowych.
+    * *amount* - kwota wyjścia transakcji w piconero(j).
     * *target* - informacje na temat celu wyjścia:
       * *key* - jednorazowy klucz publiczny odbiorcy. Ktokolwiek posiada prywatny klucz połączony z tym kluczem, kontroluje wyjście tej 	transakcji.
   * *extra* - zazwyczaj nazywane "numerem identyfikacyjnym płatności", może zostać użyte do włączenia dowolnych 32 bajtów.
@@ -729,7 +729,7 @@ Wynik:
 * *low_mixin* - logiczny typ danych; liczba Mixin jest zbyt niska (`true`) lub nie (`false`).
 * *not_rct* - logiczny typ danych; transakcja nie jest transakcją pierścieniową (`true`) lub jest transakcją pierścieniową (`false`).
 * *not_relayed* - logiczny typ danych; transakcja nie została przekazana (`true`) lub została przekazana (`false`).
-* *overspend* - logiczny typ danych; transakcja korzysta z większej kwoty niż to możliwe (`true`) lub nie (`false`). 
+* *overspend* - logiczny typ danych; transakcja korzysta z większej kwoty niż to możliwe (`true`) lub nie (`false`).
 * *reason* - ciąg; dodatkowe informacje. Obecnie puste lub "Not relayed", jeśli transakcja została zaakceptowana, ale nie przekazana.
 * *too_big* - logiczny typ danych; rozmiar transakcji jest zbyt duży (`true`) lub nie (`false`).
 
@@ -756,7 +756,7 @@ Wynik:
 * *status* - ciąg; kod generalnego błędu RPC. "OK" oznacza, że wszystko jest w porządku.
 * *transactions* - lista transakcji w puli pamięci, które nie zostały uwzględnione w bloku:
   * *blob_size* - niepodpisana liczba całkowita; rozmiar pełnego blobu transakcji.
-  * *fee* - niepodpisana liczba całkowita; kwota opłaty wydobywczej uwzględnionej w transakcji w jednostkach atomowych.
+  * *fee* - niepodpisana liczba całkowita; kwota opłaty wydobywczej uwzględnionej w transakcji w piconero(j).
   * *id_hash* - ciąg; hasz numeru identyfikacyjnego transakcji.
   * *kept_by_block* - logiczny typ danych; nie akceptujemy transakcji, które skończyły się wcześsniej, chyba że ustawiono jako `true`.
   * *last_failed_height* - niepodpisana liczba całkowita; jeśli transakcja skończyła się wcześniej, funckja ta określa, na jakiej 	wysokości się to stało.
@@ -769,11 +769,11 @@ Wynik:
     * *unlock_time* - jeśli różne od 0, określa czas, kiedy wyjście transakcji będzie możliwe do wydania.
  * *vin* - lista wkładów do transakcji:
     * *key* - publiczny klucz poprzedniego wyjścia, wydanego w tej transakcji.
-      * *amount* - kwota wkładu w jednostkach atomowych.
+      * *amount* - kwota wkładu w piconero(j).
       * *key_offsets* - lista numerycznych offsetów wkładu.
       * *k_image* - obraz klucza danego wkładu.
   * *vout* - lista wyjść transakcji:
-    * *amount* - kwota wyjścia transakcji w jednostkach atomowych.
+    * *amount* - kwota wyjścia transakcji w piconero(j).
     * *target* - informacje na temat celu wyjścia:
       * *key* - jednorazowy klucz publiczny odbiorcy. Ktokolwiek posiada prywatny klucz połączony z tym kluczem, kontroluje wyjście tej 	transakcji.
   * *extra* - zazwyczaj nazywane "numerem identyfikacyjnym płatności", może zostać użyte do włączenia dowolnych 32 bajtów.

--- a/_i18n/pl/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/pl/resources/developer-guides/wallet-rpc.md
@@ -29,7 +29,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Zauważ, że jednostki atomowe są najmniejszą częścią 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 jednostek atomowych.**
+Zauważ, że @piconero jest najmniejszą częścią 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 piconeroj.**
 
 ### Lista metod JSON RPC:
 
@@ -157,7 +157,7 @@ Wysyła Monero do wielu odbiorców.
 Wejście:
 
 * *destinations* - szereg odbiorców XMR:
-  * *amount* - niepodpisana liczba całkowita; kwota do wysłania każdemu z odbiorców w jednostkach atomowych.
+  * *amount* - niepodpisana liczba całkowita; kwota do wysłania każdemu z odbiorców w piconero(j).
   * *address* - ciąg; adres publiczny odbiorcy.
 * *fee* - niepodpisana liczba całkowita; kwota opłaty, gdy zignorowana, zostanie obliczona automatycznie.
 * *mixin* - niepodpisana liczba całkowita; liczba wyjść łańcucha do zmiksowaniah (0 oznacza brak miksowania).
@@ -201,7 +201,7 @@ Funkcja podobna do "transfer", ale potrafi podzielić płatności na więcej ni�
 Wejście:
 
 * *destinations* - szereg odbiorców XMR:
-  * *amount* - niepodpisana liczba całkowita; kwota do wysłania każdemu z odbiorców w jednostkach atomowych.
+  * *amount* - niepodpisana liczba całkowita; kwota do wysłania każdemu z odbiorców w piconero(j).
   * *address* - ciąg; adres publiczny odbiorcy.
 * *fee* - niepodpisana liczba całkowita; kwota opłaty, gdy zignorowana, zostanie obliczona automatycznie.
 * *mixin* - niepodpisana liczba całkowita; liczba wyjść łańcucha do zmiksowaniah (0 oznacza brak miksowania).
@@ -283,7 +283,7 @@ Wynik:
 
 * *tx_hash_list* - szereg ciągów;
 * *tx_key_list* - szereg ciągów;
-* *tx_blob_list* - szereg ciągów; 
+* *tx_blob_list* - szereg ciągów;
 
 Przykład:
 
@@ -1067,7 +1067,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/template/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/template/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new piconeroj generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 piconeroj.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in piconero(j).
       * *target* -
         * *key* -
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in piconero(j).
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in piconero(j).
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -757,7 +757,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in piconero(j).
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -770,11 +770,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in piconero(j).
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in piconero(j).
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/template/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/template/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@piconero" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 piconeroj.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in piconero(j).
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).


### PR DESCRIPTION
After translating the deamon developer-guide and reading about the denomination, i figured out we were refering to "atomic units" which are not defined anywhere else.

So i suggest to change this and use the official denomination of piconero(j).

This PR include changes in all files for all languages, and an additional link to the moneropedia denomination page for the "heading note" about it.

I even changed it for Polski, but this will need a quick review from @zofiazinha to make sure something is not inconsistent.