### PR TITLE
Guides Pages versionning

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,41 @@ Contributers should use [issue keywords](https://help.github.com/articles/closin
 
 Pull requests allow others to make comments or review your changes to the site. We ask that you remain available to comment or make changes to your PR. Pull requests with pending changes for more than 30 days will be closed and need to be resubmitted in the future. Sometimes someone else's changes might make your changes conflict with the current site. If that happens you may need to rebase your PR. (If you're unsure about how to do so, you can reach out to other contributers on IRC (freenode #monero) and someone should be able to walk you through it.
 
+### 3.2 Updates on User Guides
+
+User guides and developer guides may need regular updates, either to fix typos, to add explanations regarding new features, to update screenshots, and so on.
+As those guides are translated in several languages, it could be hard to keep all languages version up to date with the English version.
+To keep track of those changes, guides are versioned using a snippet at the top of each localized (\_i18n/en/ressources/\*-guides) file:
+```
+{% assign version = '1.1.0' | split: '.' %}
+```
+This snippet is responsible for keeping track of the language version.
+
+The based version (English version) is however also tracked in the `Front Matter` from the /resources/user-guides/ or /resources/developer-guides/ directory file:
+```
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
+```
+
+- First number is the Major version number
+- Second number is the Minor version number
+- Third number is the build number.
+
+When you update a guide, you are responsible for updating this version tracking in every file involved in your update:
+
+- For an update on English files, you will update the version tracking number in the `Front Matter` of /ressources/\*-guides/ and in \_i18n/en/ressources/\*-guides
+- For an update on localized files, you will update the version tracking number in the \_i18n/<local>/ressources/\*-guides only, and
+  - You will not update to a higher Major or Minor version number than the reference English guide
+  - If you want to update to a higher Major or Minor version number, you should update the English version accordingly so that English is always the highest Major.Minor version.
+
+And you will increment the version number in the following way:
+
+- Cosmetic change only (typo, rephrasing, screenshot update with exact same field names and positions): Increment the third number (build number). We do not want to even warn the user about this update in another language.
+- Changes that add instructions or explanations (or screenshot updates with different field names and positions), without making the old version misleading for users: Increment the second number (Minor version number) and reset the third to 0. We want to let the user know the English version could be more accurate and helpful to read.
+- Changes that makes the old version false, or misleading to users: Increment the first number (Major version number) and reset the second and third to 1.0. We want to discourage users from reading this too outdated version that could lead them to do wrong things (for instance, buy the wrong algo of mining power on nicehash, after a pow change).
+
 ## 4.0 How to make a blog post
 
 ### 4.1 Quick Start
@@ -138,8 +173,9 @@ You're all done. Submit a PR and wait for it to be reviewed and merged. Be sure 
 * File content as in 5.3
 * Create file in /_i18n/en/resources/user-guides with the exact same filename as above ending in .md
 * Write User Guide
+* Add versioning snippet
 * Copy User Guide file to ALL LANGUAGES in /_i18n/[ALL LANGUAGES]/resources/user-guides
-* Paste `{% include untranslated.html %}` into the top of each language version of your User Guide, except the original language
+* set translation to false in the snippet the top of each language version of your User Guide, except the original language
 * Add guide using markdown in the correct category, and in alphabetic order, in ALL LANGUAGES to /_i18n/[ALL LANGUAGES]/resources/user-guides/index.md being careful not to mess with any indentation
 * Test/Build
 * Submit PR
@@ -153,6 +189,10 @@ Navigate to the /resources/user-guides folder and make a new file. Be sure the f
 layout: user-guide
 title: TITLE OF YOUR USER GUIDE
 permalink: /resources/user-guides/NAME-OF-FILE-GOES-HERE.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/NAME-OF-FILE-GOES-HERE.md %}
@@ -168,11 +208,18 @@ Write your user guide. Be succinct but thorough. Remember, people will be using 
 
 The title should be at the top of the User Guide using a single `#` for an H1 tag. Titles will not be automatically put on these pages as with other pages. There should be NO front matter on this file.
 
+Add the version snippet at the top of your guide (before your title):
+```
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
+```
+Your version should start at `1.1.0` as it is the first Major, first Minor, and no cosmetic changes have occured.
+
 ### 5.6 Copy User Guide file into all languages
 Copy your file and navigate to each language file in the /i18n folder. In each language folder (INCLUDING template) go to the resources/user-guides folder and paste your user guide (don't worry, you don't have to translate it) there. This is very important, and the site will not build if the file with the same name is not in each language folder.
 
-As you paste into each folder, open up the file and paste the following snippet at the top of the file (before your title):
-`{% include untranslated.html %}`. This does not need to be done in the original language that the User Guide was written in.
+As you paste into each folder, open up the file and edit the snippet at the top of the file (before your title) to mark it untranslated:
+`{% include disclaimer.html translated="false" version=page.version %}`. This does not need to be done in the original language that the User Guide was written in.
 
 ### 5.7 Add Guide to the 'User Guide' landing page of EACH LANGUAGE
 In the /_i18n/[ORIGINAL LANGUAGE OF USER GUIDE]/resources/user-guides folder, find the file labeled index.md and open it.
@@ -519,8 +566,8 @@ Go to the /i18n folder and find the two letter code for the language you wish to
 ### 14.3 Translate the file
 Here you can do your translation. Depending on the page, you may have to maneuver around some HTML or markdown. In general, anything between two tags (such as `<p>TRANSLATE THIS</p>`) should be fine. Testing is VERY important, so do NOT skip step 13.4. If during testing, the page appears different from the original English page (besides the translated text of course), you did something wrong and may have to start again.
 
-### 14.4 Remove the 'untranslated' snippet
-Somewhere on the page (usually the top) should be a snippet that says `{% include untranslated.html %}`. Simply delete this completely from the file. This will remove the orange bar from the bottom saying the page is untranslated.
+### 14.4 set the 'translated' snippet to true
+Somewhere on the page (usually the top) should be a snippet that says `{% include disclaimer.html translated="false" version=page.version %}`. Simply change this to `{% include disclaimer.html translated="true" version=page.version %}`. This will remove the orange bar from the bottom saying the page is untranslated.
 
 ### 14.5 Build/Test
 Build your website using `jekyll serve` if it's not rebuilding automatically.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -21,6 +21,9 @@ global:
   privacy: Privacy
   copyright: Copyright
   untranslated: This page is not yet translated. If you would like to help translate it, please see the
+  outdatedMax: This page is outdated. We do not recommend using it. Instead, please see the
+  outdatedVersion: english version
+  outdatedMin: This page has been updated since the translation. You can use this version, but it may be incomplete.
 
 titles:
   index: Home

--- a/_i18n/en/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/en/resources/developer-guides/daemon-rpc.md
@@ -1,3 +1,5 @@
+{% assign version = '2.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Introduction
 
 This is a list of the monerod daemon RPC calls, their inputs and outputs, and examples of each.

--- a/_i18n/en/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/en/resources/developer-guides/wallet-rpc.md
@@ -1,3 +1,5 @@
+{% assign version = '1.2.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Introduction
 
 This is a list of the monero-wallet-rpc calls, their inputs and outputs, and examples of each. The program monero-wallet-rpc replaced the rpc interface that was in simplewallet and then monero-wallet-cli.
@@ -1234,7 +1236,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/en/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
+++ b/_i18n/en/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## How to mine Monero (XMR) without a mining equipment?
 
 If you don’t have a profitable mining equipment, nor time or

--- a/_i18n/en/resources/user-guides/Offline_Backup.md
+++ b/_i18n/en/resources/user-guides/Offline_Backup.md
@@ -1,36 +1,38 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Operating Systems:  Various versions of Linux and Windows 7, 8
- 
+
 ### Wallet Software:  Simplewallet
- 
+
 #### Resource for Creating Bootable Disks:  [Linux](http://www.pendrivelinux.com/),       [Windows](https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool)
- 
+
 #### Resource for Monero Binaries:  [Monero Binaries](https://getmonero.org/downloads/)
- 
+
 - Take any computer you have lying around, even your normal workstation. You may find it easier to use an older computer that has no wifi or bluetooth if you're particularly paranoid
- 
+
 - Create a Linux or Windows bootable disk, and make sure you have the Monero binaries on the same disk or on a second disk (for Linux make sure you have also downloaded copies of the dependencies you will need, libboost1.55 and miniupnpc for instance)
- 
+
 - Disconnect the network and/or Internet cables from your computer, physically remove the wifi card or switch the wifi/bluetooth off on a laptop if possible
- 
+
 - Boot into your bootable OS, install the dependencies if necessary
- 
+
 - Copy the Monero binaries to a RAM disk (/dev/shm in Linux, Windows bootable ISOs normally have a Z: drive or something)
- 
+
 - Don't run the Monero daemon. Instead, using the command line, use monero-wallet-cli to create a new Monero @account
- 
+
 - When prompted for a name, give it any name, it doesn't really matter
- 
+
 - When prompted for a password, type in like 50 - 100 random characters. Don't worry that you don't know the password, just make it LONG
- 
+
 - **CRITICAL STEP**: Write down (on paper) your 25 word @mnemonic-seed  
 **WARNING**:  If you forget to write down this information your funds may be lost forever
- 
+
 - Write down (on your phone, on paper, on another computer, wherever you want) your address and view key
- 
+
 - Switch off the computer, remove the battery if there is one, and leave it physically off for a few hours
- 
+
 The account you've created was created in RAM, and the digital files are now inaccessible. If some adversary manages to somehow obtain the data, they will lack the long password to open it. If you need to receive payments, you have your public address, and you have the view key if needed. If you need access to it, you have your 25 word @mnemonic-seed, and you can now write out several copies of it, including an offsite copy (e.g. a bank deposit box).
- 
+
 Credit:  Riccardo Spagni
- 
+
 Related:  [Offline Account Generator](http://moneroaddress.org/)

--- a/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # CLI Wallet/Daemon Isolation with Qubes + Whonix
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
@@ -7,7 +9,7 @@ Qubes gives the flexibility to easily create separate VMs for different purposes
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
 
-## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install): 
+## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install):
 
 + Using a Whonix workstation template, create two workstations as follows:
 
@@ -15,14 +17,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
 
-## 2. In the AppVM `monerod-ws`: 
+## 2. In the AppVM `monerod-ws`:
 
 + Download, verify, and install Monero software.
 
 ```
 user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "https://getmonero.org/downloads/hashes.txt"
 user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt 
+user@host:~$ gpg --verify hashes.txt
 gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
 gpg:                using RSA key 0x55432DF31CCD4FCD
 gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]

--- a/_i18n/en/resources/user-guides/create_wallet.md
+++ b/_i18n/en/resources/user-guides/create_wallet.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Operating Systems:  Ubuntu
 
 - Download the [official binaries](https://getmonero.org/downloads/) or compile the last source available on [Github](https://github.com/monero-project/bitmonero)
@@ -31,7 +33,7 @@
 ![image12](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/12.png)
 
 - Enter the name you want for your portfolio and follow the instructions from the terminal
- 
+
 ![image13](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/13.png)
 ![image14](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/14.png)
 ![image15](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/15.png)

--- a/_i18n/en/resources/user-guides/easiest_buy.md
+++ b/_i18n/en/resources/user-guides/easiest_buy.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## How to obtain Monero
 
 This is a guide to obtain your own Monero as of 20150919. This is perhaps the easiest way to purchase and hold Monero.
@@ -8,7 +10,7 @@ There are many ways to buy Bitcoin. Perhaps the easiest way is through circle.co
 
 ####Step 2: Set up a mymonero.com account
 
-MyMonero.com is an online wallet for Monero, maintained by Monero Core Developer Ricardo Spagni (fluffpony). It is the easiest wallet to use. Simply go to MyMonero.com and click on the "Create an Account" button. 
+MyMonero.com is an online wallet for Monero, maintained by Monero Core Developer Ricardo Spagni (fluffpony). It is the easiest wallet to use. Simply go to MyMonero.com and click on the "Create an Account" button.
 
 ![image1](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/easiest_way/01.png)
 

--- a/_i18n/en/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/en/resources/user-guides/howto_fix_stuck_funds.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Sometimes, your funds will become stuck - you will have some locked funds that never become unlocked. This is how you fix it.
 
 - Load your wallet in monero-wallet-cli.

--- a/_i18n/en/resources/user-guides/importing_blockchain.md
+++ b/_i18n/en/resources/user-guides/importing_blockchain.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Importing the Blockchain to Monero GUI wallet (Windows)
 
 ### Step 1
@@ -14,7 +16,7 @@ Your path may be different depending on where you decided to download your walle
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was: 
+Find the path of your downloaded Blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
@@ -28,7 +30,7 @@ Open a Command Prompt window. You can do this by pressing the Windows key + R, a
 
 Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE` 
+`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
 
 It should look something like:
 
@@ -50,7 +52,7 @@ If you downloaded the Blockchain from a trusted, reputable source you may set `v
 
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted. 
+After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/en/resources/user-guides/mine-to-pool.md
+++ b/_i18n/en/resources/user-guides/mine-to-pool.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Selecting a pool
 
 There are many pools to choose from, a list is available at

--- a/_i18n/en/resources/user-guides/mining_with_xmrig_and_docker.md
+++ b/_i18n/en/resources/user-guides/mining_with_xmrig_and_docker.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Introduction
 
 This guide is two fold, ease of use for mining on Linux distributions and some extra security around mining as most of these miners have not had security auditing.
@@ -19,7 +21,7 @@ For distribution specific installation please refer to the [Docker Docs](https:/
 
 ### Why XMRig
 
-[XMRig](https://github.com/xmrig/xmrig) is just a really solid miner to me. Nice output and statistics, no flashy web-ui's or dependencies. The XMRig container is only ~4MB what makes it extremely portable. 
+[XMRig](https://github.com/xmrig/xmrig) is just a really solid miner to me. Nice output and statistics, no flashy web-ui's or dependencies. The XMRig container is only ~4MB what makes it extremely portable.
 
 #### Step 1: Mining with XMRig
 

--- a/_i18n/en/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/en/resources/user-guides/monero-wallet-cli.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # monero-wallet-cli
 
 `monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
@@ -21,7 +23,7 @@ balance without refreshing:
 
     balance
     Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-    
+
 In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
 
 ## Sending monero

--- a/_i18n/en/resources/user-guides/monero_tools.md
+++ b/_i18n/en/resources/user-guides/monero_tools.md
@@ -1,6 +1,8 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Monero tools
 
-These tools can be used to gain information about the Monero network or your transaction data in the blockchain. 
+These tools can be used to gain information about the Monero network or your transaction data in the blockchain.
 
 ### [Check that a recipient has received your funds](http://xmrtests.llcoins.net/checktx.html)
 

--- a/_i18n/en/resources/user-guides/prove-payment.md
+++ b/_i18n/en/resources/user-guides/prove-payment.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Prove payments
 
 When you send money to a party who then disputes the payment was made, you need to be able to prove the payment was made.

--- a/_i18n/en/resources/user-guides/remote_node_gui.md
+++ b/_i18n/en/resources/user-guides/remote_node_gui.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Finding a node
 First things first, you need to find a node to connect to! [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods
 would be to use a node run by moneroworld, but they have a tool for finding random nodes too.

--- a/_i18n/en/resources/user-guides/restore_account.md
+++ b/_i18n/en/resources/user-guides/restore_account.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Operating Systems:  Windows, Linux, Mac
 
 - Retrieve your 25 word @mnemonic-seed that you saved when creating your old Monero @wallet

--- a/_i18n/en/resources/user-guides/restore_from_keys.md
+++ b/_i18n/en/resources/user-guides/restore_from_keys.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Restoring from keys
 
 Restoring a wallet from private keys is pretty simple. If you have the necessary information, with this guide you can completely restore your wallet. Note: you do NOT have to have your password to restore from keys.

--- a/_i18n/en/resources/user-guides/securely_purchase.md
+++ b/_i18n/en/resources/user-guides/securely_purchase.md
@@ -1,6 +1,8 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## How to purchase Monero and securely store it.
 
-This is a guide to purchase and securely store Monero as of June 2017. 
+This is a guide to purchase and securely store Monero as of June 2017.
 
 #### Step 1: Buy Bitcoin
 
@@ -8,9 +10,9 @@ There are many ways to buy Bitcoin. Two semi-reliable companies at this time are
 
 #### Step 2: Download and create a Paper Wallet on a secure and air-gapped computer.
 
-Download the paper wallet generator at: https://moneroaddress.org and copy it to a USB stick (Direct link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip). 
+Download the paper wallet generator at: https://moneroaddress.org and copy it to a USB stick (Direct link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip).
 
-Unzip and open the paper wallet generator (monero-wallet-generator.html) into a web browser on an air-gapped computer that hasn't been used before, or has had a clean installation of the OS. 
+Unzip and open the paper wallet generator (monero-wallet-generator.html) into a web browser on an air-gapped computer that hasn't been used before, or has had a clean installation of the OS.
 
 Your paper wallet will have four important items:
 

--- a/_i18n/en/resources/user-guides/solo_mine_GUI.md
+++ b/_i18n/en/resources/user-guides/solo_mine_GUI.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 It is very easy to solo mine with the official GUI. If you have not done so already, go to the <a href="{{site.baseurl}}/downloads/">Monero downloads page</a> and download the official GUI for your operating system. Then, run the setup and be patient as Monero synchronizes with the network. You should see that it displays "Connected" in the lower left corner.
 
 <img src="png/solo_mine_GUI/01.PNG" style="width: 600px;"/>

--- a/_i18n/en/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/en/resources/user-guides/verification-allos-advanced.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 #  Binary Verification: Linux, Mac, or Windows Using CLI Tools (Advanced)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero software. If you receive a fake Monero binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/en/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/en/resources/user-guides/verification-windows-beginner.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Verify Binaries: Windows (Beginner)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero binary. If you receive a fake binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/en/resources/user-guides/view_only.md
+++ b/_i18n/en/resources/user-guides/view_only.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 A view-only wallet can only see which incoming transactions belong to you. It can not spend any of your Monero, in fact it can't even see outgoing transactions from this wallet. This makes view-only wallets particularly interesting for
 
 * Developers writing libraries to validate payments

--- a/_i18n/en/resources/user-guides/vps_run_node.md
+++ b/_i18n/en/resources/user-guides/vps_run_node.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # monerod
 
 `monerod` is the daemon software that ships with the Monero tree. It is a console program, and manages the blockchain. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
@@ -39,7 +41,7 @@ Launch the daemon as a background process:
 Monitor the output of `monerod` if running as daemon:
 
     tail -f ~/.bitmonero/bitmonero.log
-    
+
 Keep the VPS secure with autoupdate:
 
 https://help.ubuntu.com/community/AutomaticSecurityUpdates

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -21,6 +21,9 @@ global:
   privacy: Privacy
   copyright: Copyright
   untranslated: Esta pagina is not yet translated. If you would like to help translate it, please see the
+  outdatedMax: Esta página no está actualizada. No recomendamos utilizarla. En su lugar, favor de ver la
+  outdatedVersion: versión en inglés
+  outdatedMin: Esta página ha sido actualizada desde la traducción. Puedes utilizar esta versión, pero puede estar incompleta.
 
 titles:
   index: Inicio

--- a/_i18n/es/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/es/resources/developer-guides/daemon-rpc.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '2.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This is a list of the monerod daemon RPC calls, their inputs and outputs, and examples of each.

--- a/_i18n/es/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/es/resources/developer-guides/wallet-rpc.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.2.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This is a list of the monero-wallet-rpc calls, their inputs and outputs, and examples of each. The program monero-wallet-rpc replaced the rpc interface that was in simplewallet and then monero-wallet-cli.
@@ -1235,7 +1236,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/es/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
+++ b/_i18n/es/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## How to mine Monero (XMR) without a mining equipment?
 
 If you don’t have a profitable mining equipment, nor time or

--- a/_i18n/es/resources/user-guides/Offline_Backup.md
+++ b/_i18n/es/resources/user-guides/Offline_Backup.md
@@ -1,37 +1,38 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Operating Systems:  Various versions of Linux and Windows 7, 8
- 
+
 ### Wallet Software:  Simplewallet
- 
+
 #### Resource for Creating Bootable Disks:  [Linux](http://www.pendrivelinux.com/),       [Windows](https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool)
- 
+
 #### Resource for Monero Binaries:  [Monero Binaries](https://getmonero.org/downloads/)
- 
+
 - Take any computer you have lying around, even your normal workstation. You may find it easier to use an older computer that has no wifi or bluetooth if you're particularly paranoid
- 
+
 - Create a Linux or Windows bootable disk, and make sure you have the Monero binaries on the same disk or on a second disk (for Linux make sure you have also downloaded copies of the dependencies you will need, libboost1.55 and miniupnpc for instance)
- 
+
 - Disconnect the network and/or Internet cables from your computer, physically remove the wifi card or switch the wifi/bluetooth off on a laptop if possible
- 
+
 - Boot into your bootable OS, install the dependencies if necessary
- 
+
 - Copy the Monero binaries to a RAM disk (/dev/shm in Linux, Windows bootable ISOs normally have a Z: drive or something)
- 
+
 - Don't run the Monero daemon. Instead, using the command line, use monero-wallet-cli to create a new Monero @account
- 
+
 - When prompted for a name, give it any name, it doesn't really matter
- 
+
 - When prompted for a password, type in like 50 - 100 random characters. Don't worry that you don't know the password, just make it LONG
- 
+
 - **CRITICAL STEP**: Write down (on paper) your 25 word @mnemonic-seed  
 **WARNING**:  If you forget to write down this information your funds may be lost forever
- 
+
 - Write down (on your phone, on paper, on another computer, wherever you want) your address and view key
- 
+
 - Switch off the computer, remove the battery if there is one, and leave it physically off for a few hours
- 
+
 The account you've created was created in RAM, and the digital files are now inaccessible. If some adversary manages to somehow obtain the data, they will lack the long password to open it. If you need to receive payments, you have your public address, and you have the view key if needed. If you need access to it, you have your 25 word @mnemonic-seed, and you can now write out several copies of it, including an offsite copy (e.g. a bank deposit box).
- 
+
 Credit:  Riccardo Spagni
- 
+
 Related:  [Offline Account Generator](http://moneroaddress.org/)

--- a/_i18n/es/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/es/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # CLI Wallet/Daemon Isolation with Qubes + Whonix
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
@@ -8,7 +9,7 @@ Qubes gives the flexibility to easily create separate VMs for different purposes
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
 
-## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install): 
+## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install):
 
 + Using a Whonix workstation template, create two workstations as follows:
 
@@ -16,14 +17,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
 
-## 2. In the AppVM `monerod-ws`: 
+## 2. In the AppVM `monerod-ws`:
 
 + Download, verify, and install Monero software.
 
 ```
 user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "https://getmonero.org/downloads/hashes.txt"
 user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt 
+user@host:~$ gpg --verify hashes.txt
 gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
 gpg:                using RSA key 0x55432DF31CCD4FCD
 gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]

--- a/_i18n/es/resources/user-guides/create_wallet.md
+++ b/_i18n/es/resources/user-guides/create_wallet.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ### Operating Systems:  Ubuntu
 
 - Download the [official binaries](https://getmonero.org/downloads/) or compile the last source available on [Github](https://github.com/monero-project/bitmonero)
@@ -32,7 +33,7 @@
 ![image12](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/12.png)
 
 - Enter the name you want for your portfolio and follow the instructions from the terminal
- 
+
 ![image13](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/13.png)
 ![image14](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/14.png)
 ![image15](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/15.png)

--- a/_i18n/es/resources/user-guides/easiest_buy.md
+++ b/_i18n/es/resources/user-guides/easiest_buy.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## How to obtain Monero
 
 This is a guide to obtain your own Monero as of 20150919. This is perhaps the easiest way to purchase and hold Monero.
@@ -9,7 +10,7 @@ There are many ways to buy Bitcoin. Perhaps the easiest way is through circle.co
 
 ####Step 2: Set up a mymonero.com account
 
-MyMonero.com is an online wallet for Monero, maintained by Monero Core Developer Ricardo Spagni (fluffpony). It is the easiest wallet to use. Simply go to MyMonero.com and click on the "Create an Account" button. 
+MyMonero.com is an online wallet for Monero, maintained by Monero Core Developer Ricardo Spagni (fluffpony). It is the easiest wallet to use. Simply go to MyMonero.com and click on the "Create an Account" button.
 
 ![image1](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/easiest_way/01.png)
 

--- a/_i18n/es/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/es/resources/user-guides/howto_fix_stuck_funds.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 Sometimes, your funds will become stuck - you will have some locked funds that never become unlocked. This is how you fix it.
 
 - Load your wallet in monero-wallet-cli.

--- a/_i18n/es/resources/user-guides/importing_blockchain.md
+++ b/_i18n/es/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Importing the Blockchain to Monero GUI wallet (Windows)
 
 ### Step 1
@@ -15,7 +16,7 @@ Your path may be different depending on where you decided to download your walle
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was: 
+Find the path of your downloaded Blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
@@ -29,7 +30,7 @@ Open a Command Prompt window. You can do this by pressing the Windows key + R, a
 
 Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE` 
+`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
 
 It should look something like:
 
@@ -51,7 +52,7 @@ If you downloaded the Blockchain from a trusted, reputable source you may set `v
 
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted. 
+After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/es/resources/user-guides/mine-to-pool.md
+++ b/_i18n/es/resources/user-guides/mine-to-pool.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Selecting a pool
 
 There are many pools to choose from, a list is available at

--- a/_i18n/es/resources/user-guides/mining_with_xmrig_and_docker.md
+++ b/_i18n/es/resources/user-guides/mining_with_xmrig_and_docker.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This guide is two fold, ease of use for mining on Linux distributions and some extra security around mining as most of these miners have not had security auditing.
@@ -20,7 +21,7 @@ For distribution specific installation please refer to the [Docker Docs](https:/
 
 ### Why XMRig
 
-[XMRig](https://github.com/xmrig/xmrig) is just a really solid miner to me. Nice output and statistics, no flashy web-ui's or dependencies. The XMRig container is only ~4MB what makes it extremely portable. 
+[XMRig](https://github.com/xmrig/xmrig) is just a really solid miner to me. Nice output and statistics, no flashy web-ui's or dependencies. The XMRig container is only ~4MB what makes it extremely portable.
 
 #### Step 1: Mining with XMRig
 

--- a/_i18n/es/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/es/resources/user-guides/monero-wallet-cli.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # monero-wallet-cli
 
 `monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
@@ -22,7 +23,7 @@ balance without refreshing:
 
     balance
     Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-    
+
 In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
 
 ## Sending monero

--- a/_i18n/es/resources/user-guides/monero_tools.md
+++ b/_i18n/es/resources/user-guides/monero_tools.md
@@ -1,7 +1,8 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Monero tools
 
-These tools can be used to gain information about the Monero network or your transaction data in the blockchain. 
+These tools can be used to gain information about the Monero network or your transaction data in the blockchain.
 
 ### [Check that a recipient has received your funds](http://xmrtests.llcoins.net/checktx.html)
 

--- a/_i18n/es/resources/user-guides/prove-payment.md
+++ b/_i18n/es/resources/user-guides/prove-payment.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ### Prove payments
 
 When you send money to a party who then disputes the payment was made, you need to be able to prove the payment was made.

--- a/_i18n/es/resources/user-guides/remote_node_gui.md
+++ b/_i18n/es/resources/user-guides/remote_node_gui.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Finding a node
 First things first, you need to find a node to connect to! [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods
 would be to use a node run by moneroworld, but they have a tool for finding random nodes too.

--- a/_i18n/es/resources/user-guides/restore_account.md
+++ b/_i18n/es/resources/user-guides/restore_account.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Operating Systems:  Windows, Linux, Mac
 
 - Retrieve your 25 word @mnemonic-seed that you saved when creating your old Monero @wallet

--- a/_i18n/es/resources/user-guides/restore_from_keys.md
+++ b/_i18n/es/resources/user-guides/restore_from_keys.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ### Restoring from keys
 
 Restoring a wallet from private keys is pretty simple. If you have the necessary information, with this guide you can completely restore your wallet. Note: you do NOT have to have your password to restore from keys.

--- a/_i18n/es/resources/user-guides/securely_purchase.md
+++ b/_i18n/es/resources/user-guides/securely_purchase.md
@@ -1,7 +1,8 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## How to purchase Monero and securely store it.
 
-This is a guide to purchase and securely store Monero as of June 2017. 
+This is a guide to purchase and securely store Monero as of June 2017.
 
 #### Step 1: Buy Bitcoin
 
@@ -9,9 +10,9 @@ There are many ways to buy Bitcoin. Two semi-reliable companies at this time are
 
 #### Step 2: Download and create a Paper Wallet on a secure and air-gapped computer.
 
-Download the paper wallet generator at: https://moneroaddress.org and copy it to a USB stick (Direct link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip). 
+Download the paper wallet generator at: https://moneroaddress.org and copy it to a USB stick (Direct link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip).
 
-Unzip and open the paper wallet generator (monero-wallet-generator.html) into a web browser on an air-gapped computer that hasn't been used before, or has had a clean installation of the OS. 
+Unzip and open the paper wallet generator (monero-wallet-generator.html) into a web browser on an air-gapped computer that hasn't been used before, or has had a clean installation of the OS.
 
 Your paper wallet will have four important items:
 

--- a/_i18n/es/resources/user-guides/solo_mine_GUI.md
+++ b/_i18n/es/resources/user-guides/solo_mine_GUI.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 It is very easy to solo mine with the official GUI. If you have not done so already, go to the <a href="{{site.baseurl}}/downloads/">Monero downloads page</a> and download the official GUI for your operating system. Then, run the setup and be patient as Monero synchronizes with the network. You should see that it displays "Connected" in the lower left corner.
 
 <img src="png/solo_mine_GUI/01.PNG" style="width: 600px;"/>

--- a/_i18n/es/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/es/resources/user-guides/verification-allos-advanced.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 #  Binary Verification: Linux, Mac, or Windows Using CLI Tools (Advanced)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero software. If you receive a fake Monero binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/es/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/es/resources/user-guides/verification-windows-beginner.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Verify Binaries: Windows (Beginner)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero binary. If you receive a fake binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/es/resources/user-guides/view_only.md
+++ b/_i18n/es/resources/user-guides/view_only.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 A view-only wallet can only see which incoming transactions belong to you. It can not spend any of your Monero, in fact it can't even see outgoing transactions from this wallet. This makes view-only wallets particularly interesting for
 
 * Developers writing libraries to validate payments

--- a/_i18n/es/resources/user-guides/vps_run_node.md
+++ b/_i18n/es/resources/user-guides/vps_run_node.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # monerod
 
 `monerod` is the daemon software that ships with the Monero tree. It is a console program, and manages the blockchain. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
@@ -40,7 +41,7 @@ Launch the daemon as a background process:
 Monitor the output of `monerod` if running as daemon:
 
     tail -f ~/.bitmonero/bitmonero.log
-    
+
 Keep the VPS secure with autoupdate:
 
 https://help.ubuntu.com/community/AutomaticSecurityUpdates

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -22,6 +22,9 @@ global:
   copyright: Propriété intellectuelle
   edit: Modifier cette page
   untranslated: Cette page n'a pas encore été traduite. Si vous voulez aider à la traduire, voyez le
+  outdatedMax: Cette page est dans une version trop ancienne. Nous vous recommandons de ne pas vous baser dessus et de consulter la
+  outdatedVersion: verson anglaise
+  outdatedMin: Cette page a été modifiée depuis sa traduction. Vous pouvez vous baser sur cette version, mais elle pourrait être incomplète.
 
 titles:
   index: Accueil

--- a/_i18n/fr/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/fr/resources/developer-guides/daemon-rpc.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '2.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This is a list of the monerod daemon RPC calls, their inputs and outputs, and examples of each.

--- a/_i18n/fr/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/fr/resources/developer-guides/wallet-rpc.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.2.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This is a list of the monero-wallet-rpc calls, their inputs and outputs, and examples of each. The program monero-wallet-rpc replaced the rpc interface that was in simplewallet and then monero-wallet-cli.
@@ -1235,7 +1236,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/fr/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
+++ b/_i18n/fr/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Comment miner Monero (XMR) sans matériel d'extraction minière ?
 
 Si vous ne disposez pas d'un matériel d'extraction minière rentable, ni de temps ou

--- a/_i18n/fr/resources/user-guides/Offline_Backup.md
+++ b/_i18n/fr/resources/user-guides/Offline_Backup.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Système d'exploitations : Différentes versions de Linux et Windows 7, 8
 
 ### Application de portefeuille : Simplewallet

--- a/_i18n/fr/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/fr/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Isolation du Portefeuille CLI et du Démon avec Qubes et Whonix
 
 Avec [Qubes](https://qubes-os.org) et [Whonix](https://whonix.org) vous pouvez disposer d'un portefeuille Monero hors connexion fonctionnant sur un système virtuel isolé du démon Monero dont tout le trafic est forcé à passer à travers [Tor](https://torproject.org).

--- a/_i18n/fr/resources/user-guides/create_wallet.md
+++ b/_i18n/fr/resources/user-guides/create_wallet.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Système d'exploitation :  Ubuntu
 
 - Téléchargez les [binaires officiels](https://getmonero.org/downloads/) ou compilez les dernières sources disponibles sur [Github](https://github.com/monero-project/bitmonero)

--- a/_i18n/fr/resources/user-guides/easiest_buy.md
+++ b/_i18n/fr/resources/user-guides/easiest_buy.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Comment obtenir Monero
 
 Voici un guide pour obtenir vos propre Moneroj datant du 9 Septembre 2015. Il s'agit peut être de la façon la plus simple d'acheter et posséder des Moneroj.

--- a/_i18n/fr/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/fr/resources/user-guides/howto_fix_stuck_funds.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Parfois, vos fonds pourraient être bloqués, ou vous auriez des fonds bloqués qui ne se débloqueraient jamais. Voici comment solutionner ce problème.
 
 - Chargez votre portefeuille dans monero-wallet-cli.

--- a/_i18n/fr/resources/user-guides/importing_blockchain.md
+++ b/_i18n/fr/resources/user-guides/importing_blockchain.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Importer la chaîne de blocs dans le portefeuille GUI
 
 ### Étape 1

--- a/_i18n/fr/resources/user-guides/mine-to-pool.md
+++ b/_i18n/fr/resources/user-guides/mine-to-pool.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Choisir un pool
 
 Il y a de nombreux pool parmi lesquels choisir, une liste est disponible sur

--- a/_i18n/fr/resources/user-guides/mining_with_xmrig_and_docker.md
+++ b/_i18n/fr/resources/user-guides/mining_with_xmrig_and_docker.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Introduction
 
 Ce guide a deux volets, la simplicité de l'extraction minière sur une distribution Linux et quelques pratique de sécurité autour de l'extraction minière, dans la mesure ou la plupart de ces applications d'extraction minière n'ont pas subits d'audit de sécurité.

--- a/_i18n/fr/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/fr/resources/user-guides/monero-wallet-cli.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # monero-wallet-cli
 
 `monero-wallet-cli` est une application de portefeuille qui est incluse dans la suite Monero. C'est un

--- a/_i18n/fr/resources/user-guides/monero_tools.md
+++ b/_i18n/fr/resources/user-guides/monero_tools.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Outils Monero
 
 Ces outils peuvent être utilisés pour obtenir des informations concernant le réseau Monero ou les données de vos transactions dans la chaîne de blocs.

--- a/_i18n/fr/resources/user-guides/remote_node_gui.md
+++ b/_i18n/fr/resources/user-guides/remote_node_gui.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Trouver un nœud
 Commencez par le commencement, vous devez trouver un nœud auquel vous connecter ! [moneroworld.com](https://moneroworld.com/#nodes) propose quelques bonnes ressources pour trouver
 des nœuds. L'une des méthodes les plus simple serait d'utiliser un nœud appartenant à moneroworld, mais ils propose également un outil pour trouver des nœuds aléatoires.

--- a/_i18n/fr/resources/user-guides/restore_account.md
+++ b/_i18n/fr/resources/user-guides/restore_account.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Systèmes d'exploitation : Windows, Linux, Mac
 
 - Récupérez votre @mnemonic-seed de 25 mots que vous avez sauvegardé lorsque vous avez créé votre ancien @wallet Monero ;

--- a/_i18n/fr/resources/user-guides/restore_from_keys.md
+++ b/_i18n/fr/resources/user-guides/restore_from_keys.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Restoring from keys
 
 Restaurer un portefeuille à partir de la clef privé est très simple. Si vous avez les informations nécessaire, avec ce guide vous pourrez totalement restaurer votre portefeuille. Notez : vous n'avez pas besoin de connaître votre mot de passe pour restaurer depuis la clef.

--- a/_i18n/fr/resources/user-guides/securely_purchase.md
+++ b/_i18n/fr/resources/user-guides/securely_purchase.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Comment acheter des Moneroj et les conserver en toute sécurité
 
 Voici un guide d'achat et de conservation en toute sécurité de Monero à la date de Juin 2017.

--- a/_i18n/fr/resources/user-guides/solo_mine_GUI.md
+++ b/_i18n/fr/resources/user-guides/solo_mine_GUI.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Il est très facile de miner en solo avec la GUI officielle. Si vous ne l'avez pas déjà fait, allez sur la <a href="{{site.baseurl}}/downloads/">page de téléchargement Monero</a> et téléchargez la GUI officielle pour votre système d'exploitation. Puis, lancez l'installation et patientez pendant que Monero se synchronise avec le réseau. Vous devriez voir qu'elle indique "Connecté" dans le coin en bas à gauche.
 
 <img src="png/solo_mine_GUI/01.PNG" style="width: 600px;"/>

--- a/_i18n/fr/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/fr/resources/user-guides/verification-allos-advanced.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 #  Vérifier des binaires : Outils CLI pour Linux, Mac ou (Avancé)
 
 Les fichiers binaires Monero devrait être vérifiés avant extraction, installation ou utilisation de l'application Monero. C'est l'unique manière de vous assurer que vous utilisez le binaire officiel Monero. Si vous recevez un binaire contrefait (p. ex. hameçonnage, HDM, etc.), suivre ce guide vous évitera de vous faire piéger.

--- a/_i18n/fr/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/fr/resources/user-guides/verification-windows-beginner.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Vérifier des binaires : Windows (Débutant)
 
 Les fichiers binaires Monero devrait être vérifiés avant extraction, installation ou utilisation de l'application Monero. C'est l'unique manière de vous assurer que vous utilisez le binaire officiel Monero. Si vous recevez un binaire contrefait (p. ex. hameçonnage, HDM, etc.), suivre ce guide vous évitera de vous faire piéger.

--- a/_i18n/fr/resources/user-guides/view_only.md
+++ b/_i18n/fr/resources/user-guides/view_only.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Un portefeuille d'audit ne peut que voir quelles transactions entrantes vous appartiennent. Il ne peut pas dépenser vos Moneroj, en fait il ne peut même pas voir les transactions sortantes de votre portefeuille. Cela rend le portefeuille d'audit particulièrement intéressant pour :
 
 * Les développeurs écrivant des librairies de validation de paiements ;

--- a/_i18n/fr/resources/user-guides/vps_run_node.md
+++ b/_i18n/fr/resources/user-guides/vps_run_node.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # monerod
 
 `monerod` est le démon est une application incluse dans la suite Monero. C'est un programme en ligne de commande qui gère la chaîne de blocs. Tandis que le portefeuille Bitcoin gère à la fois un compte et la chaîne de blocs, Monero sépare ces composants : `monerod` gère la chaîne de blocs, et `monero-wallet-cli` gère le compte.

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -21,6 +21,9 @@ global:
   privacy: Privacy
   copyright: Copyright
   untranslated: Questa pagina non è ancora stata tradotta. Se vuoi aiutare a tradurla vedi il
+  outdatedMax: Questa pagina è obsoleta. Suggeriamo di non utilizzarla. Invece, per favore guarda
+  outdatedVersion: versione in inglese
+  outdatedMin: Questa pagina è stata aggiornata successivamente all'ultima traduzione. Puoi utilizzare questa versione, ma potrebbe essere incompleta.
 
 titles:
   index: Home

--- a/_i18n/it/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/it/resources/developer-guides/daemon-rpc.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '2.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This is a list of the monerod daemon RPC calls, their inputs and outputs, and examples of each.

--- a/_i18n/it/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/it/resources/developer-guides/wallet-rpc.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.2.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This is a list of the monero-wallet-rpc calls, their inputs and outputs, and examples of each. The program monero-wallet-rpc replaced the rpc interface that was in simplewallet and then monero-wallet-cli.
@@ -1235,7 +1236,7 @@ $ curl -X POST http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","me
   }
 }
 ```
-    
+
 
 ### **rescan_spent**
 

--- a/_i18n/it/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
+++ b/_i18n/it/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## How to mine Monero (XMR) without a mining equipment?
 
 If you don’t have a profitable mining equipment, nor time or

--- a/_i18n/it/resources/user-guides/Offline_Backup.md
+++ b/_i18n/it/resources/user-guides/Offline_Backup.md
@@ -1,37 +1,38 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Operating Systems:  Various versions of Linux and Windows 7, 8
- 
+
 ### Wallet Software:  Simplewallet
- 
+
 #### Resource for Creating Bootable Disks:  [Linux](http://www.pendrivelinux.com/),       [Windows](https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool)
- 
+
 #### Resource for Monero Binaries:  [Monero Binaries](https://getmonero.org/downloads/)
- 
+
 - Take any computer you have lying around, even your normal workstation. You may find it easier to use an older computer that has no wifi or bluetooth if you're particularly paranoid
- 
+
 - Create a Linux or Windows bootable disk, and make sure you have the Monero binaries on the same disk or on a second disk (for Linux make sure you have also downloaded copies of the dependencies you will need, libboost1.55 and miniupnpc for instance)
- 
+
 - Disconnect the network and/or Internet cables from your computer, physically remove the wifi card or switch the wifi/bluetooth off on a laptop if possible
- 
+
 - Boot into your bootable OS, install the dependencies if necessary
- 
+
 - Copy the Monero binaries to a RAM disk (/dev/shm in Linux, Windows bootable ISOs normally have a Z: drive or something)
- 
+
 - Don't run the Monero daemon. Instead, using the command line, use monero-wallet-cli to create a new Monero @account
- 
+
 - When prompted for a name, give it any name, it doesn't really matter
- 
+
 - When prompted for a password, type in like 50 - 100 random characters. Don't worry that you don't know the password, just make it LONG
- 
+
 - **CRITICAL STEP**: Write down (on paper) your 25 word @mnemonic-seed  
 **WARNING**:  If you forget to write down this information your funds may be lost forever
- 
+
 - Write down (on your phone, on paper, on another computer, wherever you want) your address and view key
- 
+
 - Switch off the computer, remove the battery if there is one, and leave it physically off for a few hours
- 
+
 The account you've created was created in RAM, and the digital files are now inaccessible. If some adversary manages to somehow obtain the data, they will lack the long password to open it. If you need to receive payments, you have your public address, and you have the view key if needed. If you need access to it, you have your 25 word @mnemonic-seed, and you can now write out several copies of it, including an offsite copy (e.g. a bank deposit box).
- 
+
 Credit:  Riccardo Spagni
- 
+
 Related:  [Offline Account Generator](http://moneroaddress.org/)

--- a/_i18n/it/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/it/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # CLI Wallet/Daemon Isolation with Qubes + Whonix
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
@@ -8,7 +9,7 @@ Qubes gives the flexibility to easily create separate VMs for different purposes
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
 
-## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install): 
+## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install):
 
 + Using a Whonix workstation template, create two workstations as follows:
 
@@ -16,14 +17,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
 
-## 2. In the AppVM `monerod-ws`: 
+## 2. In the AppVM `monerod-ws`:
 
 + Download, verify, and install Monero software.
 
 ```
 user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "https://getmonero.org/downloads/hashes.txt"
 user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt 
+user@host:~$ gpg --verify hashes.txt
 gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
 gpg:                using RSA key 0x55432DF31CCD4FCD
 gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]

--- a/_i18n/it/resources/user-guides/create_wallet.md
+++ b/_i18n/it/resources/user-guides/create_wallet.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ### Operating Systems:  Ubuntu
 
 - Download the [official binaries](https://getmonero.org/downloads/) or compile the last source available on [Github](https://github.com/monero-project/bitmonero)
@@ -32,7 +33,7 @@
 ![image12](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/12.png)
 
 - Enter the name you want for your portfolio and follow the instructions from the terminal
- 
+
 ![image13](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/13.png)
 ![image14](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/14.png)
 ![image15](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/15.png)

--- a/_i18n/it/resources/user-guides/easiest_buy.md
+++ b/_i18n/it/resources/user-guides/easiest_buy.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## How to obtain Monero
 
 This is a guide to obtain your own Monero as of 20150919. This is perhaps the easiest way to purchase and hold Monero.
@@ -9,7 +10,7 @@ There are many ways to buy Bitcoin. Perhaps the easiest way is through circle.co
 
 ####Step 2: Set up a mymonero.com account
 
-MyMonero.com is an online wallet for Monero, maintained by Monero Core Developer Ricardo Spagni (fluffpony). It is the easiest wallet to use. Simply go to MyMonero.com and click on the "Create an Account" button. 
+MyMonero.com is an online wallet for Monero, maintained by Monero Core Developer Ricardo Spagni (fluffpony). It is the easiest wallet to use. Simply go to MyMonero.com and click on the "Create an Account" button.
 
 ![image1](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/easiest_way/01.png)
 

--- a/_i18n/it/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/it/resources/user-guides/howto_fix_stuck_funds.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 Sometimes, your funds will become stuck - you will have some locked funds that never become unlocked. This is how you fix it.
 
 - Load your wallet in monero-wallet-cli.

--- a/_i18n/it/resources/user-guides/importing_blockchain.md
+++ b/_i18n/it/resources/user-guides/importing_blockchain.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Importare la Blockchain nel portafoglio Monero GUI (Windows)
 
 ### Passo 1

--- a/_i18n/it/resources/user-guides/mine-to-pool.md
+++ b/_i18n/it/resources/user-guides/mine-to-pool.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Selecting a pool
 
 There are many pools to choose from, a list is available at

--- a/_i18n/it/resources/user-guides/mining_with_xmrig_and_docker.md
+++ b/_i18n/it/resources/user-guides/mining_with_xmrig_and_docker.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Introduction
 
 This guide is two fold, ease of use for mining on Linux distributions and some extra security around mining as most of these miners have not had security auditing.
@@ -20,7 +21,7 @@ For distribution specific installation please refer to the [Docker Docs](https:/
 
 ### Why XMRig
 
-[XMRig](https://github.com/xmrig/xmrig) is just a really solid miner to me. Nice output and statistics, no flashy web-ui's or dependencies. The XMRig container is only ~4MB what makes it extremely portable. 
+[XMRig](https://github.com/xmrig/xmrig) is just a really solid miner to me. Nice output and statistics, no flashy web-ui's or dependencies. The XMRig container is only ~4MB what makes it extremely portable.
 
 #### Step 1: Mining with XMRig
 

--- a/_i18n/it/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/it/resources/user-guides/monero-wallet-cli.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # monero-wallet-cli
 
 `monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
@@ -22,7 +23,7 @@ balance without refreshing:
 
     balance
     Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-    
+
 In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
 
 ## Sending monero

--- a/_i18n/it/resources/user-guides/monero_tools.md
+++ b/_i18n/it/resources/user-guides/monero_tools.md
@@ -1,7 +1,8 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Monero tools
 
-These tools can be used to gain information about the Monero network or your transaction data in the blockchain. 
+These tools can be used to gain information about the Monero network or your transaction data in the blockchain.
 
 ### [Check that a recipient has received your funds](http://xmrtests.llcoins.net/checktx.html)
 

--- a/_i18n/it/resources/user-guides/prove-payment.md
+++ b/_i18n/it/resources/user-guides/prove-payment.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ### Prove payments
 
 When you send money to a party who then disputes the payment was made, you need to be able to prove the payment was made.

--- a/_i18n/it/resources/user-guides/remote_node_gui.md
+++ b/_i18n/it/resources/user-guides/remote_node_gui.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Finding a node
 First things first, you need to find a node to connect to! [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods
 would be to use a node run by moneroworld, but they have a tool for finding random nodes too.

--- a/_i18n/it/resources/user-guides/restore_account.md
+++ b/_i18n/it/resources/user-guides/restore_account.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## Operating Systems:  Windows, Linux, Mac
 
 - Retrieve your 25 word @mnemonic-seed that you saved when creating your old Monero @wallet

--- a/_i18n/it/resources/user-guides/restore_from_keys.md
+++ b/_i18n/it/resources/user-guides/restore_from_keys.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ### Restoring from keys
 
 Restoring a wallet from private keys is pretty simple. If you have the necessary information, with this guide you can completely restore your wallet. Note: you do NOT have to have your password to restore from keys.

--- a/_i18n/it/resources/user-guides/securely_purchase.md
+++ b/_i18n/it/resources/user-guides/securely_purchase.md
@@ -1,7 +1,8 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 ## How to purchase Monero and securely store it.
 
-This is a guide to purchase and securely store Monero as of June 2017. 
+This is a guide to purchase and securely store Monero as of June 2017.
 
 #### Step 1: Buy Bitcoin
 
@@ -9,9 +10,9 @@ There are many ways to buy Bitcoin. Two semi-reliable companies at this time are
 
 #### Step 2: Download and create a Paper Wallet on a secure and air-gapped computer.
 
-Download the paper wallet generator at: https://moneroaddress.org and copy it to a USB stick (Direct link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip). 
+Download the paper wallet generator at: https://moneroaddress.org and copy it to a USB stick (Direct link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip).
 
-Unzip and open the paper wallet generator (monero-wallet-generator.html) into a web browser on an air-gapped computer that hasn't been used before, or has had a clean installation of the OS. 
+Unzip and open the paper wallet generator (monero-wallet-generator.html) into a web browser on an air-gapped computer that hasn't been used before, or has had a clean installation of the OS.
 
 Your paper wallet will have four important items:
 

--- a/_i18n/it/resources/user-guides/solo_mine_GUI.md
+++ b/_i18n/it/resources/user-guides/solo_mine_GUI.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Minare con la GUI ufficiale è molto semplice. Se non l'hai ancora fatto, vai sulla <a href="{{site.baseurl}}/downloads/">pagina dei download di Monero</a> e scarica la GUI ufficiale per il tuo sistema operativo. Avvia la GUI e attendi che Monero si sincronizzi con la rete. Dovresti vedere "Connesso" nell'angolo in basso a sinistra.
 
 <img src="png/solo_mine_GUI/01.PNG" style="width: 600px;"/>

--- a/_i18n/it/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/it/resources/user-guides/verification-allos-advanced.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 #  Binary Verification: Linux, Mac, or Windows Using CLI Tools (Advanced)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero software. If you receive a fake Monero binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/it/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/it/resources/user-guides/verification-windows-beginner.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Verify Binaries: Windows (Beginner)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero binary. If you receive a fake binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/it/resources/user-guides/view_only.md
+++ b/_i18n/it/resources/user-guides/view_only.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 A view-only wallet can only see which incoming transactions belong to you. It can not spend any of your Monero, in fact it can't even see outgoing transactions from this wallet. This makes view-only wallets particularly interesting for
 
 * Developers writing libraries to validate payments

--- a/_i18n/it/resources/user-guides/vps_run_node.md
+++ b/_i18n/it/resources/user-guides/vps_run_node.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # monerod
 
 `monerod` is the daemon software that ships with the Monero tree. It is a console program, and manages the blockchain. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
@@ -40,7 +41,7 @@ Launch the daemon as a background process:
 Monitor the output of `monerod` if running as daemon:
 
     tail -f ~/.bitmonero/bitmonero.log
-    
+
 Keep the VPS secure with autoupdate:
 
 https://help.ubuntu.com/community/AutomaticSecurityUpdates

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -22,6 +22,9 @@ global:
   copyright: Prawa autorskie
   edit: Edytuj tę stronę
   untranslated: Ta strona jeszcze nie została przetłumaczona. Jeśli chcesz pomóc w jej tłumaczeniu, przejdź do
+  outdatedMax: Ta strona jest nieaktualna. Nie zalecamy korzystania z niej. Zamiast tego, przejdź do
+  outdatedVersion: wersja po angielsku
+  outdatedMin: Ta strona została zaktualizowana po tym, jak została przetłumaczona. Możesz korzystać z tej wersji, jednak może być ona niekompletna.
 
 titles:
   index: Start

--- a/_i18n/pl/resources/developer-guides/daemon-rpc.md
+++ b/_i18n/pl/resources/developer-guides/daemon-rpc.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Wprowadzenie
 
 Poniżej znajduje się lista funkcji RPC demona monerod, ich wejścia i wyników oraz przykłady.

--- a/_i18n/pl/resources/developer-guides/wallet-rpc.md
+++ b/_i18n/pl/resources/developer-guides/wallet-rpc.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Wprowadzenie
 
 Poniżej znajduje się lista funkcji monero-wallet-rpc, ich wejścia i wyniki oraz przykłady. Oprogramowanie monero-wallet-rpc zamieniło interfejs rpc, które znajdowało się w simplewallet, a później w monero-wallet-cli.

--- a/_i18n/pl/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
+++ b/_i18n/pl/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Jak wydobywać Monero (XMR) bez sprzętu wydobywczego?
 
 Jeżeli nie posiadasz opłacalnego sprzętu wydobywczego ani czasu lub pieniędzy na zainwestowanie w niego, nadal możesz wydobywać Monero z NiceHash.

--- a/_i18n/pl/resources/user-guides/Offline_Backup.md
+++ b/_i18n/pl/resources/user-guides/Offline_Backup.md
@@ -1,36 +1,38 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Systemy operacyjne: różne wersje Linuxa oraz Windows 7 i 8
- 
+
 ### Oprogramowanie portfela:  Simplewallet
- 
+
 #### Materiały do tworzenia dysków rozruchowych:  [Linux](http://www.pendrivelinux.com/),       [Windows](https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool)
- 
+
 #### Materiały do plików binarnych Monero:  [Pliki Binarne Monero](https://getmonero.org/downloads/)
- 
+
 - Przygotuj jakikolwiek dostępny komputer, może być nawet twoja normalna stacja robocza. Jeśli jesteś szczególnie paranoidalny, najlepiej użyj starego komputera bez WiFi ani Bluetoothe'a.
- 
+
 - Stwórz dysk rozruchowy Linux lub Windows i upewnij się, że twoje pliki binarne Monero znajdują się na tym samym dysku lub na drugim dysku (w przypadku Linuxa, upewnij się, że ściągnąłeś także kopie zależności, których będziesz potrzebował, np. libboost1.55 i miniupnpc).
- 
+
 - Rozłącz sieć i/lub kable internetowe, fizycznie usuń kartę WiFi lub wyłącz przycisk WiFi/Bluetooth na laptopie, jeśli to możliwe.
- 
+
 - Uruchom swój rozruchowy system operacyjny, zainstaluj zależności, jeśli to konieczne.
- 
+
 - Skopiuj pliki binarne Monero na dysk RAM (/dev/shm w Linuxie, pliki binarne Windowsa normalnie mają dysk Z: lub coś w tym stylu).
- 
+
 - Nie uruchamiaj daemona Monero. Zamiast tego, za pomocą polecenia wiersza, użyj funkcji monero-wallet-cli, żeby stworzyć nowe konto Monero.
- 
+
 - Jeśli zostaniesz poproszony o nadanie nazwy swojemu kontu, nazwij je jakkolwiek, to nie ma dużego znaczenia.
- 
+
 - Jeśli zostaniesz poproszony o hasło, wpisz 50-100 losowych znaków. Nie przejmuj się, że nie zapamiętasz hasła, po prostu wybierz je DŁUGIE.
- 
+
 - **KLUCZOWY KROK**: Zapisz na kartce swój kod mnemoniczny składający się z 25 słów  
 **UWAGA**:  Jeśli zapomnisz zapisać swojego kodu, twoje środki mogą zostać utracone na zawsze!
- 
+
 - Zapisz w telefonie, na kartce, na innym komputerze lub w innym miejscu swój adres i klucz widoczności.
- 
+
 - Wyłącz komputer, wyciągnij baterię i zostaw go fizycznie wyłączonego na kilka godzin.
 
  Konto, które założyłeś, zostało zapisane w pamięci RAM i pliki cyfrowe są teraz niedostępne. Jeśli ktoś niepożądany w jakikolwiek sposób wejdzie w posiadanie tych danych, nie będzie posiadał długiego hasła niezbędnego do ich otworzenia. Aby otrzymać płatność, użyj swojego publicznego adresu lub klucza widoczności. Jeżeli potrzebujesz dostępu do swoich danych, użyj swojego 25-słownego kodu mnemonicznego, którego kopie możesz teraz zapisać w różnych miejscach, na przykład w skrytce bankowej.
- 
+
 Zasługa:  Riccardo Spagni
- 
+
 Powiązane:  [Generator Konta Offline](http://moneroaddress.org/)

--- a/_i18n/pl/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/pl/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # CLI Wallet/Daemon Isolation with Qubes + Whonix
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
@@ -8,7 +9,7 @@ Qubes gives the flexibility to easily create separate VMs for different purposes
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
 
-## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install): 
+## 1. [Create Whonix AppVMs](https://www.whonix.org/wiki/Qubes/Install):
 
 + Using a Whonix workstation template, create two workstations as follows:
 
@@ -16,14 +17,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
 
-## 2. In the AppVM `monerod-ws`: 
+## 2. In the AppVM `monerod-ws`:
 
 + Download, verify, and install Monero software.
 
 ```
 user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "https://getmonero.org/downloads/hashes.txt"
 user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt 
+user@host:~$ gpg --verify hashes.txt
 gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
 gpg:                using RSA key 0x55432DF31CCD4FCD
 gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]

--- a/_i18n/pl/resources/user-guides/create_wallet.md
+++ b/_i18n/pl/resources/user-guides/create_wallet.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Systemy operacyjne:  Ubuntu
 
 - Ściągnij [oficjalne pliki binarne](https://getmonero.org/downloads/) lub skompiluj ostatnie dostępne źródło na [Github](https://github.com/monero-project/bitmonero).
@@ -30,8 +32,8 @@
 
 ![image12](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/12.png)
 
-- Wpisz nazwę, którą chcesz nadać swojemu portfolio i postępuj zgodnie z instrukcjami terminala. 
- 
+- Wpisz nazwę, którą chcesz nadać swojemu portfolio i postępuj zgodnie z instrukcjami terminala.
+
 ![image13](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/13.png)
 ![image14](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/14.png)
 ![image15](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/15.png)
@@ -41,7 +43,7 @@
 
 ![image17](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/17.png)
 
-*To jest twój klucz widoczności. 
+*To jest twój klucz widoczności.
 This is your view key. Potrzebujesz go do stworzenia portfela tylko do wyświetlania (zobacz także: powiązany przewodnik dla użytkowników).*
 
 ![image18](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/create_wallet/18.png)

--- a/_i18n/pl/resources/user-guides/easiest_buy.md
+++ b/_i18n/pl/resources/user-guides/easiest_buy.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## W jaki sposób nabyć Monero?
 
 To jest przewodnik dotyczący nabycia Monero według stanu na dzień 19 września 2015 roku. To prawdopodobnie najprostsza metoda na zakup i posiadanie Monero.
@@ -8,7 +10,7 @@ Istnieje wiele sposobów na zakup Bitcoina. Być może najłatwiejszym z nich je
 
 ####Krok 2: Załóż konto na mymonero.com
 
-MyMonero.com jest portfelem Monero on-line, utrzymywanym przez głównego dewelopera Monero - Ricardo Spagni (fluffpony). Jest najłatwiejszym protfelem w użyciu. Po prostu przejdź do strony MyMonero.com i kliknij na "Create a new account". 
+MyMonero.com jest portfelem Monero on-line, utrzymywanym przez głównego dewelopera Monero - Ricardo Spagni (fluffpony). Jest najłatwiejszym protfelem w użyciu. Po prostu przejdź do strony MyMonero.com i kliknij na "Create a new account".
 
 ![image1](https://github.com/luuul/monero-site/blob/master/knowledge-base/user-guides/png/easiest_way/01.png)
 

--- a/_i18n/pl/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/pl/resources/user-guides/howto_fix_stuck_funds.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Czasami twoje fundusze utkną - część z nich zostanie zablokowana i nigdy nie odblokowana. Oto jak to naprawić:
 
 - Załaduj swój portfel w monero-wallet-cli.

--- a/_i18n/pl/resources/user-guides/importing_blockchain.md
+++ b/_i18n/pl/resources/user-guides/importing_blockchain.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Importowanie łańcucha bloków do portfela Graficznego Interfejsu Użytkownika Monero (dla Windowsa)
 
 ### Krok 1
@@ -28,7 +30,7 @@ Otwórz okno wiersza polecenia. Możesz tego dokonać, klikając w przycisk Wind
 
 Używając okienka CMD, przejdź do lokalizacji twojego portfela Monero. Możesz tego dokonać, wpisując:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE` 
+`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
 
 Powinno to wyglądać mniej więcej tak:
 
@@ -46,7 +48,7 @@ Na przykład:
 
 `monero-blockchain-import --verify 1 --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Jeśli ściągnąłeś łańcuch bloków z zaufanego, renomowanego źródła, możesz ustawić `verify 0`. To zmniejszy czas synchronizacji łańcucha. 
+Jeśli ściągnąłeś łańcuch bloków z zaufanego, renomowanego źródła, możesz ustawić `verify 0`. To zmniejszy czas synchronizacji łańcucha.
 
 ### Krok 7
 

--- a/_i18n/pl/resources/user-guides/mine-to-pool.md
+++ b/_i18n/pl/resources/user-guides/mine-to-pool.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Wybieranie zrzeszenia
 
 Istnieje wiele zrzeszeń do wyboru. Lista dostępna jest na stronie [moneropools.com](https://moneropools.com). Wydobywanie w większym zrzeszeniu może oznaczać częstszą wypłatę, ale to wydobywanie w mniejszej grupie pomaga utrzymać sieć zdecentralizowaną.

--- a/_i18n/pl/resources/user-guides/mining_with_xmrig_and_docker.md
+++ b/_i18n/pl/resources/user-guides/mining_with_xmrig_and_docker.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Wprowadzenie
 
 Ten przewodnik jest dwojaki: opisuje łatwość użycia do wydobycia w dystrybucjach Linuksa oraz dodatkowe zabezpieczenia wydobycia, ponieważ większość koparek nie miała przeprowadzonego audytu bezpieczeństwa. Po jego przeczytaniu będziesz mógł spać spokojniej, wiedząc, że wyeksploatowana koparka nie migruje do systemu operacyjnego.

--- a/_i18n/pl/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/pl/resources/user-guides/monero-wallet-cli.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # monero-wallet-cli
 
 `monero-wallet-cli` jest oprogramowaniem, które współpracuje z Monero. To program konsoli zarządzający kontem. Podczas gdy portfel Bitcoina zarządza zarówno kontem, jak i łańcuchem bloków, Monero rozdzielił je, aby `monerod`operował łańcuchem, a `monero-wallet-cli` kontem.
@@ -16,7 +18,7 @@ Przyciągnie to bloki z daemona, których portfel jeszcze nie widział oraz zakt
 
     balance
     Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-    
+
 W tym przypadku, `Balance` jest twoim saldem całkowitym. `unlocked balance` jest kwotą aktualnie dostępną do wydania. Nowe transakcje przychodzące wymagają 10 potwierdzeń zanim zostaną odblokowane. `unlocked dust` to bardzo mała liczba niewydanych wyników, które mogły się nagromadzić na twoim koncie.
 
 ## Wysyłanie monero

--- a/_i18n/pl/resources/user-guides/monero_tools.md
+++ b/_i18n/pl/resources/user-guides/monero_tools.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # Narzędzia Monero
 
 Poniższe narzędzia mogą zostać użyte w celu zdobycia informacji na temat sieci Monero lub twoich transakcji w łańcuchu bloków.

--- a/_i18n/pl/resources/user-guides/prove-payment.md
+++ b/_i18n/pl/resources/user-guides/prove-payment.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Udowodnij płatności
 
 Jeżeli dokonasz płatności osobie, która później ją zakwestionuje, musisz być w stanie udowodnić, że pieniądze zostały przesłane.

--- a/_i18n/pl/resources/user-guides/remote_node_gui.md
+++ b/_i18n/pl/resources/user-guides/remote_node_gui.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Wyszukiwanie węzła
 
 Pierwszą rzeczą jest znalezienie węzła, aby się podłączyć. [Moneroworld.com](https://moneroworld.com/#nodes) posiada dobre materiały służące odnajdywaniu węzłów. Jedną z najprostszych metod jest użycie węzła prowadzonego przez moneroworld, ale oni mają także narzędzie służące do wynajdywania losowych węzłów.

--- a/_i18n/pl/resources/user-guides/restore_account.md
+++ b/_i18n/pl/resources/user-guides/restore_account.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Systemy operacyjne:  Windows, Linux, Mac
 
 - Przygotuj swój 25-słowny kod mnemoniczny, który zachowałeś przy zakładaniu swojego starego portfela Monero

--- a/_i18n/pl/resources/user-guides/restore_from_keys.md
+++ b/_i18n/pl/resources/user-guides/restore_from_keys.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ### Przywróć portfel z kluczy
 
 Przywracanie portfela za pomocą prywatnych kluczy jest całkiem proste. Jeśli posiadasz potrzebne informacje, z tym przewodnikiem będziesz mógł całkowicie przywrócić swój portfel. Zauważ, że nie musisz posiadać swojego hasła, aby przywracać za pomocą kluczy.

--- a/_i18n/pl/resources/user-guides/securely_purchase.md
+++ b/_i18n/pl/resources/user-guides/securely_purchase.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 ## Jak bezpiecznie kupować i przechowywać Monero?
 
 Ten przewodnik opisuje, jak kupować i bezpiecznie przechowywać Monero, zgodnie ze stanem na czerwiec 2017 roku.
@@ -8,7 +10,7 @@ Istnieje wiele sposobów na zakupo Bitcoina. Dwie na wpół niezawodne organizac
 
 #### Krok 2: Ściągnij i utwórz papierowy portfel na bezpiecznym i odłączonym od sieci komputerze.
 
-Ściągnij generator papierowego portfela ze strony https://moneroaddress.org i skopiuj go na USB (bezpośredni link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip). 
+Ściągnij generator papierowego portfela ze strony https://moneroaddress.org i skopiuj go na USB (bezpośredni link: https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip).
 
 Rozpakuj i otwórz generator papierowego portfela (monero-wallet-generator.html) w przeglądarce na odłączonym od sieci komputerze, który nie był wcześniej używany lub posiada świeżo zainstalowany system operacyjny.
 

--- a/_i18n/pl/resources/user-guides/solo_mine_GUI.md
+++ b/_i18n/pl/resources/user-guides/solo_mine_GUI.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Wydobywanie samemu za poomocą oficjalnego Interfejsu Graficznego Użytkownika jest bardzo proste. Jeśli jeszcze go nie ściągnąłeś, wejdź na <a href="{{site.baseurl}}/downloads/">stronę z materiałami do ściągnięcia</a> i wybierz wersję Graficznego Interfejsu Użytkownika dla twojego systemu operacyjnego. Następnie uruchom ustawienia i uzbrój się w cierpliwość podczas synchronizacji Monero z siecią. Powinienieś zobaczyć "Connected" w lewym dolnym rogu.
 
 <img src="png/solo_mine_GUI/01.PNG" style="width: 600px;"/>

--- a/_i18n/pl/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/pl/resources/user-guides/verification-allos-advanced.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 #  Binary Verification: Linux, Mac, or Windows Using CLI Tools (Advanced)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero software. If you receive a fake Monero binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/pl/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/pl/resources/user-guides/verification-windows-beginner.md
@@ -1,4 +1,5 @@
-{% include untranslated.html %}
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
 # Verify Binaries: Windows (Beginner)
 
 Verification of the Monero binary files should be done prior to extracting, installing, or using the Monero software. This is the only way to ensure that you are using the official Monero binary. If you receive a fake binary (eg. phishing, MITM, etc.), following this guide will protect you from being tricked into using it.

--- a/_i18n/pl/resources/user-guides/view_only.md
+++ b/_i18n/pl/resources/user-guides/view_only.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 Portfel tylko do odczytu wyświetla jedynie twoje przychodzące transakcje. Nie może on dokonać żadnej płatności, nie może nawet wyświetlić żadnej transakcji wychodzącej. Portfel tylko do odczytu może być ciekawą opcją dla:
 
 * deweloperów, którzy tworzą biblioteki w celu sprawdzania poprawności płatności

--- a/_i18n/pl/resources/user-guides/vps_run_node.md
+++ b/_i18n/pl/resources/user-guides/vps_run_node.md
@@ -1,3 +1,5 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
 # monerod
 
 `monerod` jest oprogramowaniem daemona, które współpracuje z Monero. To program konsoli zarządzający łańcuchem bloków. Podczas gdy portfel Bitcoina zarządza zarówno kontem, jak i łańcuchem bloków, Monero rozdzielił je, aby `monerod` operował łańcuchem, a `monero-wallet-cli` kontem.
@@ -39,7 +41,7 @@ Uruchom daemona w tle:
 Monitoruj rezultaty `monerod`, jeśli daemon jest uruchomiony:
 
     tail -f ~/.bitmonero/bitmonero.log
-    
+
 Utrzymuj VPS w bezpieczeństwie, korzystając z autoaktualizacji:
 
 https://help.ubuntu.com/community/AutomaticSecurityUpdates

--- a/_includes/disclaimer.html
+++ b/_includes/disclaimer.html
@@ -1,0 +1,28 @@
+{% assign disclaimer = "" %}
+
+{% if site.lang == 'en' %}
+  <!-- Do nothing for English -->
+{% elsif version[0] != page.mainVersion[0] %}
+  <!-- Add outdated disclaimer and link to English version for major version mismatch -->
+  {% capture linkEN %}{{ site.baseurl_root }}{{ page.url }}{% endcapture %}
+  {% capture disclaimer %}{% t global.outdatedMax %} <a class="disclaimer-link" href="{{ linkEN }}" >{% t global.outdatedVersion %}</a>.{% endcapture %}
+{% elsif version[1] != page.mainVersion[1] %}
+  <!-- Add outdated disclaimer for minor version mismatch -->
+  {% capture disclaimer %}{% t global.outdatedMin %}{% endcapture %}
+{% endif %}
+
+{% if include.translated != "true" %}
+  <!-- Add untranslated disclaimer if needed -->
+  {% if disclaimer != "" %}
+    {% capture disclaimer %}<br>{{ disclaimer }}{% endcapture %}
+  {% endif %}
+  {% capture disclaimer %}{% t global.untranslated %} <a class="disclaimer-link" href="https://github.com/monero-project/monero-site/blob/master/README.md">README</a>.{{ disclaimer }}{% endcapture %}
+{% else %}
+
+{% endif %}
+{% if disclaimer != "" %}
+  <!-- Print the disclaimer if not empty -->
+  <div class="disclaimer">
+    <p>{{ disclaimer }}</p>
+  </div>
+{% endif %}

--- a/css/custom.css
+++ b/css/custom.css
@@ -1095,7 +1095,24 @@ pre.highlight>code {
     display: block;
 }
 
+.disclaimer {
+    background-color: #ff7519;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    z-index: 4;
+    width: 100%;
+    text-align: center;
+    color: white;
+    padding-bottom: 1rem;
+}
+
 .untranslated-link {
+    color: white;
+    text-decoration: underline;
+}
+
+.disclaimer-link {
     color: white;
     text-decoration: underline;
 }

--- a/resources/developer-guides/daemon-rpc.md
+++ b/resources/developer-guides/daemon-rpc.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "Daemon RPC documentation"
 permalink: /resources/developer-guides/daemon-rpc.html
+mainVersion:
+  - "2"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/developer-guides/daemon-rpc.md %}

--- a/resources/developer-guides/wallet-rpc.md
+++ b/resources/developer-guides/wallet-rpc.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: "Wallet RPC documentation"
 permalink: /resources/developer-guides/wallet-rpc.html
+mainVersion:
+  - "1"
+  - "2"
+  - "0"
 ---
 {% tf resources/developer-guides/wallet-rpc.md %}

--- a/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
+++ b/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "How to mine Monero XMR without a mining equipment"
 permalink: /resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.md %}

--- a/resources/user-guides/Offline_Backup.md
+++ b/resources/user-guides/Offline_Backup.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "Creating an Offline Backup of your Monero Account"
 permalink: /resources/user-guides/Offline_Backup.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
- 
+
 {% tf resources/user-guides/Offline_Backup.md %}

--- a/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: CLI Wallet/Daemon Isolation with Qubes + Whonix
 permalink: /resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md %}

--- a/resources/user-guides/create_wallet.md
+++ b/resources/user-guides/create_wallet.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "Creating a Monero wallet"
 permalink: /resources/user-guides/create_wallet.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/create_wallet.md %}

--- a/resources/user-guides/easiest_buy.md
+++ b/resources/user-guides/easiest_buy.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "Easiest way to buy Monero"
 permalink: /resources/user-guides/easiest_buy.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/easiest_buy.md %}

--- a/resources/user-guides/howto_fix_stuck_funds.md
+++ b/resources/user-guides/howto_fix_stuck_funds.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "How to fix stuck funds"
 permalink: /resources/user-guides/howto_fix_stuck_funds.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/howto_fix_stuck_funds.md %}

--- a/resources/user-guides/importing_blockchain.md
+++ b/resources/user-guides/importing_blockchain.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: Importing the Monero Blockchain from an outside source
 permalink: /resources/user-guides/importing_blockchain.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/importing_blockchain.md %}

--- a/resources/user-guides/mine-to-pool.md
+++ b/resources/user-guides/mine-to-pool.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: How to mine on a pool with xmr-stak-cpu
 permalink: /resources/user-guides/mine-to-pool.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 {% tf resources/user-guides/mine-to-pool.md %}

--- a/resources/user-guides/mining_with_xmrig_and_docker.md
+++ b/resources/user-guides/mining_with_xmrig_and_docker.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: "Mining with XMRig and Docker"
 permalink: /resources/user-guides/mining_with_xmrig_and_docker.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 {% tf resources/user-guides/mining_with_xmrig_and_docker.md %}

--- a/resources/user-guides/monero-wallet-cli.md
+++ b/resources/user-guides/monero-wallet-cli.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: "Monero tools"
 permalink: /resources/user-guides/monero-wallet-cli.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 {% tf resources/user-guides/monero-wallet-cli.md %}

--- a/resources/user-guides/monero_tools.md
+++ b/resources/user-guides/monero_tools.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: "Monero tools"
 permalink: /resources/user-guides/monero_tools.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 {% tf resources/user-guides/monero_tools.md %}

--- a/resources/user-guides/prove-payment.md
+++ b/resources/user-guides/prove-payment.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "How to prove payment"
 permalink: /resources/user-guides/prove-payment.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/prove-payment.md %}

--- a/resources/user-guides/remote_node_gui.md
+++ b/resources/user-guides/remote_node_gui.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: How to use a remote node in the GUI wallet
 permalink: /resources/user-guides/remote_node_gui.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/remote_node_gui.md %}

--- a/resources/user-guides/restore_account.md
+++ b/resources/user-guides/restore_account.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "Restoring your Monero Wallet"
 permalink: /resources/user-guides/restore_account.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/restore_account.md %}

--- a/resources/user-guides/restore_from_keys.md
+++ b/resources/user-guides/restore_from_keys.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: "Restoring a wallet from private keys"
 permalink: /resources/user-guides/restore_from_keys.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 {% tf resources/user-guides/restore_from_keys.md %}

--- a/resources/user-guides/securely_purchase.md
+++ b/resources/user-guides/securely_purchase.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: Securely purchasing and storing Monero
 permalink: /resources/user-guides/securely_purchase.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/securely_purchase.md %}

--- a/resources/user-guides/solo_mine_GUI.md
+++ b/resources/user-guides/solo_mine_GUI.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "How to solo mine with the GUI"
 permalink: /resources/user-guides/solo_mine_GUI.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/solo_mine_GUI.md %}

--- a/resources/user-guides/verification-allos-advanced.md
+++ b/resources/user-guides/verification-allos-advanced.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "Binary Verification: Linux, Mac, or Windows Using CLI Tools (Advanced)"
 permalink: /resources/user-guides/verification-allos-advanced.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/verification-allos-advanced.md %}

--- a/resources/user-guides/verification-windows-beginner.md
+++ b/resources/user-guides/verification-windows-beginner.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: Verify Binaries Windows (Beginner)
 permalink: /resources/user-guides/verification-windows-beginner.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/verification-windows-beginner.md %}

--- a/resources/user-guides/view_only.md
+++ b/resources/user-guides/view_only.md
@@ -2,6 +2,10 @@
 layout: user-guide
 title: "View Only Wallets"
 permalink: /resources/user-guides/view_only.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 
 {% tf resources/user-guides/view_only.md %}

--- a/resources/user-guides/vps_run_node.md
+++ b/resources/user-guides/vps_run_node.md
@@ -2,5 +2,9 @@
 layout: user-guide
 title: "Monero tools"
 permalink: /resources/user-guides/vps_run_node.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
 ---
 {% tf resources/user-guides/vps_run_node.md %}


### PR DESCRIPTION
~~This is a proof of concept to add version tracking in pages, as described in #738.~~
~~Tests are done with the "How to solo mine with the GUI" guide.~~

~~I've added a current version "2.1.2" to the "main" page.~~
~~Spanish is on another major version "1.X.X"~~
~~French is on another minor version "2.0.0"~~
~~Italian & Polish are on another build version "2.1.Y"~~

~~The disclaimer for untranslated and outdated version is unified.~~

~~I can create a test account for anyone who wants to see it in action on my local build (wire me for URL and account) - @rehrar already has one.~~

Edit: This is ready to merge.

With this, guides are versioned and a disclaimer at the bottom tells users if they should, could, or shouldn't trust the guide.
This very disclaimer includes the untranlated snippet also.

Each guide now has a header including the verson number, and a translated=true/false variable.

Default (EN) version is handle in the guide Front Matter of root /ressources/*

All guides are in v1.1.0 exept for:
- daemon RPC : 2.1.0 (polish kept in 1.1.0)
- wallet RPC : 1.2.0 (polish kept in 1.1.0)