### PR TITLE
Moneropedia article "Atomic Units"

### DIFF
--- a/_i18n/en/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/en/resources/developer-guides/daemon-rpc.md
@@ -4,7 +4,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -170,7 +170,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new @atomic-units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 @atomic-units.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -308,7 +308,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in @atomic-units.
       * *target* - 
         * *key* - 
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -651,11 +651,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in @atomic-units.
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in @atomic-units.
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -756,7 +756,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in @atomic-units.
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -769,11 +769,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in @atomic-units.
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in @atomic-units.
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/en/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/en/resources/developer-guides/wallet-rpc.md
@@ -29,7 +29,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### Index of JSON RPC Methods:
 
@@ -157,7 +157,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -201,7 +201,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/en/resources/moneropedia/atomic-units.md
+++ b/_i18n/en/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/_i18n/en/resources/moneropedia/denominations.md
+++ b/_i18n/en/resources/moneropedia/denominations.md
@@ -2,12 +2,14 @@
 layout: moneropedia
 entry: "Denominations"
 terms: ["denominations", "subunits", "tacoshi", "piconero", "nanonero", "micronero", "millinero", "centinero", "decinero","decanero","hectonero","kilonero","meganero","giganero"]
-summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a a particular unit of currency.)"
+summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a particular unit of currency.)"
 ---
 
 ### The Basics
 
-A denomination is a proper description of a currency amount, oftentimes a sub-unit of the currency (for example, traditionally a cent is 1/100th of a a unit of currency). Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. The smallest unit of Monero is 1 piconero (0.000000000001 XMR).
+{{ page.summary | capitalize }}.
+
+Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. Actually, the smallest unit of Monero is 1 piconero (0.000000000001 XMR).
 
 ### Denominations of Monero
 
@@ -31,6 +33,8 @@ A denomination is a proper description of a currency amount, oftentimes a sub-un
 
 ### In-depth Information
 
-Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
+Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of Monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
 
-{{ page.summary | capitalize }}.
+### Monerod Implementation
+
+The smallest fraction of Monero in current monerod implementation is also known as an @atomic-unit which actually equals to 1 piconero.

--- a/_i18n/es/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/es/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new @atomic-units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 @atomic-units.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in @atomic-units.
       * *target* - 
         * *key* - 
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in @atomic-units.
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in @atomic-units.
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -757,7 +757,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in @atomic-units.
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -770,11 +770,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in @atomic-units.
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in @atomic-units.
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/es/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/es/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/es/resources/moneropedia/atomic-units.md
+++ b/_i18n/es/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/_i18n/es/resources/moneropedia/denominations.md
+++ b/_i18n/es/resources/moneropedia/denominations.md
@@ -2,12 +2,14 @@
 layout: moneropedia
 entry: "Denominations"
 terms: ["denominations", "subunits", "tacoshi", "piconero", "nanonero", "micronero", "millinero", "centinero", "decinero","decanero","hectonero","kilonero","meganero","giganero"]
-summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a a particular unit of currency.)"
+summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a particular unit of currency.)"
 ---
 
 ### The Basics
 
-A denomination is a proper description of a currency amount, oftentimes a sub-unit of the currency (for example, traditionally a cent is 1/100th of a a unit of currency). Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. The smallest unit of Monero is 1 piconero (0.000000000001 XMR).
+{{ page.summary | capitalize }}.
+
+Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. Actually, the smallest unit of Monero is 1 piconero (0.000000000001 XMR).
 
 ### Denominations of Monero
 
@@ -31,6 +33,8 @@ A denomination is a proper description of a currency amount, oftentimes a sub-un
 
 ### In-depth Information
 
-Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
+Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of Monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
 
-{{ page.summary | capitalize }}.
+### Monerod Implementation
+
+The smallest fraction of Monero in current monerod implementation is also known as an @atomic-unit which actually equals to 1 piconero.

--- a/_i18n/fr/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/fr/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new @atomic-units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 @atomic-units.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in @atomic-units.
       * *target* -
         * *key* -
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in @atomic-units.
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in @atomic-units.
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -757,7 +757,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in @atomic-units.
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -770,11 +770,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in @atomic-units.
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in @atomic-units.
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/fr/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/fr/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/fr/resources/moneropedia/atomic-units.md
+++ b/_i18n/fr/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/_i18n/fr/resources/moneropedia/denominations.md
+++ b/_i18n/fr/resources/moneropedia/denominations.md
@@ -2,12 +2,14 @@
 layout: moneropedia
 entry: "Denominations"
 terms: ["denominations", "subunits", "tacoshi", "piconero", "nanonero", "micronero", "millinero", "centinero", "decinero","decanero","hectonero","kilonero","meganero","giganero"]
-summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a a particular unit of currency.)"
+summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a particular unit of currency.)"
 ---
 
 ### The Basics
 
-A denomination is a proper description of a currency amount, oftentimes a sub-unit of the currency (for example, traditionally a cent is 1/100th of a a unit of currency). Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. The smallest unit of Monero is 1 piconero (0.000000000001 XMR).
+{{ page.summary | capitalize }}.
+
+Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. Actually, the smallest unit of Monero is 1 piconero (0.000000000001 XMR).
 
 ### Denominations of Monero
 
@@ -31,6 +33,8 @@ A denomination is a proper description of a currency amount, oftentimes a sub-un
 
 ### In-depth Information
 
-Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
+Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of Monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
 
-{{ page.summary | capitalize }}.
+### Monerod Implementation
+
+The smallest fraction of Monero in current monerod implementation is also known as an @atomic-unit which actually equals to 1 piconero.

--- a/_i18n/it/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/it/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new @atomic-units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 @atomic-units.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in @atomic-units.
       * *target* - 
         * *key* - 
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in @atomic-units.
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in @atomic-units.
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -756,7 +756,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in @atomic-units.
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -769,11 +769,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in @atomic-units.
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in @atomic-units.
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/it/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/it/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/it/resources/moneropedia/atomic-units.md
+++ b/_i18n/it/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/_i18n/it/resources/moneropedia/denominations.md
+++ b/_i18n/it/resources/moneropedia/denominations.md
@@ -2,12 +2,14 @@
 layout: moneropedia
 entry: "Denominations"
 terms: ["denominations", "subunits", "tacoshi", "piconero", "nanonero", "micronero", "millinero", "centinero", "decinero","decanero","hectonero","kilonero","meganero","giganero"]
-summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a a particular unit of currency.)"
+summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a particular unit of currency.)"
 ---
 
 ### The Basics
 
-A denomination is a proper description of a currency amount, oftentimes a sub-unit of the currency (for example, traditionally a cent is 1/100th of a a unit of currency). Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. The smallest unit of Monero is 1 piconero (0.000000000001 XMR).
+{{ page.summary | capitalize }}.
+
+Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. Actually, the smallest unit of Monero is 1 piconero (0.000000000001 XMR).
 
 ### Denominations of Monero
 
@@ -31,6 +33,8 @@ A denomination is a proper description of a currency amount, oftentimes a sub-un
 
 ### In-depth Information
 
-Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
+Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of Monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
 
-{{ page.summary | capitalize }}.
+### Monerod Implementation
+
+The smallest fraction of Monero in current monerod implementation is also known as an @atomic-unit which actually equals to 1 piconero.

--- a/_i18n/pl/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/pl/resources/developer-guides/daemon-rpc.md
@@ -4,7 +4,7 @@ Poniżej znajduje się lista funkcji RPC demona monerod, ich wejścia i wyników
 
 Wiele funkcji RPC korzysta z interfejsu demona JSON RPC, podczas gdy inne używają własnego interfejsu, jak przedstawiono poniżej.
 
-Uwaga: "jednostki atomowe" dotyczą najmniejszego ułamka 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 jednostek atomowych.**
+Uwaga: "jednostki atomowe (@atomic-unit)" dotyczą najmniejszego ułamka 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 jednostek atomowych.**
 
 ### [Metody JSON RPC](#json-rpc-methods):
 
@@ -85,7 +85,7 @@ Wyszukuje hasz bloku za pomocą jego wysokości.
 Wejście:
 
 * wysokość bloku (liczba całkowita szeregu o długości 1)
-  
+
 Wynik:
 
 * hasz bloku (ciąg)
@@ -309,8 +309,8 @@ Wynik:
         * *height* - wysokość danego bloku, czyli kiedy coinbase został wygenerowany.
     * *vout* - lista wyjść transakcji. Każde wyjście zawiera:
       * *amount* - kwotę wyjścia w jednostkach atomowych.
-      * *target* - 
-        * *key* - 
+      * *target* -
+        * *key* -
     * *extra* - zazwyczaj nazywane "numerem identyfikacyjnym transakcji", może być użyte do zawarcia jakiegokolwiek ciągu 32-		bajtowego/64-znakowego heksadecymalnego.
     * *signatures* - zawiera podpisy uczestników transakcji. Transakcje coinbase nie posiadają podpisów.
   * *tx_hashes* - lista haszy transakcji nie-coinbase w bloku. Jeśli nie było takich transakcji, lista będzie pusta.
@@ -543,7 +543,7 @@ Wejście:
   * *ip* - niepodpisana liczba całkowita; adres IP do zbanowania w formacie numerycznym.
   * *ban* - logiczny typ danych; ustaw `true`, aby zbanować.
   * *seconds* - niepodpisana liczba całkowita; liczba sekund do zbanowania węzła.
-  
+
 Wynik:
 
 * *status* - ciąg; kod generalnego błędu RPC. "OK" oznacza, że wszystko jest w porządku.
@@ -729,7 +729,7 @@ Wynik:
 * *low_mixin* - logiczny typ danych; liczba Mixin jest zbyt niska (`true`) lub nie (`false`).
 * *not_rct* - logiczny typ danych; transakcja nie jest transakcją pierścieniową (`true`) lub jest transakcją pierścieniową (`false`).
 * *not_relayed* - logiczny typ danych; transakcja nie została przekazana (`true`) lub została przekazana (`false`).
-* *overspend* - logiczny typ danych; transakcja korzysta z większej kwoty niż to możliwe (`true`) lub nie (`false`). 
+* *overspend* - logiczny typ danych; transakcja korzysta z większej kwoty niż to możliwe (`true`) lub nie (`false`).
 * *reason* - ciąg; dodatkowe informacje. Obecnie puste lub "Not relayed", jeśli transakcja została zaakceptowana, ale nie przekazana.
 * *too_big* - logiczny typ danych; rozmiar transakcji jest zbyt duży (`true`) lub nie (`false`).
 

--- a/_i18n/pl/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/pl/resources/developer-guides/wallet-rpc.md
@@ -29,7 +29,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Zauważ, że jednostki atomowe są najmniejszą częścią 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 jednostek atomowych.**
+Zauważ, że jednostki atomowe (@atomic-unit) są najmniejszą częścią 1 XMR, zgodnie z implementacją monerod. **1 XMR = 1e12 jednostek atomowych.**
 
 ### Lista metod JSON RPC:
 
@@ -283,7 +283,7 @@ Wynik:
 
 * *tx_hash_list* - szereg ciągów;
 * *tx_key_list* - szereg ciągów;
-* *tx_blob_list* - szereg ciągów; 
+* *tx_blob_list* - szereg ciągów;
 
 Przykład:
 
@@ -1067,7 +1067,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/pl/resources/moneropedia/atomic-units.md
+++ b/_i18n/pl/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/_i18n/template/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/template/resources/developer-guides/daemon-rpc.md
@@ -5,7 +5,7 @@ This is a list of the monerod daemon RPC calls, their inputs and outputs, and ex
 
 Many RPC calls use the daemon's JSON RPC interface while others use their own interfaces, as demonstrated below.
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### [JSON RPC Methods](#json-rpc-methods):
 
@@ -171,7 +171,7 @@ Outputs:
   * *nonce* - unsigned int; a cryptographic random one-time number used in mining a Monero block.
   * *orphan_status* - boolean; Usually `false`. If `true`, this block is not part of the longest chain.
   * *prev_hash* - string; The hash of the block immediately preceding this block in the chain.
-  * *reward* - unsigned int; The amount of new atomic units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 atomic units.
+  * *reward* - unsigned int; The amount of new @atomic-units generated in this block and rewarded to the miner. Note: 1 XMR = 1e12 @atomic-units.
   * *timestamp* - unsigned int; The time the block was recorded into the blockchain.
 * *status* - string; General RPC error code. "OK" means everything looks good.
 
@@ -309,7 +309,7 @@ Outputs:
       * *gen* - Miner txs are coinbase txs, or "gen".
         * *height* - This block height, a.k.a. when the coinbase is generated.
     * *vout* - List of transaction outputs. Each output contains:
-      * *amount* - The amount of the output, in atomic units.
+      * *amount* - The amount of the output, in @atomic-units.
       * *target* -
         * *key* -
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 byte/64 character hex string.
@@ -652,11 +652,11 @@ Outputs:
   * *unlock_time* - If not 0, this tells when a transaction output is spendable.
   * *vin* - List of inputs into transaction:
     * *key* - The public key of the previous output spent in this transaction.
-      * *amount* - The amount of the input, in atomic units.
+      * *amount* - The amount of the input, in @atomic-units.
       * *key_offsets* - A list of integer offets to the input.
       * *k_image* - The key image for the given input
   * *vout* - List of outputs from transaction:
-    * *amount* - Amount of transaction output, in atomic units.
+    * *amount* - Amount of transaction output, in @atomic-units.
     * *target* - Output destination information:
       * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
   * *extra* - Usually called the "payment ID" but can be used to include any random 32 bytes.
@@ -757,7 +757,7 @@ Outputs:
 * *status* - string; General RPC error code. "OK" means everything looks good.
 * *transactions* - List of transactions in the mempool that have not been included in a block:
   * *blob_size* - unsigned int; The size of the full transaction blob.
-  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in atomic units.
+  * *fee* - unsigned int; The amount of the mining fee included in the transaction, in @atomic-units.
   * *id_hash* - string; The transaction ID hash.
   * *kept_by_block* - boolean; We do not accept transactions that timed out before, unless set `true`.
   * *last_failed_height* - unsigned int; If the transaction has previously timed out, this tells at what height that occured.
@@ -770,11 +770,11 @@ Outputs:
     * *unlock_time* - If not 0, this tells when a transaction output is spendable.
     * *vin* - List of inputs into transaction:
       * *key* - The public key of the previous output spent in this transaction.
-        * *amount* - The amount of the input, in atomic units.
+        * *amount* - The amount of the input, in @atomic-units.
         * *key_offsets* - A list of integer offets to the input.
         * *k_image* - The key image for the given input
     * *vout* - List of outputs from transaction:
-      * *amount* - Amount of transaction output, in atomic units.
+      * *amount* - Amount of transaction output, in @atomic-units.
       * *target* - Output destination information:
         * *key* - The stealth public key of the receiver. Whoever owns the private key associated with this key controls this transaction output.
     * *extra* - Usually called the "transaction ID" but can be used to include any random 32 bytes.

--- a/_i18n/template/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/template/resources/developer-guides/wallet-rpc.md
@@ -30,7 +30,7 @@ curl \
     -H 'Content-Type: application/json'
 ```
 
-Note: "atomic units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 atomic units.**
+Note: "@atomic-units" refer to the smallest fraction of 1 XMR according to the monerod implementation. **1 XMR = 1e12 @atomic-units.**
 
 ### Index of JSON RPC Methods:
 
@@ -158,7 +158,7 @@ Send monero to a number of recipients.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).
@@ -202,7 +202,7 @@ Same as transfer, but can split into more than one tx if necessary.
 Inputs:
 
 * *destinations* - array of destinations to receive XMR:
-  * *amount* - unsigned int; Amount to send to each destination, in atomic units.
+  * *amount* - unsigned int; Amount to send to each destination, in @atomic-units.
   * *address* - string; Destination public address.
 * *fee* - unsigned int; Ignored, will be automatically calculated.
 * *mixin* - unsigned int; Number of outpouts from the blockchain to mix with (0 means no mixing).

--- a/_i18n/template/resources/moneropedia/atomic-units.md
+++ b/_i18n/template/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/_i18n/template/resources/moneropedia/denominations.md
+++ b/_i18n/template/resources/moneropedia/denominations.md
@@ -2,12 +2,14 @@
 layout: moneropedia
 entry: "Denominations"
 terms: ["denominations", "subunits", "tacoshi", "piconero", "nanonero", "micronero", "millinero", "centinero", "decinero","decanero","hectonero","kilonero","meganero","giganero"]
-summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a a particular unit of currency.)"
+summary: "A denomination is a proper description of a currency amount. It is oftentimes a sub-unit of the currency. For example, traditionally a cent is 1/100th of a particular unit of currency.)"
 ---
 
 ### The Basics
 
-A denomination is a proper description of a currency amount, oftentimes a sub-unit of the currency (for example, traditionally a cent is 1/100th of a a unit of currency). Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. The smallest unit of Monero is 1 piconero (0.000000000001 XMR).
+{{ page.summary | capitalize }}.
+
+Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. Actually, the smallest unit of Monero is 1 piconero (0.000000000001 XMR).
 
 ### Denominations of Monero
 
@@ -31,6 +33,8 @@ A denomination is a proper description of a currency amount, oftentimes a sub-un
 
 ### In-depth Information
 
-Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
+Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of Monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
 
-{{ page.summary | capitalize }}.
+### Monerod Implementation
+
+The smallest fraction of Monero in current monerod implementation is also known as an @atomic-unit which actually equals to 1 piconero.

--- a/resources/moneropedia/atomic-units.md
+++ b/resources/moneropedia/atomic-units.md
@@ -1,0 +1,12 @@
+---
+layout: moneropedia
+entry: "Atomic Units"
+terms: ["atomic-units", "atomic-unit"]
+summary: "Atomic Units refer to the smallest fraction of 1 XMR according to the monerod implementation."
+---
+
+### The Basics
+
+{{ page.summary | capitalize }}.
+This fraction is actually of 10^-12 XMR (0.000000000001 XMR), which equals to 1 @piconero.
+It may be changed in the future.

--- a/resources/moneropedia/denominations.md
+++ b/resources/moneropedia/denominations.md
@@ -9,7 +9,7 @@ summary: "A denomination is a proper description of a currency amount. It is oft
 
 {{ page.summary | capitalize }}.
 
-Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. The smallest unit of Monero is 1 piconero (0.000000000001 XMR).
+Monero denomination names add SI prefixes after dropping the initial "mo" for ease of use. Actually, the smallest unit of Monero is 1 piconero (0.000000000001 XMR).
 
 ### Denominations of Monero
 
@@ -34,3 +34,7 @@ Monero denomination names add SI prefixes after dropping the initial "mo" for ea
 ### In-depth Information
 
 Support for input using SI prefixes was [added to the Monero codebase](https://github.com/monero-project/monero/pull/1826) on March 3, 2017 by [Moneromooo](https://github.com/moneromooo-monero). The smallest unit of Monero (10^-12 XMR) was originally called a tacoshi in honor of user [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270), an early Monero contributor and was later renamed for ease of use and consistancy.
+
+### Monerod Implementation
+
+The smallest fraction of Monero in current monerod implementation is also known as an @atomic-unit which actually equals to 1 piconero.


### PR DESCRIPTION
As i have been suggested by @mattcode55 in #705 not to change the Atomic units denomination in the developer guides, i suggest to add a moneropedia "Atomic Units" article, cross-refered in "denomination" article, and links to in developer guides.

I made three separated commit for ease of change, let me know if you want anything removed or squashed.