### PR TITLE
Update importing_blockchain.md

### DIFF
--- a/_i18n/en/resources/user-guides/importing_blockchain.md
+++ b/_i18n/en/resources/user-guides/importing_blockchain.md
@@ -40,11 +40,11 @@ If your Monero wallet is on another drive you can use `DriveLetter:` for example
 
 Now type in your command prompt window:
 
-`monero-blockchain-import --verify 1 --input-file C:\YOUR\BLOCKCHAIN\FILE\PATH\HERE`
+`monero-blockchain-import --input-file C:\YOUR\BLOCKCHAIN\FILE\PATH\HERE`
 
 For example I would type :
 
-`monero-blockchain-import --verify 1 --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
+`monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
 If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
 


### PR DESCRIPTION
With the most recent gui release download for windows 10 from https://getmonero.org/downloads/ (Lithium Luna) the supported relevant command line option is:
```
 --guard-against-pwnage arg (=1)       Verify blocks and transactions during
                                        import (only disable if you exported
                                        the file yourself)
```

Since --verify 1 is not only not supported anymore, but is default behavior it is misleading and should be removed from the guide.