### PR TITLE
Moneropedia transaction mixin cleanup

### DIFF
--- a/_i18n/en/resources/moneropedia/transaction.md
+++ b/_i18n/en/resources/moneropedia/transaction.md
@@ -9,7 +9,9 @@ summary: "a cryptographically signed container that details the transfer of Mone
 
 {{ page.summary | capitalize }}.
 
-The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a `mixin_count` parameter that specifies the number of foreign outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee would be higher. It is possible to form a transaction offline, which is a huge benefit for privacy. 
+The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a @ring-size parameter that specifies the number outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
+
+It is possible to form a transaction offline, which offers additional privacy benefits.
 
 A transaction can be uniquely identified with the use of an optional Transaction ID, which is usually represented by a 32-byte string (64 hexadecimal characters).
 

--- a/_i18n/es/resources/moneropedia/transaction.md
+++ b/_i18n/es/resources/moneropedia/transaction.md
@@ -9,7 +9,9 @@ summary: "a cryptographically signed container that details the transfer of Mone
 
 {{ page.summary | capitalize }}.
 
-The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a `mixin_count` parameter that specifies the number of foreign outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee would be higher. It is possible to form a transaction offline, which is a huge benefit for privacy. 
+The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a @ring-size parameter that specifies the number outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
+
+It is possible to form a transaction offline, which offers additional privacy benefits.
 
 A transaction can be uniquely identified with the use of an optional Transaction ID, which is usually represented by a 32-byte string (64 hexadecimal characters).
 

--- a/_i18n/fr/resources/moneropedia/transaction.md
+++ b/_i18n/fr/resources/moneropedia/transaction.md
@@ -9,7 +9,9 @@ summary: "a cryptographically signed container that details the transfer of Mone
 
 {{ page.summary | capitalize }}.
 
-The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a `mixin_count` parameter that specifies the number of foreign outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee would be higher. It is possible to form a transaction offline, which is a huge benefit for privacy. 
+The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a @ring-size parameter that specifies the number outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
+
+It is possible to form a transaction offline, which offers additional privacy benefits.
 
 A transaction can be uniquely identified with the use of an optional Transaction ID, which is usually represented by a 32-byte string (64 hexadecimal characters).
 

--- a/_i18n/it/resources/moneropedia/transaction.md
+++ b/_i18n/it/resources/moneropedia/transaction.md
@@ -9,7 +9,9 @@ summary: "a cryptographically signed container that details the transfer of Mone
 
 {{ page.summary | capitalize }}.
 
-The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a `mixin_count` parameter that specifies the number of foreign outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee would be higher. It is possible to form a transaction offline, which is a huge benefit for privacy. 
+The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a @ring-size parameter that specifies the number outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
+
+It is possible to form a transaction offline, which offers additional privacy benefits.
 
 A transaction can be uniquely identified with the use of an optional Transaction ID, which is usually represented by a 32-byte string (64 hexadecimal characters).
 

--- a/_i18n/template/resources/moneropedia/transaction.md
+++ b/_i18n/template/resources/moneropedia/transaction.md
@@ -9,7 +9,9 @@ summary: "a cryptographically signed container that details the transfer of Mone
 
 {{ page.summary | capitalize }}.
 
-The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a `mixin_count` parameter that specifies the number of foreign outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee would be higher. It is possible to form a transaction offline, which is a huge benefit for privacy. 
+The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a @ring-size parameter that specifies the number outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
+
+It is possible to form a transaction offline, which offers additional privacy benefits.
 
 A transaction can be uniquely identified with the use of an optional Transaction ID, which is usually represented by a 32-byte string (64 hexadecimal characters).
 

--- a/resources/moneropedia/transaction.md
+++ b/resources/moneropedia/transaction.md
@@ -9,9 +9,9 @@ summary: "a cryptographically signed container that details the transfer of Mone
 
 {{ page.summary | capitalize }}.
 
-The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a `mixin_count` parameter that specifies the number of foreign outputs bound to the transaction (see @ring-size). The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
+The parameters of a transaction contain one or more recipient addresses with corresponding amounts of funds and a @ring-size parameter that specifies the number outputs bound to the transaction. The more outputs that are used, a higher degree of obfuscation is possible, but that comes with a cost. Since a transaction gets larger with more outputs, the transaction fee will be higher.
 
-It is possible to form a transaction offline, offline, which offers additional privacy benefits. 
+It is possible to form a transaction offline, which offers additional privacy benefits.
 
 A transaction can be uniquely identified with the use of an optional Transaction ID, which is usually represented by a 32-byte string (64 hexadecimal characters).
 


### PR DESCRIPTION
While reading moneropedia articles, i found that the Transaction article was still refering to a 'mixin_count' parameter.
I suggest to replace it with a link to \@ring-size article, and adding the ~~faxt~~ fact that it is not only the count of foreign transaction, but ~~also yours~~ all outputs.