### PR TITLE
Ledger Wallet CLI Guide (dEBRUYNE)

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -417,6 +417,7 @@ user-guides:
   prove-payment: How to prove payment
   restore-from-keys: Restoring wallet from keys
   nicehash: How to mine Monero XMR without a mining equipment
+  ledger-wallet-cli: How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
 
 roadmap:
   translated: "yes"

--- a/_i18n/en/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/en/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,165 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
+## How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
+
+### Table of Content
+
+* [1. Windows](#1-windows)
+* [2. Mac OS X](#2-mac-os-x)
+* [3. Linux](#3-linux)
+* [4. Final notes](#4-a-few-final-notes)
+
+### 1. Windows
+
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.3 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod.exe`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monerod.exe and monero-wallet-cli.exe are located.
+
+2. Open a new command prompt / powershell. This is done by first making sure your cursor isn't located on any of the files and subsequently doing SHIFT + right click. It will give you an option to "Open command window here". If you're using Windows 10 in latest version, it'll give you an option to "open the PowerShell window here".
+
+3. Now type:
+
+`monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 10)
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 10)
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 2. Mac OS X
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.2 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Note that the instructions for system configuration (section 3.2.2) on Mac OS X are quite elaborate and can be perceived as slightly convoluted. Fortunately, tficharmers has created a guide [here](https://monero.stackexchange.com/questions/8438/how-do-i-make-my-macos-detect-my-ledger-nano-s-when-plugged-in) that you can use for assistance.
+
+5. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+6. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Use Finder to browse to the directory / folder `monero-wallet-cli` (CLI v0.12.2.0) is located.
+
+2. Go to your desktop.
+
+3. Open a new terminal (if don't know how to open a terminal, see [here](https://apple.stackexchange.com/a/256263)).
+
+4. Drag `monero-wallet-cli` in the terminal. It should add the full path to the terminal. Do not hit enter.
+
+5. Now type:
+
+`--generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`--generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+Note that aforementioned text will be appended to the path of `monero-wallet-cli`. Thus, before you hit enter, your terminal should look like:
+
+`/full/path/to/monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Where the full path is, intuitively, the actual path on your Mac OS X.
+
+7. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+8. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+9. You may have to hit confirm twice before it proceeds.
+
+10. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+11. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+12. Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 3. Linux
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.1 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monero-wallet-cli and monerod are located.
+
+2. Open a new terminal
+
+3. Now type:
+
+`./monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`./monero-wallet-cli --generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 4. A few final notes
+
+1. We'd strongly advise to test the full process first. That is, send a small amount to the wallet and subsequently restore it (using aforementioned guide) to verify that you can recover the wallet. Note that, upon recreating / restoring the wallet, you ought to append the `--restore-height` flag (with a block height before the height of your first transaction to the wallet) to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux). More information about the restore height and how to approximate it can be found [here](https://monero.stackexchange.com/questions/7581/what-is-the-relevance-of-the-restore-height).
+
+2. If you use a remote node, append the `--daemon-address host:port` flag to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux).
+
+3. If desired, you can manually tweak the `--subaddress-lookahead` value. The first value is the number of accounts and the second value is the number of subaddresses per account. Thus, if you, for instance, want to pregenerate 5 accounts with 100 subaddresses each, use `--subaddress-lookahead 5:100`. Bear in mind that, the more subaddresses you pregenerate, the longer it takes for the Ledger to create your wallet.
+
+4. You only have to use the `--generate-from-device` flag once (i.e. upon wallet creation). Thereafter, you'd basically use it similar to how you normally use the CLI. That is:
+   1. Make sure your Ledger is plugged in and the Monero app is running.
+   2. Open `monero-wallet-cli`.
+   3. Enter the wallet name of your Ledger Monero wallet.
+   4. Enter the password to open the wallet.
+
+   If the Ledger wallet files are not in the same directory as `monero-wallet-cli`, you ought to open `monero-wallet-cli` with the `--wallet-file /path/to/wallet.keys/file` flag. Alternatively, you can copy the Ledger wallet files to the same directory as `monero-wallet-cli`.
+
+5. If you have any further questions or need assistance, please leave a comment to the orginal [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli) answer.
+
+Author: dEBRUYNE
+Secondary scribe: el00ruobuob

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -417,6 +417,7 @@ user-guides:
   prove-payment: How to prove payment
   restore-from-keys: Restoring wallet from keys
   nicehash:
+  ledger-wallet-cli: How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
 
 roadmap:
   translated: "no"

--- a/_i18n/es/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/es/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,165 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
+## How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
+
+### Table of Content
+
+* [1. Windows](#1-windows)
+* [2. Mac OS X](#2-mac-os-x)
+* [3. Linux](#3-linux)
+* [4. Final notes](#4-a-few-final-notes)
+
+### 1. Windows
+
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.3 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod.exe`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monerod.exe and monero-wallet-cli.exe are located.
+
+2. Open a new command prompt / powershell. This is done by first making sure your cursor isn't located on any of the files and subsequently doing SHIFT + right click. It will give you an option to "Open command window here". If you're using Windows 10 in latest version, it'll give you an option to "open the PowerShell window here".
+
+3. Now type:
+
+`monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 10)
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 10)
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 2. Mac OS X
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.2 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Note that the instructions for system configuration (section 3.2.2) on Mac OS X are quite elaborate and can be perceived as slightly convoluted. Fortunately, tficharmers has created a guide [here](https://monero.stackexchange.com/questions/8438/how-do-i-make-my-macos-detect-my-ledger-nano-s-when-plugged-in) that you can use for assistance.
+
+5. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+6. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Use Finder to browse to the directory / folder `monero-wallet-cli` (CLI v0.12.2.0) is located.
+
+2. Go to your desktop.
+
+3. Open a new terminal (if don't know how to open a terminal, see [here](https://apple.stackexchange.com/a/256263)).
+
+4. Drag `monero-wallet-cli` in the terminal. It should add the full path to the terminal. Do not hit enter.
+
+5. Now type:
+
+`--generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`--generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+Note that aforementioned text will be appended to the path of `monero-wallet-cli`. Thus, before you hit enter, your terminal should look like:
+
+`/full/path/to/monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Where the full path is, intuitively, the actual path on your Mac OS X.
+
+7. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+8. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+9. You may have to hit confirm twice before it proceeds.
+
+10. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+11. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+12. Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 3. Linux
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.1 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monero-wallet-cli and monerod are located.
+
+2. Open a new terminal
+
+3. Now type:
+
+`./monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`./monero-wallet-cli --generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 4. A few final notes
+
+1. We'd strongly advise to test the full process first. That is, send a small amount to the wallet and subsequently restore it (using aforementioned guide) to verify that you can recover the wallet. Note that, upon recreating / restoring the wallet, you ought to append the `--restore-height` flag (with a block height before the height of your first transaction to the wallet) to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux). More information about the restore height and how to approximate it can be found [here](https://monero.stackexchange.com/questions/7581/what-is-the-relevance-of-the-restore-height).
+
+2. If you use a remote node, append the `--daemon-address host:port` flag to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux).
+
+3. If desired, you can manually tweak the `--subaddress-lookahead` value. The first value is the number of accounts and the second value is the number of subaddresses per account. Thus, if you, for instance, want to pregenerate 5 accounts with 100 subaddresses each, use `--subaddress-lookahead 5:100`. Bear in mind that, the more subaddresses you pregenerate, the longer it takes for the Ledger to create your wallet.
+
+4. You only have to use the `--generate-from-device` flag once (i.e. upon wallet creation). Thereafter, you'd basically use it similar to how you normally use the CLI. That is:
+   1. Make sure your Ledger is plugged in and the Monero app is running.
+   2. Open `monero-wallet-cli`.
+   3. Enter the wallet name of your Ledger Monero wallet.
+   4. Enter the password to open the wallet.
+
+   If the Ledger wallet files are not in the same directory as `monero-wallet-cli`, you ought to open `monero-wallet-cli` with the `--wallet-file /path/to/wallet.keys/file` flag. Alternatively, you can copy the Ledger wallet files to the same directory as `monero-wallet-cli`.
+
+5. If you have any further questions or need assistance, please leave a comment to the orginal [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli) answer.
+
+Author: dEBRUYNE
+Secondary scribe: el00ruobuob

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -419,6 +419,7 @@ user-guides:
   prove-payment: Comment vérifier un paiement
   restore-from-keys: Restaurer un portefeuille depuis les clefs
   nicehash: Comment miner Monero sans équipement d'extraction minière
+  ledger-wallet-cli: Comment générer un portefeuille Monero Ledger avec la CLI (monero-wallet-cli)
 
 roadmap:
   translated: "yes"

--- a/_i18n/fr/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/fr/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,167 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="true" version=page.version %}
+## Comment générer un portefeuille Monero Ledger avec la CLI (monero-wallet-cli)
+
+### Table des Matières
+
+* [1. Windows](#1-windows)
+* [2. Mac OS X](#2-mac-os-x)
+* [3. Linux](#3-linux)
+* [4. Remarques Finales](#4-quelques-remarques-finales)
+
+### 1. Windows
+
+Nous devons nous assurer d'être suffisamment préparé. Cela implique ce qui suit :
+
+1. Ce guide suppose que vous avez déjà initialisé votre portefeuille Ledger et par conséquent généré une phrase mnémonique de 24 mots.
+
+2. Vous devez lancer / utiliser la CLI v0.12.2.0, qui peut être récupérée <a href="{{site.baseurl}}/downloads/">ici</a>.
+
+3. Vous avez besoin d'installer et de configurer l'application de portefeuille Monero de Ledger. Vous trouverez les instructions [ici](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 et 3.2.3 en particulier). De plus, assurez-vous de configurer le réseau sur `Mainnet`.
+
+4. Votre Ledger doit être connecté et l'application Monero de Ledger en cours d'exécution.
+
+5. Vous devez soit avoir votre démon (`monerod.exe`) lancé et de préférence totalement synchronisé, soit vous connecter à un nœud distant.
+
+Maintenant que nous sommes suffisamment préparé, commençons !
+
+1. Allez dans le répertoire / dossier où sont situés monerod.exe et monero-wallet-cli.exe.
+
+2. Ouvrez une nouvelle invite de commande / fenêtre powershell. Vous pouvez faire cela en vous assurant que votre curseur n'est pas positionné sur un fichier, puis en faisant consécutivement SHUFT + Click Droit. Une nouvelle option "Ouvrir une fenêtre de commande ici" vous sera proposée. Si vous utilisez Windows 10 en dernière version, l'option sera "Ouvrir la fenêtre PowerShell ici".
+
+3. Saisissez maintenant :
+
+`monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 10)
+
+Remarquez qu'il s'agit simplement d'un emplacement pour le nom effectif du portefeuille. Si vous vouliez, par exemple, nommer votre portefeuille `MoneroWallet`, la commande serait la suivante :
+
+`monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 10)
+
+4. Après avoir exécutée la commande susmentionnée, la CLI va vous demander de saisir un mot de passe. Assurez-vous de saisir un mot de passe robuste, puis confirmez-le.
+
+5. Le Ledger vous demandera si vous souhaitez ou non exporter la clef privée d'audit. Avant tout, vos fonds ne peuvent pas être compromis uniquement avec la clef privée d'audit. Exporter la clef privée d'audit permet au client (sur l'ordinateur - Monero v0.12.2.0) de scanner les blocs à la recherche de transactions appartenant à votre portefeuille / adresse. Si cette option n'est pas utilisée, le périphérique (Ledger) scannera les blocs, ce qui est considérablement plus lent. Il y a cependant une mise en garde : si votre système est compromis, un ennemi serait potentiellement en mesure de compromettre également votre clef privée d'audit, au détriment de votre confidentialité. C'est pratiquement impossible lorsque votre clef privée d'audit n'est pas exportée.
+
+6. Vous pourriez avoir besoin de confirmer deux fois avant qu'il ne procède.
+
+7. Votre portefeuille Monero Ledger va maintenant être généré. Notez que cela pourrait prendre de 5 à 10 minutes. De plus, il n'y aura pas de retour immédiat, ni sur la CLI ni sur Ledger.
+
+8. `monero-wallet-cli` va se réactualiser. Patientez jusqu'à la fin de cette opération.
+
+Félicitations, vous pouvez maintenant utiliser votre portefeuille Monero Ledger conjointement avec la CLI.
+
+### 2. Mac OS X
+
+Nous devons nous assurer d'être suffisamment préparé. Cela implique ce qui suit :
+
+1. Ce guide suppose que vous avez déjà initialisé votre portefeuille Ledger et par conséquent généré une phrase mnémonique de 24 mots.
+
+2. Vous devez lancer / utiliser la CLI v0.12.2.0, qui peut être récupérée <a href="{{site.baseurl}}/downloads/">ici</a>.
+
+3. Vous avez besoin d'installer et de configurer l'application de portefeuille Monero de Ledger. Vous trouverez les instructions [ici](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 et 3.2.2 en particulier). De plus, assurez-vous de configurer le réseau sur `Mainnet`.
+
+4. Remarquez que les instructions pour la configuration du système (section 3.2.2) sur Mac OS X sont assez compliquées et peuvent être perçues comme quelque peu alambiqués. Par chance, tficharmers a écrit un guide [ici](https://monero.stackexchange.com/questions/8438/how-do-i-make-my-macos-detect-my-ledger-nano-s-when-plugged-in) que vous pouvez utiliser pour vous aider.
+
+5. Votre Ledger doit être connecté et l'application Monero de Ledger en cours d'exécution.
+
+6. Vous devez soit avoir votre démon (`monerod`) lancé et de préférence totalement synchronisé, soit vous connecter à un nœud distant.
+
+Maintenant que nous sommes suffisamment préparé, commençons !
+
+1. Utilisez Finder pour naviguer dans le répertoire / dossier où se situe `monero-wallet-cli` (CLI v0.12.2.0).
+
+2. Allez sur votre bureau.
+
+3. Ouvrez un nouveau terminal (Si vous ne savez pas comment ouvrir un terminal, allez voir [ici](https://apple.stackexchange.com/a/256263)).
+
+4. Glissez-déposez `monero-wallet-cli` dans le terminal. Cela devrait ajouter le chemin complet au terminal. N'appuyez pas sur la touche Entrée.
+
+5. Saisissez maintenant :
+
+`--generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Remarquez qu'il s'agit simplement d'un emplacement pour le nom effectif du portefeuille. Si vous vouliez, par exemple, nommer votre portefeuille `MoneroWallet`, la commande serait la suivante :
+
+`--generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+Remarquez que le texte susmentionné sera ajouté au chemin de `monero-wallet-cli`. Donc, avant que vous n'appuyez sur la touche Entrée, votre terminal devrait ressembler à cela :
+
+`/chemin/complet/vers/monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Où le chemin complet est, comme son nom l'indique, le chemin actuel sur votre Mac OS X.
+
+7. Après avoir exécutée la commande susmentionnée, la CLI va vous demander de saisir un mot de passe. Assurez-vous de saisir un mot de passe robuste, puis confirmez-le.
+
+8. Le Ledger vous demandera si vous souhaitez ou non exporter la clef privée d'audit. Avant tout, vos fonds ne peuvent pas être compromis uniquement avec la clef privée d'audit. Exporter la clef privée d'audit permet au client (sur l'ordinateur - Monero v0.12.2.0) de scanner les blocs à la recherche de transactions appartenant à votre portefeuille / adresse. Si cette option n'est pas utilisée, le périphérique (Ledger) scannera les blocs, ce qui est considérablement plus lent. Il y a cependant une mise en garde : si votre système est compromis, un ennemi serait potentiellement en mesure de compromettre également votre clef privée d'audit, au détriment de votre confidentialité. C'est pratiquement impossible lorsque votre clef privée d'audit n'est pas exportée.
+
+9. Vous pourriez avoir besoin de confirmer deux fois avant qu'il ne procède.
+
+10. Votre portefeuille Monero Ledger va maintenant être généré. Notez que cela pourrait prendre de 5 à 10 minutes. De plus, il n'y aura pas de retour immédiat, ni sur la CLI ni sur Ledger.
+
+11. `monero-wallet-cli` va se réactualiser. Patientez jusqu'à la fin de cette opération.
+
+12. Félicitations, vous pouvez maintenant utiliser votre portefeuille Monero Ledger conjointement avec la CLI.
+
+### 3. Linux
+
+Nous devons nous assurer d'être suffisamment préparé. Cela implique ce qui suit :
+
+1. Ce guide suppose que vous avez déjà initialisé votre portefeuille Ledger et par conséquent généré une phrase mnémonique de 24 mots.
+
+2. Vous devez lancer / utiliser la CLI v0.12.2.0, qui peut être récupérée <a href="{{site.baseurl}}/downloads/">ici</a>.
+
+3. Vous avez besoin d'installer et de configurer l'application de portefeuille Monero de Ledger. Vous trouverez les instructions [ici](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 et 3.2.1 en particulier). De plus, assurez-vous de configurer le réseau sur `Mainnet`.
+
+4. Votre Ledger doit être connecté et l'application Monero de Ledger en cours d'exécution.
+
+5. Vous devez soit avoir votre démon (`monerod`) lancé et de préférence totalement synchronisé, soit vous connecter à un nœud distant.
+
+Maintenant que nous sommes suffisamment préparé, commençons !
+
+1. Allez dans le répertoire / dossier où sont situés monero-wallet-cli et monerod.
+
+2. Ouvrir un nouveau terminal
+
+3. Saisissez maintenant :
+
+`./monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Remarquez qu'il s'agit simplement d'un emplacement pour le nom effectif du portefeuille. Si vous vouliez, par exemple, nommer votre portefeuille `MoneroWallet`, la commande serait la suivante :
+
+`./monero-wallet-cli --generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+4. Après avoir exécutée la commande susmentionnée, la CLI va vous demander de saisir un mot de passe. Assurez-vous de saisir un mot de passe robuste, puis confirmez-le.
+
+5. Le Ledger vous demandera si vous souhaitez ou non exporter la clef privée d'audit. Avant tout, vos fonds ne peuvent pas être compromis uniquement avec la clef privée d'audit. Exporter la clef privée d'audit permet au client (sur l'ordinateur - Monero v0.12.2.0) de scanner les blocs à la recherche de transactions appartenant à votre portefeuille / adresse. Si cette option n'est pas utilisée, le périphérique (Ledger) scannera les blocs, ce qui est considérablement plus lent. Il y a cependant une mise en garde : si votre système est compromis, un ennemi serait potentiellement en mesure de compromettre également votre clef privée d'audit, au détriment de votre confidentialité. C'est pratiquement impossible lorsque votre clef privée d'audit n'est pas exportée.
+
+6. Vous pourriez avoir besoin de confirmer deux fois avant qu'il ne procède.
+
+7. Votre portefeuille Monero Ledger va maintenant être généré. Notez que cela pourrait prendre de 5 à 10 minutes. De plus, il n'y aura pas de retour immédiat, ni sur la CLI ni sur Ledger.
+
+8. `monero-wallet-cli` va se réactualiser. Patientez jusqu'à la fin de cette opération.
+
+Félicitations, vous pouvez maintenant utiliser votre portefeuille Monero Ledger conjointement avec la CLI.
+
+### 4. Quelques remarques finales
+
+1. Nous vous recommandons fortement de d'abord tester la totalité du processus. C'est à dire, envoyer un petit montant au portefeuille et le restaurer consécutivement (en utilisant le guide susmentionné) pour vérifier que vous pouvez récupérer le portefeuille. Remarquez que, lors de la recréation / restauration d'un portefeuille, vous devez ajouter l'option `--restore-height` (avec la hauteur de bloc de la première transaction de ce portefeuille) à la commande de l'étape 3 (Windows), l'étape 5 (Mac OS X) ou l'étape 3 (Linux). Vous trouverez plus d'information concernant la hauteur de restauration et la manière de l'estimer [ici](https://monero.stackexchange.com/questions/7581/what-is-the-relevance-of-the-restore-height).
+
+2. Si vous utilisez un nœud distant, ajoutez l'option `--daemon-address host:port` à la commande de l'étape 3 (Windows), l'étape 5 (Mac OS X) ou l'étape 3 (Linux).
+
+3. Si vous les souhaitez, vous pouvez personnaliser la valeur de l'option `--subaddress-lookahead`. La première valeur correspond au nombre de comptes et la seconde au nombre de sous-adresses par compte. ainsi, si par exemple vous voulez pré-générer 5 comptes avec 100 sous-adresses chacun, utilisez `--subaddress-lookahead 5:100`. Gardez à l'esprit que plus vous pré-générez de sous-adresses, plus le temps de création de votre portefeuille sur le Ledger sera long.
+
+4. Vous n'avez à utiliser l'option `--generate-from-device` qu'une seule fois (c-à-d lors de la création du portefeuille). Ultérieurement vous l'utiliserez d'une façon similaire à la CLI habituelle, c'est à dire :
+   1. Vous assurer que votre Ledge est connecté et que l'application Monro est démarrée ;
+   2. Ouvrir `monero-wallet-cli`.
+   3. Entrer le nom de votre portefeuille Monero Ledger ;
+   4. Entrer le mot de passe pour ouvrir le portefeuille.
+
+   Si les fichiers du portefeuille Ledger ne sont pas dans le même répertoire que `monero-wallet-cli`, vous devez ouvrir `monero-wallet-cli` avec l'option `--wallet-file /chemin/vers/fichier/clefs.portefeuille`. Sinon, vous pouvez copier les fichiers du portefeuille Ledger dans le même répertoire que `monero-wallet-cli`.
+
+5. Si vous avez des questions, ou besoin d'aide, ajoutez un commentaire sur l'article d'origine sur [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli).
+
+Auteur: dEBRUYNE
+Transcripteur secondaire: el00ruobuob

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -417,6 +417,7 @@ user-guides:
   prove-payment: How to prove payment
   restore-from-keys: Restoring wallet from keys
   nicehash:
+  ledger-wallet-cli: How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
 
 roadmap:
   translated: "no"

--- a/_i18n/it/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/it/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,165 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
+## How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
+
+### Table of Content
+
+* [1. Windows](#1-windows)
+* [2. Mac OS X](#2-mac-os-x)
+* [3. Linux](#3-linux)
+* [4. Final notes](#4-a-few-final-notes)
+
+### 1. Windows
+
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.3 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod.exe`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monerod.exe and monero-wallet-cli.exe are located.
+
+2. Open a new command prompt / powershell. This is done by first making sure your cursor isn't located on any of the files and subsequently doing SHIFT + right click. It will give you an option to "Open command window here". If you're using Windows 10 in latest version, it'll give you an option to "open the PowerShell window here".
+
+3. Now type:
+
+`monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 10)
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 10)
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 2. Mac OS X
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.2 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Note that the instructions for system configuration (section 3.2.2) on Mac OS X are quite elaborate and can be perceived as slightly convoluted. Fortunately, tficharmers has created a guide [here](https://monero.stackexchange.com/questions/8438/how-do-i-make-my-macos-detect-my-ledger-nano-s-when-plugged-in) that you can use for assistance.
+
+5. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+6. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Use Finder to browse to the directory / folder `monero-wallet-cli` (CLI v0.12.2.0) is located.
+
+2. Go to your desktop.
+
+3. Open a new terminal (if don't know how to open a terminal, see [here](https://apple.stackexchange.com/a/256263)).
+
+4. Drag `monero-wallet-cli` in the terminal. It should add the full path to the terminal. Do not hit enter.
+
+5. Now type:
+
+`--generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`--generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+Note that aforementioned text will be appended to the path of `monero-wallet-cli`. Thus, before you hit enter, your terminal should look like:
+
+`/full/path/to/monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Where the full path is, intuitively, the actual path on your Mac OS X.
+
+7. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+8. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+9. You may have to hit confirm twice before it proceeds.
+
+10. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+11. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+12. Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 3. Linux
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.1 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monero-wallet-cli and monerod are located.
+
+2. Open a new terminal
+
+3. Now type:
+
+`./monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`./monero-wallet-cli --generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 4. A few final notes
+
+1. We'd strongly advise to test the full process first. That is, send a small amount to the wallet and subsequently restore it (using aforementioned guide) to verify that you can recover the wallet. Note that, upon recreating / restoring the wallet, you ought to append the `--restore-height` flag (with a block height before the height of your first transaction to the wallet) to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux). More information about the restore height and how to approximate it can be found [here](https://monero.stackexchange.com/questions/7581/what-is-the-relevance-of-the-restore-height).
+
+2. If you use a remote node, append the `--daemon-address host:port` flag to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux).
+
+3. If desired, you can manually tweak the `--subaddress-lookahead` value. The first value is the number of accounts and the second value is the number of subaddresses per account. Thus, if you, for instance, want to pregenerate 5 accounts with 100 subaddresses each, use `--subaddress-lookahead 5:100`. Bear in mind that, the more subaddresses you pregenerate, the longer it takes for the Ledger to create your wallet.
+
+4. You only have to use the `--generate-from-device` flag once (i.e. upon wallet creation). Thereafter, you'd basically use it similar to how you normally use the CLI. That is:
+   1. Make sure your Ledger is plugged in and the Monero app is running.
+   2. Open `monero-wallet-cli`.
+   3. Enter the wallet name of your Ledger Monero wallet.
+   4. Enter the password to open the wallet.
+
+   If the Ledger wallet files are not in the same directory as `monero-wallet-cli`, you ought to open `monero-wallet-cli` with the `--wallet-file /path/to/wallet.keys/file` flag. Alternatively, you can copy the Ledger wallet files to the same directory as `monero-wallet-cli`.
+
+5. If you have any further questions or need assistance, please leave a comment to the orginal [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli) answer.
+
+Author: dEBRUYNE
+Secondary scribe: el00ruobuob

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -418,6 +418,7 @@ user-guides:
   prove-payment: Jak udowodnić płatność
   restore-from-keys: Przywracanie portfela za pomocą kluczy
   nicehash: Jak wydobywać Monero (XMR) bez sprzętu wydobywczego
+  ledger-wallet-cli: 
 
 roadmap:
   translated: "yes"

--- a/_i18n/pl/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/pl/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,165 @@
+{% assign version = '1.1.0' | split: '.' %}
+{% include disclaimer.html translated="false" version=page.version %}
+## How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
+
+### Table of Content
+
+* [1. Windows](#1-windows)
+* [2. Mac OS X](#2-mac-os-x)
+* [3. Linux](#3-linux)
+* [4. Final notes](#4-a-few-final-notes)
+
+### 1. Windows
+
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.3 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod.exe`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monerod.exe and monero-wallet-cli.exe are located.
+
+2. Open a new command prompt / powershell. This is done by first making sure your cursor isn't located on any of the files and subsequently doing SHIFT + right click. It will give you an option to "Open command window here". If you're using Windows 10 in latest version, it'll give you an option to "open the PowerShell window here".
+
+3. Now type:
+
+`monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 10)
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 10)
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 2. Mac OS X
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.2 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Note that the instructions for system configuration (section 3.2.2) on Mac OS X are quite elaborate and can be perceived as slightly convoluted. Fortunately, tficharmers has created a guide [here](https://monero.stackexchange.com/questions/8438/how-do-i-make-my-macos-detect-my-ledger-nano-s-when-plugged-in) that you can use for assistance.
+
+5. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+6. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Use Finder to browse to the directory / folder `monero-wallet-cli` (CLI v0.12.2.0) is located.
+
+2. Go to your desktop.
+
+3. Open a new terminal (if don't know how to open a terminal, see [here](https://apple.stackexchange.com/a/256263)).
+
+4. Drag `monero-wallet-cli` in the terminal. It should add the full path to the terminal. Do not hit enter.
+
+5. Now type:
+
+`--generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`--generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+Note that aforementioned text will be appended to the path of `monero-wallet-cli`. Thus, before you hit enter, your terminal should look like:
+
+`/full/path/to/monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Where the full path is, intuitively, the actual path on your Mac OS X.
+
+7. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+8. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+9. You may have to hit confirm twice before it proceeds.
+
+10. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+11. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+12. Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 3. Linux
+We first have to ensure that we're sufficiently prepared. This entails the following:
+
+1. This guide assumes you have already initialized your Ledger wallet and thus generated a 24 word mnemonic seed.
+
+2. You need to run / use CLI v0.12.2.0, which can be found <a href="{{site.baseurl}}/downloads/">here</a>.
+
+3. You need to install the Ledger Monero app and configure your system. Instructions can be found [here](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (sections 3.1.1 and 3.2.1 in particular). In addition, make sure to set the network to `Mainnet`
+
+4. Your Ledger needs to be plugged in and the Ledger Monero app should be running.
+
+5. Either your daemon (`monerod`) should be running and preferably be fully synced or you should connect to a remote node.
+
+Now that we're sufficiently prepared, let's start!
+
+1. Go to the directory / folder monero-wallet-cli and monerod are located.
+
+2. Open a new terminal
+
+3. Now type:
+
+`./monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Note that is simply a placeholder for the actual wallet name. If you, for instance, want to name your wallet `MoneroWallet`, the command would be as follows:
+
+`./monero-wallet-cli --generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+4. The CLI will, after executing aforementioned command, prompt your for a password. Make sure to set a strong password and confirm it thereafter.
+
+5. The Ledger will ask whether you want to export the private view key or not. First and foremost, your funds cannot be compromised with merely the private view key. Exporting the private view key enables the client (on the computer - Monero v0.12.2.0) to scan blocks looking for transactions that belong to your wallet / address. If this option is not utilized, the device (Ledger) will scan blocks, which will be significantly slower. There is, however, one caveat. That is, if your system gets compromised, the adversary will potentially be able to compromise your private view key as well, which is detrimental to privacy. This is virtually impossible when the private view key is not exported.
+
+6. You may have to hit confirm twice before it proceeds.
+
+7. Your Ledger Monero wallet will now be generated. Note that this may take up to 5-10 minutes. Furthermore, there will be no immediate feedback in the CLI nor on the Ledger.
+
+8. `monero-wallet-cli` will start refreshing. Wait until it has fully refreshed.
+
+Congratulations, you can now use your Ledger Monero wallet in conjunction with the CLI.
+
+### 4. A few final notes
+
+1. We'd strongly advise to test the full process first. That is, send a small amount to the wallet and subsequently restore it (using aforementioned guide) to verify that you can recover the wallet. Note that, upon recreating / restoring the wallet, you ought to append the `--restore-height` flag (with a block height before the height of your first transaction to the wallet) to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux). More information about the restore height and how to approximate it can be found [here](https://monero.stackexchange.com/questions/7581/what-is-the-relevance-of-the-restore-height).
+
+2. If you use a remote node, append the `--daemon-address host:port` flag to the command in step 3 (Windows), step 5 (Mac OS X), or step 3 (Linux).
+
+3. If desired, you can manually tweak the `--subaddress-lookahead` value. The first value is the number of accounts and the second value is the number of subaddresses per account. Thus, if you, for instance, want to pregenerate 5 accounts with 100 subaddresses each, use `--subaddress-lookahead 5:100`. Bear in mind that, the more subaddresses you pregenerate, the longer it takes for the Ledger to create your wallet.
+
+4. You only have to use the `--generate-from-device` flag once (i.e. upon wallet creation). Thereafter, you'd basically use it similar to how you normally use the CLI. That is:
+   1. Make sure your Ledger is plugged in and the Monero app is running.
+   2. Open `monero-wallet-cli`.
+   3. Enter the wallet name of your Ledger Monero wallet.
+   4. Enter the password to open the wallet.
+
+   If the Ledger wallet files are not in the same directory as `monero-wallet-cli`, you ought to open `monero-wallet-cli` with the `--wallet-file /path/to/wallet.keys/file` flag. Alternatively, you can copy the Ledger wallet files to the same directory as `monero-wallet-cli`.
+
+5. If you have any further questions or need assistance, please leave a comment to the orginal [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli) answer.
+
+Author: dEBRUYNE
+Secondary scribe: el00ruobuob

--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -76,6 +76,7 @@ title: titles.userguides
                             <a href="{{site.baseurl}}/resources/user-guides/remote_node_gui.html">{% t user-guides.remote-node-gui %}</a>
                             <a href="{{site.baseurl}}/resources/user-guides/view_only.html">{% t user-guides.view-only %}</a>
                             <a href="{{site.baseurl}}/resources/user-guides/prove-payment.html">{% t user-guides.prove-payment %}</a>
+                            <a href="{{site.baseurl}}/resources/user-guides/ledger-wallet-cli.html">{% t user-guides.ledger-wallet-cli %}</a>
                         </p>
                     </div>
                 </div>

--- a/resources/user-guides/ledger-wallet-cli.md
+++ b/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,11 @@
+---
+layout: user-guide
+title: "How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)"
+permalink: /resources/user-guides/ledger-wallet-cli.html
+mainVersion:
+  - "1"
+  - "1"
+  - "0"
+---
+
+{% tf resources/user-guides/ledger-wallet-cli.md %}


### PR DESCRIPTION
This is a new user-guide based on @dEBRUYNE-1 [How do I generate a Ledger Monero wallet with the CLI (monero-wallet-cli)?](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli) StackExchange Q&A, as i told i'll do on [twitter](https://twitter.com/boubour_/status/1004106259937849344).

A few corrections have been applied :
+ De-personalized (s/"I"/"We"/g)
+ Download links moved to getmonero.org instead of GitHub
+ Typo Correction
  - Mac OS referring to GUI 0.12.1.0 instead of CLI 0.12.2.0
  - Monero v0.12.1.0 mentioned instead of v0.12.2.0
  - s/cavaet/caveat/g
+ Precision on installation section of Ledger Monero app guide for windows
+ Update the "need assistance" final note to link to the StackExchange answer.

And i already translated it in French.