### PR TITLE
Correct double date in Posts

### DIFF
--- a/_posts/2016-03-05-overview-and-logs-for-the-dev-meeting-held-on-2016-03-05.md
+++ b/_posts/2016-03-05-overview-and-logs-for-the-dev-meeting-held-on-2016-03-05.md
@@ -6,8 +6,6 @@ tags: [dev diaries, core, crypto]
 author: gingeropolous
 ---
 
-*March 5th, 2016*
-
 # Overview
 
 Open pull requests mostly just DB stuff by warptangent and hyc, and will be merged within next couple of hours. In the last couple of weeks, unit test fixes, threading fixes, "lots of little things". Hyc had some readtxn changes. Hyc's performance changes need to wait until some kind of migration system is implemented / developed.

--- a/_posts/2017-09-16-logs-for-the-Community-meeting-held-on-2017-09-16.md
+++ b/_posts/2017-09-16-logs-for-the-Community-meeting-held-on-2017-09-16.md
@@ -6,8 +6,6 @@ tags: [community]
 author: dEBRUYNE / fluffypony
 ---
 
-*September 16th, 2017*  
-
 # Logs  
 
 **\<sgp>** Starting the meeting (on the correct channel this time)  

--- a/_posts/2017-09-17-overview-and-logs-for-the-dev-meeting-held-on-2017-09-17.md
+++ b/_posts/2017-09-17-overview-and-logs-for-the-dev-meeting-held-on-2017-09-17.md
@@ -6,8 +6,6 @@ tags: [dev diaries, core, crypto]
 author: dEBRUYNE / fluffypony
 ---
 
-*September 17th, 2017*  
-
 # Overview  
 
 An overview can be found on [MoneroBase](https://monerobase.com/wiki/DevMeeting_2017-09-17).  

--- a/_posts/2017-09-24-logs-for-the-Kovri-dev-meeting-held-on-2017-09-24.md
+++ b/_posts/2017-09-24-logs-for-the-Kovri-dev-meeting-held-on-2017-09-24.md
@@ -6,8 +6,6 @@ tags: [dev diaries, i2p, crypto]
 author: dEBRUYNE / fluffypony
 ---
 
-*September 24th, 2017*  
-
 # Logs  
 
 **\<anonimal>** 1. Greetings  

--- a/_posts/2017-09-30-logs-for-the-Community-meeting-held-on-2017-09-30.md
+++ b/_posts/2017-09-30-logs-for-the-Community-meeting-held-on-2017-09-30.md
@@ -6,8 +6,6 @@ tags: [community]
 author: dEBRUYNE / fluffypony
 ---
 
-*September 30th, 2017*  
-
 # Logs  
 
 **\<rehrar>** 0. Introduction  

--- a/_posts/2017-10-01-overview-and-logs-for-the-dev-meeting-held-on-2017-10-01.md
+++ b/_posts/2017-10-01-overview-and-logs-for-the-dev-meeting-held-on-2017-10-01.md
@@ -6,8 +6,6 @@ tags: [dev diaries, core, crypto]
 author: dEBRUYNE / fluffypony
 ---
 
-*October 1st, 2017*  
-
 # Overview  
 
 An overview can be found on [MoneroBase](https://monerobase.com/wiki/DevMeeting_2017-10-01).  

--- a/_posts/2017-10-06-logs-for-the-Kovri-dev-meeting-held-on-2017-10-06.md
+++ b/_posts/2017-10-06-logs-for-the-Kovri-dev-meeting-held-on-2017-10-06.md
@@ -6,8 +6,6 @@ tags: [dev diaries, i2p, crypto]
 author: dEBRUYNE / fluffypony
 ---
 
-*October 6th, 2017*  
-
 # Logs  
 
 **\<anonimal>** 1. Greetings  

--- a/_posts/2017-10-14-logs-for-the-Community-meeting-held-on-2017-10-14.md
+++ b/_posts/2017-10-14-logs-for-the-Community-meeting-held-on-2017-10-14.md
@@ -6,8 +6,6 @@ tags: [community]
 author: dEBRUYNE / fluffypony
 ---
 
-*October 14th, 2017*  
-
 # Logs  
   
 **\<sgp>** 1. Greetings  

--- a/_posts/2017-10-22-overview-and-logs-for-the-dev-meeting-held-on-2017-10-22.md
+++ b/_posts/2017-10-22-overview-and-logs-for-the-dev-meeting-held-on-2017-10-22.md
@@ -6,8 +6,6 @@ tags: [dev diaries, core, crypto]
 author: dEBRUYNE / fluffypony
 ---
 
-*October 22nd, 2017*  
-
 # Overview  
 
 An overview can be found on [MoneroBase](https://monerobase.com/wiki/DevMeeting_2017-10-22).  

--- a/_posts/2017-10-28-logs-for-the-Community-meeting-held-on-2017-10-28.md
+++ b/_posts/2017-10-28-logs-for-the-Community-meeting-held-on-2017-10-28.md
@@ -6,8 +6,6 @@ tags: [community]
 author: dEBRUYNE / fluffypony
 ---
 
-*October 28th, 2017*  
-
 # Logs  
 
 **\<sgp>** Meeting is starting  

--- a/_posts/2017-10-30-logs-for-the-Monero-Research-Lab-meeting-held-on-2017-10-30.md
+++ b/_posts/2017-10-30-logs-for-the-Monero-Research-Lab-meeting-held-on-2017-10-30.md
@@ -6,8 +6,6 @@ tags: [community, crypto, research]
 author: dEBRUYNE / fluffypony
 ---
 
-*October 30th, 2017*  
-
 # Logs  
 
 **\<sarang>** Let's go  


### PR DESCRIPTION
This solves #746
A few posts had the date hard written in the md file, when Jekyll is building automatically a date header based on the date in the title.
As a result, those posts were displaying the date twice.

I removed the hard written date.