### PR TITLE
Roadmap update to match #575 and more

### DIFF
--- a/_data/lang/en/roadmap.yml
+++ b/_data/lang/en/roadmap.yml
@@ -31,13 +31,13 @@
     - name: Monero Research Lab Paper 5 published
       date: 2016-02-10
       status: completed
-    - name: Hardfork to require minimum ringsize of 3 on all transactions
+    - name: Network Upgrade to require minimum ringsize of 3 on all transactions
       date: 2016-03-22
       status: completed
     - name: 0.10.0 Wolfram Warptangent released
       date: 2016-09-18
       status: completed
-    - name: Hardfork to split coinbase into denominations
+    - name: Network Upgrade to split coinbase into denominations
       date: 2016-09-21
       status: completed
     - name: 0.10.1 Wolfram Warptangent released
@@ -48,7 +48,7 @@
       status: completed
 - year: 2017
   accomplishments:
-    - name: Hardfork to enable RingCT transactions
+    - name: Network Upgrade to enable RingCT transactions
       date: 2017-01-05
       status: completed
     - name: 0.10.2 released; critical vulnerability patched
@@ -57,7 +57,7 @@
     - name: 0.10.3.1 Wolfram Warptangent released
       date: 2017-03-27
       status: completed
-    - name: Hardfork to adjust minimum blocksize and dynamic fee algorithm
+    - name: Network Upgrade to adjust minimum blocksize and dynamic fee algorithm
       date: 2017-04-15
       status: completed
     - name: Website redesigned
@@ -72,7 +72,7 @@
     - name: GUI out of beta
       date: 2017-09-10
       status: completed
-    - name: Hardfork to increase minimum ringsize to 5 and require RingCT transactions
+    - name: Network Upgrade to increase minimum ringsize to 5 and require RingCT transactions
       date: 2017-09-15
       status: completed
     - name: 0MQ/ZeroMQ
@@ -86,6 +86,15 @@
       status: completed
 - year: 2018
   accomplishments:
+    - name: New Proof of Work CryptoNoteV7
+      date: 2018-04-06
+      status: completed
+    - name: Network upgrade to increase minimal ringsize to 7, integrate multisig, subaddresses, and change PoW algo
+      date: 2018-04-06
+      status: completed
+    - name: Getmonero.org Localization in French and Polish
+      date: 2018-04-24
+      status: completed
     - name: Forum Funding System redesign
       date:
       status: ongoing

--- a/_data/lang/es/roadmap.yml
+++ b/_data/lang/es/roadmap.yml
@@ -31,13 +31,13 @@
     - name: Monero Research Lab Paper 5 published
       date: 2016-02-10
       status: completed
-    - name: Hardfork to require minimum ringsize of 3 on all transactions
+    - name: Network Upgrade to require minimum ringsize of 3 on all transactions
       date: 2016-03-22
       status: completed
     - name: 0.10.0 Wolfram Warptangent released
       date: 2016-09-18
       status: completed
-    - name: Hardfork to split coinbase into denominations
+    - name: Network Upgrade to split coinbase into denominations
       date: 2016-09-21
       status: completed
     - name: 0.10.1 Wolfram Warptangent released
@@ -48,7 +48,7 @@
       status: completed
 - year: 2017
   accomplishments:
-    - name: Hardfork to enable RingCT transactions
+    - name: Network Upgrade to enable RingCT transactions
       date: 2017-01-05
       status: completed
     - name: 0.10.2 released; critical vulnerability patched
@@ -57,7 +57,7 @@
     - name: 0.10.3.1 Wolfram Warptangent released
       date: 2017-03-27
       status: completed
-    - name: Hardfork to adjust minimum blocksize and dynamic fee algorithm
+    - name: Network Upgrade to adjust minimum blocksize and dynamic fee algorithm
       date: 2017-04-15
       status: completed
     - name: Website redesigned
@@ -72,38 +72,43 @@
     - name: GUI out of beta
       date: 2017-09-10
       status: completed
-    - name: Hardfork to increase minimum ringsize to 5 and require RingCT transactions
+    - name: Network Upgrade to increase minimum ringsize to 5 and require RingCT transactions
       date: 2017-09-15
       status: completed
     - name: 0MQ/ZeroMQ
       date: September, 2017
       status: completed
-    - name: Fluffy blocks
-      date:
-      status: ongoing
-    - name: GUI port to android
-      date:
-      status: ongoing
+    - name: Subaddresses
+      date: October, 2017
+      status: completed
+    - name: Multi-signatures (multisig)
+      date: December, 2017
+      status: completed
+- year: 2018
+  accomplishments:
+    - name: New Proof of Work CryptoNoteV7
+      date: 2018-04-06
+      status: completed
+    - name: Network upgrade to increase minimal ringsize to 7, integrate multisig, subaddresses, and change PoW algo
+      date: 2018-04-06
+      status: completed
+    - name: Getmonero.org Localization in French and Polish
+      date: 2018-04-24
+      status: completed
     - name: Forum Funding System redesign
       date:
       status: ongoing
-    - name: Subaddresses
+    - name: More efficient range proofs for RingCT to reduce transaction sizes
       date:
-      status: ongoing
-    - name: Multi-signatures (multisig)
-      date:
-      status: ongoing
+      status: upcoming
     - name: Kovri alpha release
       date:
       status: upcoming
-- year: 2018
+- year: 2019
   accomplishments:
-    - name: Additional MRL research papers
-      date:
-      status: upcoming
     - name: Second-layer solutions for speed and scalability
       date:
       status: upcoming
-    - name: More efficient range proofs for RingCT to reduce transaction sizes
+    - name: Additional MRL research papers
       date:
       status: upcoming

--- a/_data/lang/fr/roadmap.yml
+++ b/_data/lang/fr/roadmap.yml
@@ -2,108 +2,113 @@
   accomplishments:
     - name: Lancé sur Bitcointalk
       date: 2014-04-18
-      status: terminé
+      status: completed
     - name: Renommé de Bitmonero à Monero
       date: 2014-04-23
-      status: terminé
+      status: completed
     - name: Rétablissement suite à une attaque par spam
       date: 2014-09-04
-      status: terminé
+      status: completed
     - name: Publication des notes 1 et 2 du Laboratoire de Recherche Monero
       date: 2014-09-12
-      status: terminé
+      status: completed
     - name: Publication de la note 3 du Laboratoire de Recherche Monero
       date: 2014-09-25
-      status: terminé
+      status: completed
     - name: Publication de la version 0.8.8.6
       date: 2014-12-08
-      status: terminé
+      status: completed
 - year: 2015
   accomplishments:
     - name: Publication de la note 4 du Laboratoire de Recherche Monero
       date: 2015-01-26
-      status: terminé
+      status: completed
 - year: 2016
   accomplishments:
     - name: Publication de la version 0.9.0 Hydrogen Helix
       date: 2016-01-01
-      status: terminé
+      status: completed
     - name: Publication de la note 5 du Laboratoire de Recherche Monero
       date: 2016-02-10
-      status: terminé
-    - name: Hardfork pour imposer un ringsize minimum de 3 pour toutes les transactions
+      status: completed
+    - name: Mise à jour du réseau pour imposer un taille de cercle minimum de 3 pour toutes les transactions
       date: 2016-03-22
-      status: terminé
+      status: completed
     - name: Publication de la version 0.10.0 Wolfram Warptangent
       date: 2016-09-18
-      status: terminé
-    - name: Hardfork pour séparer la coinbase en dénominations
+      status: completed
+    - name: Mise à jour du réseau pour séparer la base de la pièce par dénominations
       date: 2016-09-21
-      status: terminé
+      status: completed
     - name: Publication de la version 0.10.1 Wolfram Warptangent
       date: 2016-12-14
-      status: terminé
+      status: completed
     - name: Publication de la Beta 1 de la GUI officielle
       date: 2016-12-22
-      status: terminé
+      status: completed
 - year: 2017
   accomplishments:
-    - name: Hardfork pour activer les transactions RingCT
+    - name: Mise à jour du réseau pour activer les transactions confidentielles de cercle (RingCT)
       date: 2017-01-05
-      status: terminé
+      status: completed
     - name: Publication de la version 0.10.2; Correction d'une vulnérabilité critique
       date: 2017-02-22
-      status: terminé
+      status: completed
     - name: Publication de la version 0.10.3.1 Wolfram Warptangent
       date: 2017-03-27
-      status: terminé
-    - name: Hardfork pour ajuster les algorithmes de frais dynamiques et la taille minimal de block
+      status: completed
+    - name: Mise à jour du réseau pour ajuster les algorithmes de frais dynamiques et la taille minimal de block
       date: 2017-04-15
-      status: terminé
+      status: completed
     - name: Refonte du site Web
       date: 2017-07-04
-      status: terminé
+      status: completed
     - name: Publication de la version 0.11.0.0 Helium Hydra
       date: 2017-09-07
-      status: terminé
+      status: completed
     - name: Fluffy blocks
       date: 2017-09-07
-      status: terminé
+      status: completed
     - name: Sortie de beta de la GUI
       date: 2017-09-10
-      status: terminé
-    - name: Hardfork pour augmenter la ringsize minimal à 5 et imposer les transactions RingCT
+      status: completed
+    - name: Mise à jour du réseau pour augmenter la taille de cercle minimal à 5 et imposer les transactions confidentielles de cercle (RingCT)
       date: 2017-09-15
-      status: terminé
+      status: completed
     - name: 0MQ/ZeroMQ
-      date: September, 2017
-      status: terminé
-    - name: Fluffy blocks
-      date:
-      status: en cours
-    - name: Portage de la GUI sur android
-      date:
-      status: en cours
-    - name: Refonte du Forum Funding System
-      date:
-      status: en cours
+      date: September 2017
+      status: completed
     - name: Sous-adresses
-      date:
-      status: en cours
+      date: Octobre 2017
+      status: completed
     - name: Multi-signatures (multisig)
-      date:
-      status: en cours
-    - name: Version alpha de Kovri
-      date:
-      status: à venir
+      date: Decembre 2017
+      status: completed
 - year: 2018
   accomplishments:
-    - name: Notes de recherches MRL additionnelles
+    - name: Nouvelle preuve de travail CryptoNoteV7
+      date: 2018-04-06
+      status: completed
+    - name: Mise à jour du réseau pour augmenter la taille de cercle minimal à 7, intégrer les sous-adresses, les multi-signatures et changer l'algorithme de preuve de travail
+      date: 2018-04-06
+      status: completed
+    - name: Traduction du site getmonero.org en Français et Polonais
+      date: 2018-04-24
+      status: completed
+    - name: Refonte du Forum Funding System (FFS)
       date:
-      status: à venir
+      status: ongoing
+    - name: Preuves à divulgation nulle de connaissance plus efficaces pour les transactions confidentielles de cercle (RingCT) afin de réduire la taille des transactions
+      date:
+      status: upcoming
+    - name: Version alpha de Kovri
+      date:
+      status: upcoming
+- year: 2019
+  accomplishments:
     - name: Solutions de seconde couche pour la vitesse et la capacité d'expension
       date:
-      status: à venir
-    - name: Range proofs plus efficaces pour RingCT pour réduire la taille des transactions
+      status: upcoming
+    - name: Notes de recherches MRL additionnelles
       date:
-      status: à venir
+      status: upcoming

--- a/_data/lang/it/roadmap.yml
+++ b/_data/lang/it/roadmap.yml
@@ -31,13 +31,13 @@
     - name: Il Monero Research Lab pubblica il Paper 5
       date: 2016-02-10
       status: completed
-    - name: Hardfork per richiedere un ringsize minimo di 3 per tutte le transazioni
+    - name: Aggiornamento della Rete per richiedere un ringsize minimo di 3 per tutte le transazioni
       date: 2016-03-22
       status: completed
     - name: 0.10.0 Wolfram Warptangent rilasciata
       date: 2016-09-18
       status: completed
-    - name: Hardfork per dividere coinbase in denominazioni
+    - name: Aggiornamento della Rete per dividere coinbase in denominazioni
       date: 2016-09-21
       status: completed
     - name: 0.10.1 Wolfram Warptangent rilasciata
@@ -48,7 +48,7 @@
       status: completed
 - year: 2017
   accomplishments:
-    - name: Hardfork per abilitare Transazioni RingCT
+    - name: Aggiornamento della Rete per abilitare Transazioni RingCT
       date: 2017-01-05
       status: completed
     - name: 0.10.2 rilasciata; vulnerabilità critica patchata
@@ -57,7 +57,7 @@
     - name: 0.10.3.1 Wolfram Warptangent rilasciata
       date: 2017-03-27
       status: completed
-    - name: Hardfork per sistemare il blocksize minimo e l'algoritmo per le fee dinamiche
+    - name: Aggiornamento della Rete per sistemare il blocksize minimo e l'algoritmo per le fee dinamiche
       date: 2017-04-15
       status: completed
     - name: Sito web ridisegnato
@@ -72,38 +72,43 @@
     - name: GUI non più in beta
       date: 2017-09-10
       status: completed
-    - name: Hardfork per incrementare il ringsize minimo a 5 e richiedere l'uso di transazioni RingCT
+    - name: Aggiornamento della Rete per incrementare il ringsize minimo a 5 e richiedere l'uso di transazioni RingCT
       date: 2017-09-15
       status: completed
     - name: 0MQ/ZeroMQ
       date: September, 2017
       status: completed
-    - name: Fluffy blocks
-      date:
-      status: ongoing
-    - name: Porting della GUI su Android
-      date:
-      status: ongoing
+    - name: Subaddresses
+      date: October, 2017
+      status: completed
+    - name: Multi-signatures (multisig)
+      date: December, 2017
+      status: completed
+- year: 2018
+  accomplishments:
+    - name: New Proof of Work CryptoNoteV7
+      date: 2018-04-06
+      status: completed
+    - name: Network upgrade to increase minimal ringsize to 7, integrate multisig, subaddresses, and change PoW algo
+      date: 2018-04-06
+      status: completed
+    - name: Getmonero.org Localization in French and Polish
+      date: 2018-04-24
+      status: completed
     - name: Redesign del Forum Funding System
       date:
       status: ongoing
-    - name: Subaddresses
+    - name: Range proofs più efficiente per RingCT - Ridurre dimensione delle transazioni
       date:
-      status: ongoing
-    - name: Multi-signatures (multisig)
-      date:
-      status: ongoing
+      status: upcoming
     - name: Rilascio versione alpha di Kovri
       date:
       status: upcoming
-- year: 2018
+- year: 2019
   accomplishments:
-    - name: Ricerche aggiuntive del MRL
-      date:
-      status: upcoming
     - name: Soluzioni Second-layer per velocità e scalabilità
       date:
       status: upcoming
-    - name: Range proofs più efficiente per RingCT - Ridurre dimensione delle transazioni
+    - name: Ricerche aggiuntive del MRL
       date:
       status: upcoming

--- a/_data/lang/pl/roadmap.yml
+++ b/_data/lang/pl/roadmap.yml
@@ -31,13 +31,13 @@
     - name: Publikacja piątej dokumentacji Laboratorium Badawczego Monero
       date: 2016-02-10
       status: completed
-    - name: Hardfork do wymagania co najmniej 3 stron we wszystkich transakcjach
+    - name: Aktualizacja sieci do wymagania co najmniej 3 stron we wszystkich transakcjach
       date: 2016-03-22
       status: completed
     - name: Wypuszczenie wersji 0.10.0 Wolfram Warptangent
       date: 2016-09-18
       status: completed
-    - name: Hardfork do rozdzielenia bazy monetarnej na jednostki
+    - name: Aktualizacja sieci do rozdzielenia bazy monetarnej na jednostki
       date: 2016-09-21
       status: completed
     - name: Wypuszczenie wersji 0.10.1 Wolfram Warptangent
@@ -48,7 +48,7 @@
       status: completed
 - year: 2017
   accomplishments:
-    - name: Hardfork do umożliwienia transakcji RingCT
+    - name: Aktualizacja sieci do umożliwienia transakcji RingCT
       date: 2017-01-05
       status: completed
     - name: Wypuszczenie wersji 0.10.2; łatka krytycznej luki
@@ -56,8 +56,8 @@
       status: completed
     - name: Wypuszczenie wersji 0.10.3.1 Wolfram Warptangent
       date: 2017-03-27
-      status: completed      
-    - name: Hardfork do regulacji minimalnego rozmiaru bloku i algorytmu dynamicznej opłaty
+      status: completed
+    - name: Aktualizacja sieci do regulacji minimalnego rozmiaru bloku i algorytmu dynamicznej opłaty
       date: 2017-04-15
       status: completed
     - name: Zmiana wyglądu strony internetowej
@@ -72,38 +72,43 @@
     - name: Graficzny Interfejs Użytkownika poza wersją beta
       date: 2017-09-10
       status: completed
-    - name: Hardfork do zwiększenia minimalnej liczby stron transakcji do 5 i do wymagania transakcji RingCT
+    - name: Aktualizacja sieci do zwiększenia minimalnej liczby stron transakcji do 5 i do wymagania transakcji RingCT
       date: 2017-09-15
       status: completed
     - name: 0MQ/ZeroMQ
       date: September, 2017
       status: completed
-    - name: Puchowe bloki
-      date:
-      status: ongoing
-    - name: Graficzny Interfejs Użytkownika dla Androida
-      date:
-      status: ongoing
+    - name: Podadresy
+      date: October, 2017
+      status: completed
+    - name: Multi-podpisy (multisig)
+      date: December, 2017
+      status: completed
+- year: 2018
+  accomplishments:
+    - name: Nowy dowód pracy CryptoNoteV7
+      date: 2018-04-06
+      status: completed
+    - name: Aktualizacja sieci w celu zmniejszenia minimalnego rozmiaru pierścienia do 7, zintegrowania multipodpisu i podadresów oraz zmiany algorytmu dowodu pracy
+      date: 2018-04-06
+      status: completed
+    - name: Lokalizacja strony Getmonero.org na język francuski i polski.
+      date: 2018-04-24
+      status: completed
     - name: Zmiana wyglądu Forumowego Systemu Finansowania
       date:
       status: ongoing
-    - name: Podadresy
+    - name: Efektywniejsze dowody zasięgu dla RingCT w celu zmniejszenia rozmiarów transakcji
       date:
-      status: ongoing
-    - name: Multi-podpisy (multisig)
-      date:
-      status: ongoing
+      status: upcoming
     - name: Wypuszczenie systemu Kovri Alpha
       date:
       status: upcoming
-- year: 2018
+- year: 2019
   accomplishments:
-    - name: Publikacja dodatkowej dokumentacji Laboratorium Badawczego Monero
-      date:
-      status: upcoming
     - name: Rozwiązania drugowarstwowe dla szybkości i skalowalności
       date:
       status: upcoming
-    - name: Efektywniejsze dowody zasięgu dla RingCT w celu zmniejszenia rozmiarów transakcji
+    - name: Publikacja dodatkowej dokumentacji Laboratorium Badawczego Monero
       date:
       status: upcoming

--- a/_data/lang/template/roadmap.yml
+++ b/_data/lang/template/roadmap.yml
@@ -31,13 +31,13 @@
     - name: Monero Research Lab Paper 5 published
       date: 2016-02-10
       status: completed
-    - name: Hardfork to require minimum ringsize of 3 on all transactions
+    - name: Network Upgrade to require minimum ringsize of 3 on all transactions
       date: 2016-03-22
       status: completed
     - name: 0.10.0 Wolfram Warptangent released
       date: 2016-09-18
       status: completed
-    - name: Hardfork to split coinbase into denominations
+    - name: Network Upgrade to split coinbase into denominations
       date: 2016-09-21
       status: completed
     - name: 0.10.1 Wolfram Warptangent released
@@ -48,7 +48,7 @@
       status: completed
 - year: 2017
   accomplishments:
-    - name: Hardfork to enable RingCT transactions
+    - name: Network Upgrade to enable RingCT transactions
       date: 2017-01-05
       status: completed
     - name: 0.10.2 released; critical vulnerability patched
@@ -57,7 +57,7 @@
     - name: 0.10.3.1 Wolfram Warptangent released
       date: 2017-03-27
       status: completed
-    - name: Hardfork to adjust minimum blocksize and dynamic fee algorithm
+    - name: Network Upgrade to adjust minimum blocksize and dynamic fee algorithm
       date: 2017-04-15
       status: completed
     - name: Website redesigned
@@ -72,38 +72,43 @@
     - name: GUI out of beta
       date: 2017-09-10
       status: completed
-    - name: Hardfork to increase minimum ringsize to 5 and require RingCT transactions
+    - name: Network Upgrade to increase minimum ringsize to 5 and require RingCT transactions
       date: 2017-09-15
       status: completed
     - name: 0MQ/ZeroMQ
       date: September, 2017
       status: completed
-    - name: Fluffy blocks
-      date:
-      status: ongoing
-    - name: GUI port to android
-      date:
-      status: ongoing
+    - name: Subaddresses
+      date: October, 2017
+      status: completed
+    - name: Multi-signatures (multisig)
+      date: December, 2017
+      status: completed
+- year: 2018
+  accomplishments:
+    - name: New Proof of Work CryptoNoteV7
+      date: 2018-04-06
+      status: completed
+    - name: Network upgrade to increase minimal ringsize to 7, integrate multisig, subaddresses, and change PoW algo
+      date: 2018-04-06
+      status: completed
+    - name: Getmonero.org Localization in French and Polish
+      date: 2018-04-24
+      status: completed
     - name: Forum Funding System redesign
       date:
       status: ongoing
-    - name: Subaddresses
+    - name: More efficient range proofs for RingCT to reduce transaction sizes
       date:
-      status: ongoing
-    - name: Multi-signatures (multisig)
-      date:
-      status: ongoing
+      status: upcoming
     - name: Kovri alpha release
       date:
       status: upcoming
-- year: 2018
+- year: 2019
   accomplishments:
-    - name: Additional MRL research papers
-      date:
-      status: upcoming
     - name: Second-layer solutions for speed and scalability
       date:
       status: upcoming
-    - name: More efficient range proofs for RingCT to reduce transaction sizes
+    - name: Additional MRL research papers
       date:
       status: upcoming

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -389,7 +389,7 @@ user-guides:
 
 roadmap:
   translated: "yes"
-  complated: Completed task
+  completed: Completed task
   ongoing: Ongoing task
   upcoming: Upcoming task
   future: Future

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -389,7 +389,7 @@ user-guides:
 
 roadmap:
   translated: "no"
-  complated: Completed task
+  completed: Completed task
   ongoing: Ongoing task
   upcoming: Upcoming task
   future: Future

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -389,7 +389,7 @@ user-guides:
 
 roadmap:
   translated: "yes"
-  complated: Tâches terminées
+  completed: Tâches terminées
   ongoing: Tâches en cours
   upcoming: Tâches à venir
   future: Ultérieur

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -389,7 +389,7 @@ user-guides:
 
 roadmap:
   translated: "no"
-  complated: Completed task
+  completed: Completed task
   ongoing: Ongoing task
   upcoming: Upcoming task
   future: Future

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -390,7 +390,7 @@ user-guides:
 
 roadmap:
   translated: "yes"
-  complated: Ukończone
+  completed: Ukończone
   ongoing: W trakcie
   upcoming: Nadchodzące
   future: W przyszłości

--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -8,15 +8,15 @@ permalink: /resources/roadmap/index.html
         <div class="row">
             <div class="col-xs-4">
                 <li class="completed"></li>
-                <p>Completed task</p>
+                <p>{% t roadmap.completed %}</p>
             </div>
             <div class="col-xs-4">
                 <li class="ongoing"></li>
-                <p>Ongoing task</p>
+                <p>{% t roadmap.ongoing %}</p>
             </div>
             <div class="col-xs-4">
                 <li class="upcoming"></li>
-                <p>Upcoming task</p>
+                <p>{% t roadmap.upcoming %}</p>
             </div>
         </div>
     </div>
@@ -108,8 +108,8 @@ permalink: /resources/roadmap/index.html
                     <input id="tab-5" type="radio" name="tabs" aria-hidden="true" checked>
                     <h2>2018</h2>
                     <div class="tabPanel-content">
-                        {% for toplevel in site.data.lang[site.lang].roadmap %} 
-                            {% if toplevel.year == 2018 %} 
+                        {% for toplevel in site.data.lang[site.lang].roadmap %}
+                            {% if toplevel.year == 2018 %}
                                 {% for roadlist in toplevel.accomplishments %}
                                     <div class="row start-xs">
                                         <div class="col-xs-1">
@@ -129,7 +129,7 @@ permalink: /resources/roadmap/index.html
                     </div>
                     <label for="tab-6" tabindex="0"></label>
                     <input id="tab-6" type="radio" name="tabs" aria-hidden="true">
-                    <h2>Future</h2>
+                    <h2>{% t roadmap.future %}</h2>
                     <div class="tabPanel-content">
                         {% for toplevel in site.data.lang[site.lang].roadmap %}
                             {% if toplevel.year == 2019 %}


### PR DESCRIPTION
This is ~~two~~ four commits:
- One for the French Roadmap to be updated according to @mattcode55 #575 (in the hope @rehrar and him would catch and merge it first), along with a few correction and a general change from "hardfork" to "network upgrade";
- One for the early 2018 achievements (still in French).
- One for fixing stuff after a build test (**new 05/11**)
- One for updating all translations at the same level FR was in the second commit. (**new 05/11**)

Regarding the early 2018 achievements, these is the English version, ~~for review comodities~~ that is visible in the code. @erciccione @zofiazinha @hrumag those needs to be updated for Polish and Italian (again, i can update for you if it is easier and you provide the translation):

- name: New Proof of Work CryptoNoteV7
  date: March, 2018
  status: completed
- name: Network upgrade to increase minimal ringsize to 7, integrate multisig, subaddresses, and change PoW algo.
  date: 2018-04-04
  status: completed
- name: Getmonero.org Localization in French and Polish
   date: 2018-04-24
   status: completed

~~Once #575 is merged, i will work~~ I have worked on a general roadmap update with those listed elements:
- Update of roadmap.md for Polish & Italian too ;
- s/HardFork/Network Upgrade/ ;
  - "aggiornamento della rete" in Italian
  - @zofiazinha what's your Polish version?
- Early 2018 achievments ;
- Update ~~of~~ on all ~~untranslated and template~~ .yml files ~~_only_~~.

So @erciccione, you see i can still found something to do ;)