### PR TITLE
Translation of es.yml

### DIFF
--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1,4 +1,4 @@
-langs:
+﻿langs:
   en: English
   es: Español
   it: Italiano
@@ -7,21 +7,21 @@ langs:
   ar: العربية
 
 global:
-  date: '%Y/%m/%d'
+  date: '%d/%m/%Y'
   monero: Monero
-  getting_started: Getting Started
+  getting_started: Para Empezar
   copyright: Copyright
-  monero_project: The Monero Project
-  sitename: getmonero.org, The Monero Project
+  monero_project: El Proyecto Monero
+  sitename: getmonero.org, El Proyecto Monero
   wiki: Moneropedia
-  tags: Articles By Tag
-  wikimeta: on Moneropedia, the open encyclopedia of Monero knowledge
-  tagsmeta: All Monero blog articles that are tagged
-  titlemeta: on the home of Monero, a digital currency that is secure, private, and untraceable
-  terms: Terms
-  privacy: Privacy
+  tags: Artículos por Etiqueta
+  wikimeta: en Moneropedia, La enciclopedia abierta de Monero
+  tagsmeta: Todo artículo del blog Monero que está etiquetado
+  titlemeta: página de inicio de Monero, una moneda digital que es segura, privada e imposible de rastrear
+  terms: Términos
+  privacy: Privacidad
   copyright: Copyright
-  untranslated: Esta pagina is not yet translated. If you would like to help translate it, please see the
+  untranslated: Esta página aún no ha sido traducida. Si deseas ayudar a traducirla, por favor lee el archivo
   outdatedMax: Esta página no está actualizada. No recomendamos utilizarla. En su lugar, favor de ver la
   outdatedVersion: versión en inglés
   outdatedMin: Esta página ha sido actualizada desde la traducción. Puedes utilizar esta versión, pero puede estar incompleta.
@@ -36,7 +36,7 @@ titles:
   mining: Minar Monero
   faq: FAQ
   downloads: Descargas
-  allposts: All Blog Posts
+  allposts: Todas las publicaciones
   team: Equipo
   hangouts: Canales de comunicación
   events: Eventos
@@ -44,43 +44,43 @@ titles:
   merchants: Comerciantes y Servicios
   about: Sobre Monero
   roadmap: Hoja de ruta
-  researchlab: Laboratorio de investigación de Monero (MRL)
+  researchlab: Laboratorio de Investigación de Monero (MRL)
   moneropedia: Moneropedia
   userguides: Guías de usuario
   developerguides: Guías de desarrolladores
   technicalspecs: Especificaciones técnicas
-  themoneroproject: The Monero Project
-  presskit: Monero Press Kit
+  themoneroproject: El Proyecto Monero
+  presskit: Kit de Prensa de Monero
   legal: Legal
-  ffs: Forum Funding System
-  ffs-cp: Completed Proposals
-  ffs-fr: Funding Required
+  ffs: Sistema de Financiamiento Colectivo
+  ffs-cp: Propuestas Completadas
+  ffs-fr: Financiamiento Requerido
   ffs-ideas: Ideas
-  ffs-ot: Open Tasks
-  ffs-wip: Work in Progress
-  blogbytag: Blog by Tag
+  ffs-ot: Tareas Abiertas
+  ffs-wip: Trabajo en Proceso
+  blogbytag: Blog por Etiqueta
   library: Librería
 
 index:
-  page_title: "Monero - secure, private, untraceable"
+  page_title: "Monero - seguro, privado e imposible de rastrear"
 
 home:
-  translated: "no"
+  translated: "yes"
   heading2: Moneda digital privada
-  monero_is_cash: Monero es una moneda privada, segura y no rastreable. Es de código abierto y está disponible para todos. Con Monero, tú eres tu propio banco. Sólo tú controlas tus finanzas. Tus cuentas y transacciones están protegidas de ojos curiosos.
+  monero_is_cash: Monero es dinero en efectivo para un mundo en conexión. Es rápido, privado y seguro. Con Monero, tú eres tu propio banco. Puedes utilizarlo con seguridad, sabiendo que otros no pueden conocer tu balance ni rastrear tus actividades.
   get_started: Comenzar
   why_monero_is_different: Por qué Monero es diferente
-  monero_is_secure: Monero es segura
-  monero_is_secure_para: Monero es una criptomoneda descentralizada. Es decir, es dinero digital seguro operado por su propia red de usuarios. Las transacciones son confirmadas por consenso distribuido y luego registradas inmutablemente en la cadena de bloques. De esta manera, mantiene tu dinero seguro sin necesidad de terceras partes.
-  monero_is_private: Monero es privada
-  monero_is_private_para: Monero usa las tecnologías de firmas de círculo y transacciones confidenciales de círculo (RingCT) para ofuscar el importe, orígen y destino cada transacción. Monero ofrece los beneficios de una criptomoneda descentralizada sin comprometer la privacidad.
-  monero_is_untraceable: Monero is untraceable
-  monero_is_untraceable_para: Sending and receiving addresses as well as transacted amounts are obfuscated by default. Transactions on the Monero blockchain cannot be linked to a particular user or real-world identity.
+  monero_is_secure: Monero es Seguro
+  monero_is_secure_para: Monero es una criptomoneda descentralizada. Es decir, es dinero digital seguro operado por su propia red de usuarios. Las transacciones son confirmadas por consenso distribuido y luego registradas inmutablemente en la blockchain. De esta manera, mantiene tu dinero seguro sin necesidad de terceros.
+  monero_is_private: Monero es Privado
+  monero_is_private_para: Monero usa las tecnologías de firmas circulares y transacciones confidenciales circulares (RingCT) para ocultar el importe, origen y destino cada transacción. Monero ofrece los beneficios de una criptomoneda descentralizada sin comprometer la privacidad.
+  monero_is_untraceable: Monero es imposible de rastrear
+  monero_is_untraceable_para: Las direcciones del emisor y receptor, al igual que la cantidad de la transacción, se ocultan por defecto. Las transacciones en la blockchain de Monero no pueden ser enlazadas a un usuario en particular o alguna entidad del mundo real.
   monero_is_fungible: Monero es fungible
   monero_is_fungible_para1: Monero es
   monero_is_fungible_para2: fungible
-  monero_is_fungible_para3: porque es privada por defecto. Eso provoca que unidades de Monero no pueden ser etiquetadas o deprivadas de su valor por provenir de transacciones específicas.
-  downloads: Downloads
+  monero_is_fungible_para3: porque es privado por defecto. Las unidades de Monero no puedan ser puestas en lista negra por vendedores o centros de compra/venta debido a alguna relación con transacciones anteriores.
+  downloads: Descargas
   downloads_windows: Monero para Windows
   downloads_mac: Monero para Mac
   downloads_linux: Monero para Linux
@@ -91,77 +91,77 @@ home:
   more_news: Más noticias
   moneropedia: Moneropedia
   moneropedia_para: ¿Quieres ver las definiciones de términos y conceptos usados en Monero? Aquí encontrarás una lista alfabética de términos de los proyectos Monero y Kovri y sus significados.
-  moneropedia_button: Leer Moneropedia
+  moneropedia_button: Ver la Wiki
   user_guides: Guías de usuario
-  user_guides_para: Guías que describen varios procesos paso a paso, separadas por categoría. Cubren todo desde cómo crear una billetera, a cómo editar este mismo sitio web.
-  user_guides_button: Ver guías de usuario
+  user_guides_para: Guías que describen varios procesos paso a paso, separadas por categoría. Cubren todo desde cómo crear un monedero, hasta cómo editar este mismo sitio web.
+  user_guides_button: Ver Guías
   faq: FAQ
-  faq_para: Hemos escuchado muchas preguntas a lo largo de los años y hemos compilado un FAQ variado y detallado para tu conveniencia. No te preocupes, si tus preguntas no están aquí, puedes hacerlas por los canales de comunicación de la comunidad.
-  faq_button: Ver respuestas
+  faq_para: Hemos compilado un FAQ específico y variado de las preguntas que han surgido a lo largo del tiempo. Si tienes alguna duda, puedes hacer tu pregunta a través de los canales de comunicación de la comunidad.
+  faq_button: Ver FAQ
 
 hangouts:
-  translated: "no"
-  intro: The Monero community is diverse and varied. We come from all over, but we definitely have some places we like to hang out together. You'll find most of them below. Join us!
-  resources: Workgroup Resources
-  resources_para: In an effort to support organic workgroups, Monero has several resources that the community can use to meet and plan projects. Mattermost even has relays into the most popular Monero-related IRC channels.
-  irc: IRC Channels
-  irc_para: The Monero community utilizes a lot of IRC channels that each serve different purposes. Some to work, and some just to hang out. You'll find the more popular ones below.
+  translated: "yes"
+  intro: La comunidad de Monero es diversa y variada. Venimos de todas partes, y tenemos esos lugares que nos gustan para pasar el rato. A continuación encontrarás la mayoría de ellos. ¡Únete a nosotros!
+  resources: Recursos del Grupo de Trabajo
+  resources_para: En un esfuerzo para apoyar grupos de trabajo, Monero tiene recursos considerables que la comunidad puede utilizar para cumplir y planificar proyectos. Mattermost tiene retransmisiones en los canales más populares de Monero en IRC.
+  irc: Canales IRC
+  irc_para: La comunidad de Monero utiliza muchos canales IRC que sirven para diferentes propósitos. Algunos para trabajo, y otros sólo para pasar el rato. A continuación encontrarás los canales más populares.
   stack_exchange: Stack Exchange
-  stack_exchange_para: The Monero Stack Exchange is a quick and easy way to ask questions and get answers. Below you'll find some high quality question/answer pairs to some frequently asked questions.
-  stack_exchange_link: Visit Stack Exchange
+  stack_exchange_para: El Stack Exchange de Monero es una forma rápida y sencilla de preguntar y recibir respuestas. A continuación encontrarás varios pares de pregunta/respuesta a algunas preguntas frecuentes.
+  stack_exchange_link: Visitar el Stack Exchange
   irc_channels:
   - channel: monero
-    description: This channel is used to discuss all things Monero related.
+    description: Este canal es utilizado para discutir todas las cosas relacionadas con Monero.
   - channel: monero-community
-    description: This channel is for the Monero community to congretate and discuss ideas.
+    description: Este canal lo utiliza la comunidad de Monero para reunirse y discutir ideas.
   - channel: monero-dev
-    description: The many contributors and developers come here to discuss dev-y things.
+    description:  Los contribuidores y desarrolladores vienen aquí a discutir asuntos de desarrollo.
   - channel: monero-markets
-    description: We use this channel to talk about the price of Monero and other coins.
+    description: Usamos este canal para hablar acerca del precio de Monero y otras monedas.
   - channel: monero-offtopic
-    description: Chatting with other Monero users about things not related to Monero.
+    description: Para hablar con otros usuarios acerca de cosas no relacionadas a Monero.
   - channel: monero-otc
-    description: Over the counter Monero. Come here to purchase XMR from your fellow Moneron.
+    description: Monero sobre la mesa (Over The Counter). Entra aquí para comprar XMR de tu compañeros de Monero.
   - channel: monero-pools
-    description: This is the place for mining questions and discussion.
+    description: Lugar para preguntas y discusiones de minado.
   - channel: monero-research-lab
-    description: Research into financial privacy with cryptocurrency.
+    description: Investiga sobre privacidad financiera con criptomonedas.
   - channel: monero-translations
-    description: Localizing Monero into other languages.
+    description: Localizar Monero en otros idiomas.
   - channel: monero-hardware
-    description: Building hardware wallets to keep your Monero safe.
+    description: Construir monederos hardware para mantener tu Monero seguro.
   - channel: kovri
-    description: This channel is used to discuss all things Kovri related.
+    description: Canal utilizado para discutir cualquier cosa relacionada a Kovri.
   - channel: kovri-dev
-    description: The many contributors and developers come here to discuss Kovri dev-y things.
+    description: Los contribuidores y desarroladores vienen aquí a discutir asuntos de desarrollo sobre Kovri.
 
 merchants:
-  translated: "no"
-  intro1: Merchants of all kinds have come to value the financial privacy that Monero brings. Below is a list of the merchants that we know of that currently accept Monero for their goods and services. If a company no longer accepts Monero or you would like your business to be listed, please
-  intro2:  open a GitHub issue and let us know.
+  translated: "yes"
+  intro1: Comerciantes de todo tipo han llegado a valorar la privacidad financiera que Monero provee. A continuación se muestra una lista de comerciantes que aceptan Monero actualmente a cambio de sus bienes y servicios. Si una compañía ya no acepta Monero o te gustaría que tu negocio aparezca en la lista, puedes
+  intro2:  abrir un caso en GitHub.
   disclaimer: |
-    "Please note: these links are being provided as a convenience and for informational purposes only; they do not constitute an endorsement by the Monero community of any products, services or opinions of the corporations or organizations or individuals listed. The Monero community bears no responsibility for the accuracy, legality, or content of these external sites. Contact the external site for answers to questions regarding its content. As always, caveat emptor ('buyer beware'); you are responsible for doing your own research. Always use judgement when making online purchases."
+    "Tenga en cuenta: estos enlaces están siendo provistos como una conveniencia y por propósitos informativos solamente; no constituyen un acto de aprobación por la comunidad de Monero de ningún producto, servicio u opinión de las corporaciones, organizaciones o individuos listados. La comunidad de Monero no tiene responsabilidad de la exactitud, legalidad o contenido de estos sitios externos. Contacte el sitio externo para respuestas a preguntas respecto a sus contenidos. Cada individuo es responsable de su propia investigación, o en otras palabras, caveat emptor (dejar que el comprador se preocupe). Siempre utilice su juicio cuando realice compras en línea."
 
 sponsorships:
-  translated: "no"
-  intro: The following businesses have supported the Monero Project in its goal to bring financial privacy to the world. We couldn't be more grateful for their contributions. If you would like to sponsor the Monero Project and be listed on this page, please send an email to dev@getmonero.org.
+  translated: "yes"
+  intro: Los siguientes negocios han dado soporte al proyecto Monero en su meta de brindar privacidad financiera al mundo. No podríamos estar más agradecidos por sus contribuciones. Si deseas patrocinar el proyecto Monero y ser listado en esta página, favor de enviar un email a dev@getmonero.org.
 
 team:
-  translated: "no"
-  core: Core
-  developers: Developers
-  developers_para1: he Monero Project has had well over 400 contributors over the life of the project. For a complete list, please see the
-  developers_para2: OpenHub contributors page.
-  developers_para3: Below you'll find some individuals that have gone above and beyond for Monero.
-  community: Community
-  mrl: Research Lab
-  thanks: Special Thanks
+  translated: "yes"
+  core: Equipo Central
+  developers: Desarrolladores
+  developers_para1: El Proyecto Monero ha tenido más de 400 contribuyentes durante la vida del proyecto. Para la lista completa, favor de ver la
+  developers_para2: página de contribuyentes de OpenHub.
+  developers_para3: A continuación encontrarás algunos individuos que han ido lejos por Monero.
+  community: Comunidad
+  mrl: Lab de Investigación
+  thanks: Reconocimientos
 
 downloads:
   translated: "yes"
-  choose: Elija su sistema operativo
-  sourceblockchain: Source & Blockchain
-  mobilelight: Mobile & Light
+  choose: Seleccione su sistema operativo
+  sourceblockchain: Archivos Fuente y Blockchain
+  mobilelight: Versiones Móvil
   hardware: Hardware
   intro1: Si necesita ayuda para elegir la aplicación correcta, haga clic
   intro2: aquí
@@ -169,365 +169,365 @@ downloads:
   note1: "Nota: para mayor comodidad los hashes SHA256 se enumeran por las descargas, pero una lista GPG firmada de los hash está en"
   note2: y debe tratarse como canónico, con la firma marcada con la clave GPG apropiada en el código fuente (en /utils/gpg_keys).
   currentversion: Versión actual
-  sourcecode: Código fuente
-  blockchain1: Si prefieres usar un blockchain bootstrap, en lugar de sincronizar desde cero, puedes
-  blockchain2: usar este enlace para el programa de arranque más reciente.
-  blockchain3: Sin embargo, normalmente es mucho más rápido sincronizar desde cero y también requiere menos RAM (la importación es muy exigente).
-  hardware1: La comunidad Monero acaba de financiar una
-  hardware2: Cartera de Hardware Dedicado
+  sourcecode: Código Fuente
+  blockchain1: Si prefieres realizar un bootstrap para sincronizar la blockchain, puedes utilizar
+  blockchain2: este enlace
+  blockchain3: para el programa de arranque más reciente. Sin embargo, normalmente es mucho más rápido sincronizar desde cero y también requiere menos RAM (la importación es muy exigente).
+  hardware1: La comunidad Monero acaba de financiar un
+  hardware2: Monedero de Hardware Dedicado
   hardware3: que ya está en progreso. Además, el libro principal está trabajando en la
-  hardware4: integración de Monero en sus carteras de hardware.
-  mobilelight1: Los siguientes son carteras móviles o livianas que los miembros de confianza de la comunidad consideran seguros. Si hay una cartera que no está aquí, puede solicitar que la comunidad la revise. Ve a nuestra
-  mobilelight2: página de Hangouts
-  mobilelight3:  para ver dónde.
-  clionly: Command-Line Tools Only
+  hardware4: integración de Monero en sus monederos de hardware.
+  mobilelight1: Los siguientes son monederos móviles y livianos que los miembros de confianza de la comunidad consideran seguros. Si hay un monedero que no está aquí, puedes solicitar que la comunidad lo revise. Ve a nuestra página de
+  mobilelight2: Medios de Comunicación
+  mobilelight3:  para ver en dónde realizar la petición.
+  clionly: v. Consola de Comandos
 
 monero-project:
-  translated: "no"
-  kovri: The Kovri project uses end-to-end encryption so that neither the sender nor receiver of a Monero transaction need to reveal their IP address to the other side or to third-party observers (the blockchain). This is done using the same technology that powers the dark net, i2p (Invisible Internet Protocol). The project is currently in heavy, active development and is not yet integrated with Monero.
-  kovri_button: Visit Kovri Website
-  openalias: The OpenAlias project simplifies cryptocurrency payments by providing FQDNs (Fully Qualified Domain Names, i.e. example.openalias.org) for Monero wallet addresses in a way that ensures everyone's privacy is secure. The project is well underway and has already been implemented in many Monero wallets.
-  openalias_button: Visit OpenAlias Website
+  translated: "yes"
+  kovri: El proyecto Kovri utiliza encriptación de extremo a extremo para que quien envía o recibe Monero en una transacción no necesite revelar su dirección IP al otro lado ni a un tercer observador (la blockchain). Esto se logra utilizando la misma tecnología que potencia la dark net, i2p (Invisible Internet Protocol, protocolo de internet invisible). El proyecto está actualmente en desarrollo activo y dedicado y no está integrado a Monero aún.
+  kovri_button: Visitar Kovri
+  openalias: El proyecto OpenAlias simplifica los pagos de criptomonedas proveyendo FQDNs (Fully Qualified Domain Names, e.g. example.openalias.org) para direcciones de monederos Monero en una forma que asegura que la privacidad de todos sea segura. El proyecto está en marcha y ya ha sido implementado en algunos monederos de Monero.
+  openalias_button: Visitar OpenAlias
 
 press-kit:
-  translated: "no"
-  intro1: Here you'll find the Monero symbol and logo below. You can choose any size that you want, or download the .ai file to mess with the logo yourself.
-  intro2: Note that the white background options have a white background under the Monero symbol ONLY, not as a background to the whole image.
-  intro3: Lastly, you can download everything on this page in one zip file by clicking
-  intro4: here.
-  noback: No background
-  whiteback: White background
-  symbol: Monero Symbol
-  logo: Monero Logo
-  small: Small
-  medium: Medium
-  large: Large
-  symbol_file: Symbol .ai file
-  logo_file: Logo .ai file
+  translated: "yes"
+  intro1: Aquí encontrarás el símbolo y logo de Monero. Puedes elegir el tamaño que desees, o descargar el archivo .ai para experimentar con el logo personalmente.
+  intro2: Tenga en cuenta que las opciones de fondo blanco tienen un fondo blanco bajo el símbolo de Monero solamente, no de la imagen completa.
+  intro3: Finalmente, puedes descargar cualquier cosa en esta página en un archivo ZIP presionando
+  intro4: aquí.
+  noback: Sin fondo
+  whiteback: Fondo blanco
+  symbol: Símbolo de Monero
+  logo: Logo de Monero
+  small: Pequeño
+  medium: Mediano
+  large: Grande
+  symbol_file: Símbolo en archivo .ai
+  logo_file: Logo en archivo .ai
 
 accepting:
-  translated: "no"
-  title: Instructions for the Command-Line Interface
-  basics: The Basics
-  basics_para1: Monero works a little differently to what you may have become accustomed to from other @cryptocurrencies. In the case of a digital currency like Bitcoin and its many derivatives merchant payment systems will usually create a new recipient @address for each payment or user.
-  basics_para2: However, because Monero has @stealth-addresses there is no need to have separate recipient addresses for each payment or user, and a single @account address can be published. Instead, when receiving payments a merchant will provide the person paying with a "payment ID".
-  basics_para3: "A @payment-ID is a hexadecimal string that is 64 characters long, and is normally randomly created by the merchant. An example of a payment ID is:"
-  checking: Checking for a Payment in monero-wallet-cli
+  translated: "yes"
+  title: Instrucciones para la interface de Consola de Comandos
+  basics: Lo Básico
+  basics_para1: Monero trabaja un poco distinto a lo que puedes estar acostumbrado de otras criptomonedas. En el caso de dinero digital como Bitcoin y sus diversos sistemas de pago mercantil derivados que usualmente crean una nueva dirección recipiente (@address) por cada pago o usuario.
+  basics_para2: No obstante, debido a que Monero cuenta con direcciones de sigilo (@stealth-addresses) no existe la necesidad de tener direcciones recipientes separadas para cada pago o usuario, y una simple cuenta (@account) puede ser publicada. En su lugar, cuando un comerciante recibes pagos proveerá al comprador con una "ID de pago".
+  basics_para3: " Un ID de pago (@payment-ID) es una cadena hexadecimal de 64 caracteres de longitud, y es creada aleatoriamente por el comerciante. Un ejemplo de una ID de pago es:"
+  checking: Revisar por un pago en monero-wallet-cli
   checking_para1: |
-    If you want to check for a payment using monero-wallet-cli you can use the "payments" command followed by the payment ID or payment IDs you want to check. For example:
-  checking_para2: If you need to check for payments programmatically, then details follow the next section.
-  receiving: Receiving a Payment Step-by-Step
-  receiving_list1: Generate a random 64 character hexadecimal string for the payment
-  receiving_list2: Communicate the payment ID and Monero address to the individual who is making payment
-  receiving_list3: Check for the payment using the "payments" command in monero-wallet-cli
-  program: Checking for a Payment Programmatically
-  program_para1: In order to check for a payment programmatically you can use the get_payments or get_bulk_payments JSON RPC API calls.
-  program_para2: this requires a payment_id parameter with a single payment ID.
-  program_para3: this is the preferred method, and requires two parameters, payment_ids - a JSON array of payment IDs - and an optional min_block_height - the block height to scan from.
+    Si deseas revisar algún pago usando monero-wallet-cli, puedes utilizar el comando "payments" seguido de el o los ID de pago que deseas revisar. Por ejemplo:
+  checking_para2: Si necesitas revisar pagos de manera programada, los detalles se encuentran en la siguiente sección.
+  receiving: Recibiendo un pago paso-a-paso
+  receiving_list1: Generar una cadena hexadecimal aleatoria de 64 caracteres para el pago
+  receiving_list2: Compartir el ID de pago y la dirección de Monero al individuo que estará haciendo el pago
+  receiving_list3: Revisar por el pago utilizando el comando "payments" en monero-wallet-cli
+  program: Revisando por pagos de manera programada
+  program_para1: En orden para revisar un pago de manera programada puedes utilizar una llamada JSON RPC API "get_payments" o "get_bulk_payments".
+  program_para2: esto requiere un parámetro del ID de pago con un solo ID de pago.
+  program_para3: este es el método preferido y requiere dos parámetros, payment_ids - un arreglo JSON de IDs de pago - y opcionalmente min_block_height - la altura del bloque para escanear.
   program_para4: |
-    An example of returned data is as follows:
-  program_para5: It is important to note that the amounts returned are in base Monero units and not in the display units normally used in end-user applications. Also, since a transaction will typically have multiple outputs that add up to the total required for the payment, the amounts should be grouped by the tx_hash or the payment_id and added together. Additionally, as multiple outputs can have the same amount, it is imperative not to try and filter out the returned data from a single get_bulk_payments call.
-  program_para6: Before scanning for payments it is useful to check against the daemon RPC API (the get_info RPC call) to see if additional blocks have been received. Typically you would want to then scan only from that received block on by specifying it as the min_block_height to get_bulk_payments.
-  scanning: Programatically Scanning for Payments
-  scanning_list1: Get the current block height from the daemon, only proceed if it has increased since our last scan
-  scanning_list2: Call the get_bulk_payments RPC API call with our last scanned height and the list of all payment IDs in our system
-  scanning_list3: Store the current block height as our last scanned height
-  scanning_list4: Remove duplicates based on transaction hashes we have already received and processed
+    Un ejemplo de datos devueltos es el siguiente:
+  program_para5: Es importante tener en cuenta que las cantidades devueltas están en base a unidades de Monero y no en unidades de visualización normalmente utilizadas en aplicaciones para el usuario final. Además, debido a que una transacción típicamente tendrá múltiples salidas que sumarán el total requerido para el pago, las cantidades deberán ser agrupadas por tx_hash o payment_id y sumadas al total. Adicionalmente, como múltiples salidas pueden tener la misma cantidad, es imperativo el no intentar filtrar la información devuelta de una salida con "get_bulk_payments".
+  program_para6: Antes de escanear por pagos es útil revisar el RPC API del daemon (con la llamada "get_info RPC") para ver si han sido recibidos bloques adicionales. En situaciones típicas querrás escanear solamente el bloque recibido especificándolo con min_block_heigh para obtener información de get_bulk_payments.
+  scanning: Escanear de manera programada por pagos
+  scanning_list1: Obtener la altura actual de bloque del daemon, proceder solamente si ha aumentado desde el último escaneo
+  scanning_list2: Llama el comando get_bulk_payments RPC API con la última altura de bloque y la lista de todos los ID de pago en el sistema
+  scanning_list3: Guarda la altura de bloque actual como el último valor de altura de bloque escaneado
+  scanning_list4: Remueve duplicados en base a hashes de transacciones que ya hemos recibido y procesado
 
 contributing:
-  translated: "no"
-  intro: Monero is an open-source, community-driven project. Described below are several ways to support the project.
-  network: Support the Network
-  develop: Develop
-  develop_para1: Monero is primarily written in C++. As it is a decentralized project, anyone is welcome to add or make changes to existing code. Pull requests are merged based on community consensus. See the
-  develop_para2: repositories
-  develop_para3: and outstanding
-  develop_para4: issues.
-  full-node: Run a Full Node
-  full-node_para: Run monerod with port 18080 open. Running a full node ensures maximum privacy when transacting with Monero. It also improves distribution of the blockchain to new users.
-  mine: Mine
-  mine_para1: Mining ensures the Monero network remains decentralized and secure. In the Monero graphical user interface and command-line interface, background mining may be activated. Additional resources for mining may be viewed
-  mine_para2: here.
-  ffs: View the Forum Funding System
-  ffs_para1: Monero utilizes a
-  ffs_para2: forum funding system
-  ffs_para3: whereby projects are proposed for development and community-funded. Funding is held in escrow and remunerated to developers once programming milestones are achieved. Anyone may generate new proposals or fund existing ones.
-  donate: Donate
-  donate_para1: Ongoing development is supported by donations and
-  donate_para2: sponsorships.
-  donate-xmr: Donating Monero
-  donate-xmr_para: Donations may be sent to
-  or: or
-  donate-btc: Donating Bitcoin
-  donate-btc_para: Donations may be sent to
-  donate-other: Other
-  donate-other_para1: E-mail
-  donate-other_para2: for alternative means of donating or if you would like to become a sponsor for the Monero Project.
+  translated: "yes"
+  intro: Monero es un proyecto dirigido por la comunidad y de código abierto. A continuación hay algunas maneras de apoyar el proyecto.
+  network: Apoyar a la Red
+  develop: Desarrollar
+  develop_para1: Monero está escrito principalmente en C++. Como un proyecto descentralizado, cualquiera es bienvenido para agregar o hacer cambios al código existente. Solicitudes (pull requests) se combinan en base a un consenso de la comunidad. Vea los
+  develop_para2: repositorios
+  develop_para3: y los
+  develop_para4: problemas pendientes.
+  full-node: Correr un Nodo
+  full-node_para: Abre monerod con puerto 18080 abierto. Correr un nodo asegura máxima privacidad cuando se utiliza Monero para transacciones. Esto también mejora la distribución de la blockchain a nuevos usuarios.
+  mine: Minar
+  mine_para1: Minar asegura que la red de Monero siga descentralizada y segura. En la interface gráfica de usuario de Monero y la interface de consola de comandos, es posible activar el minado en segundo plano. Recursos adicionales para minar pueden ser vistos
+  mine_para2: aquí.
+  ffs: Ver el Sistema de Financiamiento Colectivo
+  ffs_para1: Monero utiliza un
+  ffs_para2: sistema de financiamiento colectivo
+  ffs_para3: en donde los proyectos son propuestos para desarrollo y son financiados por la comunidad. El financiamiento se almacena en escrow y se remunera a los desarrolladores cuando se cumple con las metas establecidas. Cualquiera puede hacer nuevas propuestas o financiar propuestas existentes.
+  donate: Donar
+  donate_para1: El desarrollo en curso está apoyado por donaciones y
+  donate_para2: patrocinadores.
+  donate-xmr: Donar Monero
+  donate-xmr_para: Donaciones pueden ser enviadas a
+  or: o
+  donate-btc: Donar Bitcoin
+  donate-btc_para: Donaciones pueden ser enviadas a
+  donate-other: Otro
+  donate-other_para1: Puedes enviar un correo electrónico a
+  donate-other_para2: para otras alternativas de donación o si deseas convertirte en un patrocinador del proyecto Monero.
 
 faq:
-  translated: "no"
-  q1: How does Monero have value?
-  a1: Monero has value because people are willing to buy it. If no one is willing to buy Monero, then it will not have any value. Monero’s price increases if demand exceeds supply, and it decreases if supply exceeds demand.
-  q2: How can I get Monero?
-  a2: You can buy Monero from an exchange or from an individual. Alternatively, you can try mining Monero to get coins from the block reward.
-  q3: What is a mnemonic seed?
-  a3: A mnemonic seed is a set of 25 words that can be used to restore your account anywhere. Keep these words safe and do not share them with someone else. You can use this seed to restore your account, even if your computer crashes.
-  q4: How is Monero’s privacy different from other coins?
+  translated: "yes"
+  q1: ¿Cómo es que Monero tiene valor?
+  a1: Monero tiene valor debido a que las personas están dispuestas a comprarlo. Si nadie está dispuesto a comprar Monero, entonces no tendría ningún valor. El precio de Monero sube si la demanda excede el suministro,  y baja si el suministro excede la demanda.
+  q2: ¿Cómo puedo obtener Monero?
+  a2: Puedes comprar Monero en un sitio de compra/venta de criptomonedas o de algún individuo. Otra manera es minar Monero para obtener monedas de la recompensa de bloque.
+  q3: ¿Qué es una semilla mnemónica (mnemonic seed)?
+  a3: Una semilla mnemónica es un conjunto de 25 palabras que pueden ser utilizadas para restaurar tu cuenta en cualquier lugar. Guarda estas palabras en un lugar seguro y no las compartas con nadie más. Puedes utilizar esta semilla para restablecer tu cuenta, incluso si tu ordenador se daña.
+  q4: ¿En qué es diferente la privacidad de Monero en diferencia a otras monedas?
   a4: |
-    Monero uses three different privacy technologies: ring signatures, ring confidential transactions (RingCT), and stealth addresses. These hide the sender, amount, and receiver in the transaction, respectively. All transactions on the network are private by mandate; there is no way to accidentally send a transparent transaction. This feature is exclusive to Monero. You do not need to trust anyone else with your privacy.
-  q5: Why is my wallet taking so long to sync?
-  a5: If you are running a full node locally, you need to copy the entire blockchain to your computer. This can take a long time, especially on an old hard drive or slow internet connection. If you are using a remote node, your computer still needs to request a copy of all the outputs, which can take several hours. Be patient, and if you would like to sacrifice some privacy for faster sync times, consider using a lightweight wallet instead.
-  q6: What is the difference between a lightweight and a normal wallet?
-  a6: For a lightweight wallet, you give your view key to a node, who scans the blockchain and looks for incoming transactions to your account on your behalf. This node will know when you receive money, but it will not know how much you receive, who you received it from, or who you are sending money to. Depending on your wallet software, you may be able to use a node you control to avoid privacy leaks. For more privacy, use a normal wallet, which can be used with your own node.
-  q7: How is Monero different from Bitcoin?
-  a7: Monero is not based on Bitcoin. It is based on the CryptoNote protocol. Bitcoin is a completely transparent system, where people can see exactly how much money is being sent from one user to another. Monero hides this information to protect user privacy in all transactions. It also has a dynamic block size and dynamic fees, an ASIC-resistant proof of work, and a tail coin emission, among several other changes.
-  q8: Does Monero have a block size limit?
-  a8: No, Monero does not have a hard block size limit. Instead, the block size can increase or decrease over time based on demand. It is capped at a certain growth rate to prevent outrageous growth.
-  q9: What is a blockchain?
-  a9: A blockchain is a system that stores a copy of all transaction history on the Monero network. Every two minutes, a new block with the latest transaction information is added to the blockchain. This chain allows the network to verify the amount of money accounts have and make it resilient to attacks and centralization attempts.
-  q10: What is Kovri?
-  a10: Kovri is an I2P router written in C++. I2P is a hidden network like Tor with several technical differences. Kovri is an independent project of Monero, but it will work with Monero and several other projects. Kovri hides the transaction broadcast, so other nodes do not know who created transactions. In adversarial conditions, Kovri can be used to hide all Monero traffic through I2P, which would prevent people from knowing Monero is being used. Kovri is currently in alpha, and it is not yet fully integrated in Monero. Learn more about Kovri at the <a href="https://getkovri.org">project website.</a>
-  q11: What is fungibility, and why is it important?
-  a11: Fungibility is a simple property of money such that there are no differences between two amounts of the same value. If two people exchanged a 10 and two 5’s, then no one would lose out. However, let’s suppose that everyone knows the 10 was previously used in a ransomware attack. Is the other person still going to make the trade? Probably not, even if the person with the 10 has no connection with the ransomware. This is a problem, since the receiver of money needs to constantly check the money they are receiving to not end up with tainted coins. Monero is fungible, which means people do not need to go through this effort.
-  q12: If Monero is so private how do we know they're not being created out of thin air?
-  a12-1: In Monero, every transaction output is uniquely associated with a key image that can only be generated by the holder of that output. Key images that are used more than once are rejected by the miners as double-spends and cannot be added to a valid block. When a new transaction is received, miners verify that the key image does not already exist for a previous transaction to ensure it's not a double-spend.
-  a12-2: We can also know that transaction amounts are valid even though the value of the inputs that you are spending and the value of the outputs you are sending are encrypted (these are hidden to everyone except the recipient). Because the amounts are encrypted using Pedersen commitments what this means is that no observers can tell the amounts of the inputs and outputs, but they can do math on the Pedersen commitments to determine that no Monero was created out of thin air.
-  a12-3: As long as the encrypted output amounts you create is equal to the sum of the inputs that are being spent (which include an output for the recipient and a change output back to yourself and the unencrypted transaction fee), then you have a legitimate transaction and know no Monero is being created out of thin air. Pedersen commitments mean that the sums can be verified as being equal, but the Monero value of each of the sums and the Monero value of the inputs and outputs individually are undeterminable.
+    Monero utiliza tres diferentes tecnologías de privacidad: firmas circulares, transacciones confidenciales circulares (RingCT), y direcciones de sigilo (stealth addresses). Estas tecnologías ocultan al remitente, la cantidad y al receptor en una transacción, respectivamente. Todas las transacciones en la red son privadas por mandato; no existe una forma de accidentalmente enviar una transacción transparente. Esta característica es exclusiva de Monero. No necesitas confiar en nadie más para tu privacidad.
+  q5: ¿Por qué mi monedero tarda mucho en sincronizar?
+  a5: Si estás corriendo un nodo entero, necesitas copiar la blockchain entera a tu ordenador. Esto puede tomar un largo tiempo, especialmente en discos duros viejos o conexión a internet lenta. Si estás usando un nodo remoto, tu ordenador necesita pedir una copia de todas las salidas de todas formas, y puede tardar varias horas. Sé paciente, y si quieres sacrificar algo de privacidad por una sincronización más rápida, considera utilizar un monedero ligero o móvil en su lugar.
+  q6: ¿Cuál es la diferencia entre un monedero ligero y uno normal?
+  a6: Para un monedero ligero, debes brindar tu llave de visualización a un nodo, que escanea la blockchain y busca transacciones de entrada a tu cuenta en tu lugar. Este nodo sabrá cuando recibas dinero, pero no sabrá cuánto recibes, de quién lo recibes, o a quién le envías dinero. Dependiendo en el software de tu monedero, puedes ser capaz de usar un nodo en tu control para evadir fugas en la privacidad. Para más privacidad, utiliza un monedero normal, que puede ser usado con tu propio nodo.
+  q7: ¿En qué difiere Monero de Bitcoin?
+  a7: Monero no está basado en Bitcoin. Monero está basado en el protocolo CryptoNote. Bitcoin es un sistema completamente transparente, en donde personas pueden saber exactamente cuánto dinero es enviado de un usuario a otro. Monero oculta esta información para proteger la privacidad del usuario en toda transacción. También cuenta con un tamaño dinámico de bloque y de cuotas, prueba de trabajo (proof-of-work) resistente a tecnología ASIC, emisión continua de monedas, entre otros cambios considerables.
+  q8: ¿Tiene Monero un tamaño límite de bloque?
+  a8: No, Monero no tiene un tamaño límite de bloque. En su lugar, el tamaño de bloque puede incrementarse o disminuir en el tiempo basado en la demanda. El tamaño está limitado a cierto ratio de crecimiento para prevenir un crecimiento descontrolado.
+  q9: ¿Qué es una blockchain?
+  a9: Una blockchain (cadena de bloques) es un sistema que guarda una copia de todo el historial de transacciones en la red de Monero. Cada dos minutos, un nuevo bloque con la última información de transacciones es agregado a la blockchain. Esta cadena permite a la red el verificar la cantidad de dinero que hay en las cuentas y así reducir la posibilidad de ataques y proyectos de centralización.
+  q10: ¿Qué es Kovri?
+  a10: Kovri es un enrutador I2P escrito en C++. I2P es una red oculta parecida a Tor con considerables diferencias técnicas. Kovri es un proyecto independiente de Monero, pero trabaja con Monero y otros considerables proyectos. Kovri oculta la emisión de la transacción, de forma que otros nodos no saben quién creó las transacciones. En condiciones adversas, Kovri puede ser utilizado para ocultar todo el tráfico de Monero a través de I2P, lo que puede prevenir que personas conozcan que se está utilizando Monero. Kovri está actualmente en alpha, y aún no está totalmente integrado en Monero. Conoce más sobre Kovri en <a href="https://getkovri.org">project website.</a>
+  q11: ¿Qué es fungibilidad, y por qué es tan importante?
+  a11: Fungibilidad es una sencilla propiedad del dinero que establece que no hay diferencias entre dos cantidades del mismo valor. Si dos personas intercambian un 10 y dos 5, entonces nadie saldrá perdiendo. No obstante, supongamos que todos saben que el 10 fue previamente utilizado en un ataque de ransomware. ¿La otra persona aun así hará el intercambio? Probablemente no, incluso si la persona con el 10 no tiene conexión al ataque de ransomware. Esto es un problema, ya que el receptor necesita revisar constantemente el dinero que está recibiendo para no terminar con monedas contaminadas. Monero es fungible, lo que significa que las personas no necesitan hacer todo ese esfuerzo.
+  q12: Si Monero es tan privado, ¿cómo sé que no está siendo creado de la nada?
+  a12-1: En Monero, cada transacción de salida está asociada únicamente con una llave de imagen que sólo puede ser generada por el dueño de esa transacción de salida. Llaves de imagen que son usadas más de una vez son rechazadas por mineros por doble uso y no pueden ser agregadas a un bloque válido. Cuando una nueva transacción es recibida, los mineros verifican que la llave imagen no exista para alguna transacción previa y aseguran que no sea una transacción repetida.
+  a12-2: También podemos saber que la cantidad de la transacción es válida incluso aunque el valor de las entradas que gastas y salidas que envías estén encriptadas (ocultas a todos excepto al receptor). Debido a que las cantidades están encriptadas con Pedersen, significa que terceros no pueden saber la cantidad de entradas o salidas, pero pueden hacer cálculos en Pedersen para determinar que ningún Monero haya sido creado de la nada.
+  a12-3: Siempre y cuando la cantidad encriptada de salidas que crees sea igual a la suma de las entradas que están siento utilizadas (lo que incluye la salida para el receptor, el cambio de vuelta para ti mismo y la no-encriptada cuota de transacción), entonces tienes una transacción legítima y sabes que Monero no ha sido creado de la nada. Pedersen significa que las sumas pueden ser verificadas como un igual, pero el valor de Monero de cada suma y de las entradas y salidas son indeterminables individualmente.
 
 mining:
-  translated: "no"
-  intro1: Monero is a cryptocurrency that relies on proof-of-work mining to achieve distributed consensus. Below you'll find some information and resources on how to begin mining.
-  intro2: The Monero Project does not endorse any particular pool, software, or hardware, and the content below is provided for informational purposes only.
-  support: Support
-  support_para1: See
-  support_para2: Hangouts,
-  support_para3: /r/moneromining (English)
-  support_para4: and
+  translated: "yes"
+  intro1: Monero es una criptomoneda que utiliza el minado por prueba-de-trabajo (proof-of-work) para lograr un consenso distribuido. A continuación encontrarás información y recursos para saber cómo empezar a minar.
+  intro2: El proyecto Monero no avala ningún software, hardware o pool en particular, y el contenido mostrado es provisto para propósitos informativos.
+  support: Apoyar
+  support_para1: Ver los
+  support_para2: Medios de Comunicación,
+  support_para3: /r/moneromining (Inglés)
+  support_para4: y
   pools: Pools
-  pools_para1: A listing of trusted Monero pools is found
-  pools_para2: here.
-  benchmarking: Hardware Benchmarking
-  benchmarking_para1: See here
-  benchmarking_para2: for a listing of GPUs/CPUs and their respective hashrates.
-  software: Mining Software
-  software_para: Note that some miners may have developer fees.
+  pools_para1: Una lista de pools de Monero confiables se encuentra
+  pools_para2: aquí.
+  benchmarking: Benchmarking de Hardware
+  benchmarking_para1: Ve aquí
+  benchmarking_para2: una lista de GPUs/CPUs y sus respectivos hashrates.
+  software: Software de Minado
+  software_para: Tenga en cuenta que algunos mineros pueden tener comisiones de desarrollador.
 
 using:
-  translated: "no"
-  intro: Transacting with Monero can be made easy. This page is designed to guide users in that process.
-  learn: 1. Learn
-  learn_para1: Monero is a secure, private, and untraceable cryptocurrency. The developers and community are committed to protecting these values. Learn more by reading the
-  learn_para2: What is Monero
-  learn_para3: page. The
-  learn_para4: source code
-  learn_para5: is also available for review and discussion.
-  support: 2. Request Support
-  support_para1: There is a large and supportive community that will assist if you experience any difficulty. See the
-  support_para2: Hangouts
-  support_para3: page for more information.
-  generate: 3. Generate a Wallet
-  generate_para1: A Monero wallet is required to secure your own funds. See the
-  generate_para2: Downloads page
-  generate_para3: for a listing of available wallets.
-  generate_para4: The easiest way to run a Monero node, without affecting your home bandwidth, is to purchase a VPS (Virtual Private Server). We strongly recommend
-  generate_para5: using the
-  generate_para6: coupon code to get a discount over and above their already cheap $6/month VPS. Using this coupon code and/or
-  generate_para7: our affiliate link
-  generate_para8: will also assist in the ongoing funding of Monero development.
-  acquire: 4. Acquire Monero
-  acquire_para1: Monero may be purchased on an
-  acquire_para2: exchange
-  acquire_para3: with fiat or other cryptocurrencies. An alternate way of acquiring Monero is via
-  acquire_para4: mining,
-  acquire_para5: the computationally-complex process whereby transactions are immutably recorded on the blockchain.
-  send-receive: 5. Send and Receive Monero
-  send-receive_para1: Learn how to send and receive Monero by viewing the
-  send-receive_para2: guide.
-  transact: 6. Transact with Monero
-  transact_para1: Monero may be used to purchase many goods and services. For a listing, see the
-  transact_para2: Merchants page.
+  translated: "yes"
+  intro: Realizar transacciones con Monero puede ser muy sencillo. Esta página fue diseñada para guiar a los usuarios en este proceso.
+  learn: 1. Aprender
+  learn_para1: Monero es una criptomoneda segura, privada y no rastreable. Los desarrolladores y la comunidad están comprometidos a proteger estos aspectos. Aprende más leyendo
+  learn_para2: ¿Qué es Monero?.
+  learn_para3: El
+  learn_para4: código fuente
+  learn_para5: también está disponible para revisión y discusión.
+  support: 2. Pedir apoyo
+  support_para1: Hay una grande y servicial comunidad que te puede asistir si experimentas alguna dificultad. Ve en los
+  support_para2: canales de comunicación
+  support_para3: para más información.
+  generate: 3. Generar un monedero
+  generate_para1: Se requiere un monedero de Monero para mantener seguros tus fondos. Ve la página de
+  generate_para2: descargas
+  generate_para3: para ver la lista de monederos disponibles.
+  generate_para4: La forma más fácil de correr un nodo de Monero sin afectar tu ancho de banda es comprando un VPS (Virtual Private Server). Recomendamos fuertemente
+  generate_para5: utilizando el código
+  generate_para6: para obtener un descuento sobre su ya bajo precio de $6 dólares por mes. Usando este código o nuestro
+  generate_para7: enlace de afiliación
+  generate_para8: también ayudará en el financiamiento actual del desarrollo de Monero.
+  acquire: 4. Adquirir Monero
+  acquire_para1: Monero puede ser comprado en un
+  acquire_para2: sitio de compra/venta
+  acquire_para3: con dinero efectivo u otras criptomonedas. Una forma alterna de adquirir monero es
+  acquire_para4: minando,
+  acquire_para5: que es el complejo proceso computacional en donde las transacciones son grabadas inmutablemente en la blockchain.
+  send-receive: 5. Enviar y recibir Monero
+  send-receive_para1: Aprende cómo enviar y recibir Monero viendo esta
+  send-receive_para2: guía.
+  transact: 6. Realiza transacciones con Monero
+  transact_para1: Monero puede ser utilizado para comprar varios bienes y servicios. Para el listado de ellos, ve la página de
+  transact_para2: comerciantes.
 
 what-is-monero:
-  translated: "no"
-  need-to-know: What you need to know
-  leading: Monero is the leading cryptocurrency with a focus on private and censorship-resistant transactions.
-  leading_para1: Most existing cryptocurrencies, including Bitcoin and Ethereum, have transparent blockchains, meaning that transactions are openly verifiable and traceable by anyone in the world. Furthermore, sending and receiving addresses for these transactions may potentially be linkable to a person's real-world identity.
-  leading_para2: Monero uses cryptography to shield sending and receiving addresses, as well as transacted amounts.
-  confidential: Monero transactions are confidential and untraceable.
-  confidential_para1: Every Monero transaction, by default, obfuscates sending and receiving addresses as well as transacted amounts. This always-on privacy means that every Monero user's activity enhances the privacy of all other users, unlike selectively transparent cryptocurrencies (e.g. Z-Cash).
-  confidential_para2: Monero is fungible. By virtue of obfuscation, Monero cannot become tainted through participation in previous transactions. This means Monero will always be accepted without the risk of censorship.
-  confidential_para3: The Kovri Project,
-  confidential_para4: currently in development
-  confidential_para5: ", will route and encrypt transactions via I2P Invisible Internet Project nodes. This will obfuscate a transactor's IP address and provide further protection against network monitoring."
-  grassroots: Monero is a grassroots community attracting the world's best cryptocurrency researchers and engineering talent.
-  grassroots_para1: Over
-  grassroots_para2: 420 developers
-  grassroots_para3: have contributed to the Monero project, including 30 core developers. Forums and chat channels are welcoming and active.
-  grassroots_para4: Monero's Research Lab, Core Development Team and Community Developers are constantly pushing the frontier of what is possible with cryptocurrency privacy and security.
-  grassroots_para5: Monero is not a corporation. It is developed by cryptography and distributed systems experts from all over the world that donate their time or are funded by community donations. This means that Monero can't be shut down by any one country and is not constrained by any particular legal jurisdiction.
-  electronic: Monero is electronic cash that allows fast, inexpensive payments to and from anywhere in the world.
-  electronic_para1: There are no multi-day holding periods and no risk of fraudulent chargebacks. It is safe from ‘capital controls’ - these are measures that restrict the flow of traditional currencies, sometimes to an extreme degree, in countries experiencing economic instability.
-  videos: Monero Videos (English)
+  translated: "yes"
+  need-to-know: Lo que necesitas saber
+  leading: Monero es la criptomoneda líder con enfoque en transacciones privadas y resistentes a la censura.
+  leading_para1: La mayoría de las criptomonedas existentes, incluidas Bitcoin y Ethereum, tienen una blockchain transparente, lo que significa que las transacciones son abiertamente verificables y rastreables por cualquier persona en el mundo. Además, las direcciones emisoras y receptoras de estas transacciones pueden ser potencialmente enlazadas a la identidad de una persona en el mundo real.
+  leading_para2: Monero utiliza criptografía para resguardar cualquier dirección emisora o receptora, al igual que las cantidades enviadas.
+  confidential: Las transacciones de Monero son confidenciales y no rastreables.
+  confidential_para1: Cada transacción en Monero, por defecto, oculta las direcciones de quien envía y quien recibe así como las cantidades enviadas. Esta tecnología de privacidad siempre activa significa que toda actividad de todo usuario en la red de Monero mejora la privacidad de todos los demás usuarios, a diferencia de criptomonedas de transparencia selectiva (e.g. Z-Cash).
+  confidential_para2: Monero es fungible. Por virtud de la ofuscación, Monero no puede contaminarse a causa de uso en transacciones previas. Esto significa que Monero siempre será aceptado sin riesgo de censura o rechazo.
+  confidential_para3: El
+  confidential_para4: proyecto Kovri, 
+  confidential_para5: "actualmente en desarrollo, será capaz de enrutar y encriptar transacciones vía nodos I2P (Invisible Internet Project). Esto ocultará la dirección IP de una transacción y proveerá protección adicional contra el monitoreo de red."
+  grassroots: Monero es una comunidad sólida que ha logrado atraer a los mejores ingenieros e investigadores del mundo en criptomonedas.
+  grassroots_para1: Más de
+  grassroots_para2: 420 desarrolladores
+  grassroots_para3: han contribuido al proyecto Monero, incluyendo 30 desarrolladores centrales. Los foros y canales de comunicación son muy acogedores y activos.
+  grassroots_para4: El Laboratorio de Investigación de Monero, Equipo de Desarrollo Central y Comunidad de Desarrolladores están constantemente rompiendo la barrera de lo que es posible con privacidad y seguridad de criptomonedas.
+  grassroots_para5: Monero no es una corporación. Es desarrollado por expertos en criptografía y sistemas distribuidos de todo el mundo que ofrecen de manera gratuita su tiempo o son patrocinados por donaciones de la comunidad. Esto significa que Monero no puede ser cerrado por ningún país y no está restringido por ninguna jurisdicción legal.
+  electronic: Monero es dinero electrónico que permite pagos rápidos y de bajo costo entre cualquier persona del mundo.
+  electronic_para1: No existen periodos de retención ni riesgo de cargos fraudulentos. Es seguro de ‘controles de capital’ - medidas que restringen el flujo de monedas tradicionales, algunas veces a un grado extremo, en países experimentando inestabilidad económica.
+  videos: Videos de Monero (en Inglés)
 
 about:
-  translated: "no"
-  history: A Brief History
-  history_para1: Monero was launched in April 2014. It was a fair, pre-announced launch of the CryptoNote reference code. There was no premine or instamine, and no portion of the block reward goes to development. See the original Bitcointalk thread
-  history_para2: here.
-  history_para3: The founder, thankful_for_today, proposed some controversial changes that the community disagreed with. A fallout ensued, and the Monero Core Team forked the project with the community following this new Core Team. This Core Team has provided oversight since.
-  history_para4: Monero has made several large improvements since launch. The blockchain was migrated to a different database structure to provide greater efficiency and flexibility, minimum ring signature sizes were set so that all transactions were private by mandate, and RingCT was implemented to hide the transaction amounts. Nearly all improvements have provided improvements to security or privacy, or they have facilitated use. Monero continues to develop with goals of privacy and security first, ease of use and efficiency second.
-  values: Our Values
-  values_para: Monero is more than just a technology. It’s also what the technology stands for. Some of the important guiding philosophies are listed below.
-  security: Security
-  security_para: Users must be able to trust Monero with their transactions, without risk of error or attack. Monero gives the full block reward to the miners, who are the most critical members of the network who provide this security. Transactions are cryptographically secure using the latest and most resilient encryption tools available.
-  privacy: Privacy
-  privacy_para: Monero takes privacy seriously. Monero needs to be able to protect users in a court of law and, in extreme cases, from the death penalty. This level of privacy must be completely accessible to all users, whether they are technologically competent or have no idea how Monero works. A user needs to confidently trust Monero in a way that this person does not feel pressured into changing their spending habits for risk of others finding out.
-  decentralization: Decentralization
-  decentralization_para: Monero is committed to providing the maximum amount of decentralization. With Monero, you do not have to trust anyone else on the network, and it is not run by any large group. An accessible “Proof of Work” algorithm makes it easy to mine Monero on normal computers, which makes it more difficult for someone to purchase a large amount of mining power. Nodes connect to each other with I2P to lower the risks of revealing sensitive transaction information and censorship (tba). Development decisions are extremely clear and open to public discussion. Developer meeting logs are published online in their entirety and visible by all.
+  translated: "yes"
+  history: Una breve historia
+  history_para1: Bitmonero (BMR) fue lanzado en abril del 2014. Fue un lanzamiento justo y con anuncios previos del código de referencia CryptoNote. No hubo pre-minado o minado instantáneo, y ninguna porción de la recompensa de bloque se dirigía al desarrollo de Bitmonero. Ve el post original de Bitcointalk
+  history_para2: aquí.
+  history_para3: El fundador, thankful_for_today, propuso algunos cambios controversiales que no fueron bien recibidos por la comunidad. Le siguió una gran caída, y el Equipo Central de Bitmonero bifurcó el proyecto con la comunidad siguiendo al nuevo equipo central. El Equipo Central actual ha estado en vigilancia desde entonces.
+  history_para4: Monero (XMR) ha hecho considerables mejoras a larga escala desde su lanzamiento. La blockchain ha migrado a una estructura de base de datos distinta para proveer mejor eficiencia y flexibilidad, el tamaño mínimo de las firmas circulares fue establecido por mandato para que todas las transacciones fueran privadas, y se implementó RingCT para esconder la cantidad de las transacciones. La mayoría de estas implementaciones han logrado mejoras a la seguridad y privacidad, o han facilitado el uso de Monero. Monero sigue en desarrollo con metas de privacidad y seguridad principalmente, y eficiencia y facilidad de uso en segundo lugar.
+  values: Nuestros valores
+  values_para: Monero es más que sólo una tecnología. Es más bien el significado de tecnología. A continuación se muestran algunas de las filosofías guía más importantes.
+  security: Seguridad
+  security_para: Los usuarios deben ser capaces de confiar en Monero y las transacciones que realicen, sin riesgo de error o ataques. Monero entrega toda la recompensa de bloque a los mineros, quienes son los miembros más críticos de la red y quienes proveen esta seguridad. Las transacciones son criptográficamente seguras ya que utilizan las herramientas de encriptación más recientes y resistentes.
+  privacy: Privacidad
+  privacy_para: Monero se toma la privacidad muy en serio. Monero necesita ser capaz de proteger a sus usuarios de posibles cuestiones legales, y, en casos extremos, de pena de muerte. Este nivel de privacidad debe ser completamente accesible a todos los usuarios, ya sea si son competentes tecnológicamente o si no tienen idea de cómo funciona Monero. Un usuario necesita confiar en Monero de forma que no se sienta presionado en cambiar sus hábitos de gasto por la posibilidad de riesgo o porque alguien más se dé cuenta de ellos.
+  decentralization: Descentralización
+  decentralization_para: Monero está comprometido a proveer la máxima descentralización posible. Con Monero, no necesitas confiar en nadie dentro de la red y no está dirigido por algún grupo de gran tamaño. Un algoritmo accesible que utiliza la prueba-de-trabajo (proof-of-work) vuelve fácil el minado en ordenadores sencillos, lo que hace más difícil que alguien compre un gran poder de minado (hashpower). Los nodos se conectan uno con otro a través de I2P para reducir el riesgo de revelar información sensible de transacciones y el riesgo de censura (de ser anunciado). Las decisiones de desarrollo son extremadamente claras y abiertas a discusión pública. Los registros de las reuniones de desarrollo son publicados en línea en su totalidad y son visibles por todos.
 
 
 developer-guides:
   translated: "yes"
-  outdated: "Please note: the guides below are currently out of date, but are considered a good starting point for most calls."
-  rpc: RPC Documentation
-  daemonrpc: Daemon RPC Documentation
-  walletrpc: Wallet RPC Documentation
-  soon: More coming soon...
+  outdated: "Tenga en cuenta: las siguientes guías están desactualizadas, pero son consideradas como un buen punto de inicio para la mayoría de las llamadas."
+  rpc: Documentación RPC
+  daemonrpc: Documentación de Daemon RPC
+  walletrpc: Documentación de Monedero RPC
+  soon: Más guías próximamente...
 
 user-guides:
-  translated: "no"
+  translated: "yes"
   general: General
-  mining: Mining
-  recovery: Recovery
-  wallets: Wallets
-  offline-backup: How to make an offline backup
-  vps-node: How to run a node on VPS
-  import-blockchain: Importing the Monero blockchain
-  monero-tools: Monero Tools
-  purchasing-storing: Securely purchasing and storing Monero
-  verify-allos: Verify binaries on Linux, Mac, or Windows command line (advanced)
-  verify-windows: Verify binaries on Windows (beginner)
-  mine-on-pool: How to mine on a pool with xmr-stak-cpu
-  solo-mine: How to solo mine with the GUI
-  mine-docker: Mining with Docker and XMRig
-  locked-funds: How to fix locked up funds
-  restore-account: How to restore your account
-  qubes: CLI wallet/daemon isolation with Qubes + Whonix
-  cli-wallet: Getting started with the CLI wallet
-  remote-node-gui: How to connect to a remote node within GUI wallet
-  view-only: How to make a view-only wallet
-  prove-payment: How to prove payment
-  restore-from-keys: Restoring wallet from keys
-  nicehash:
-  ledger-wallet-cli: How to generate a Ledger Monero wallet with the CLI (monero-wallet-cli)
+  mining: Minado
+  recovery: Recuperación
+  wallets: Monederos
+  offline-backup: Cómo hacer un respaldo sin conexión
+  vps-node: Cómo correr un nodo en un VPS
+  import-blockchain: Importar la blockchain de Monero
+  monero-tools: Herramientas de Monero
+  purchasing-storing: Comprar y almacenar Monero de forma segura
+  verify-allos: Verificar binarios en Linux, Mac o Windows en Consola de Comandos (avanzado)
+  verify-windows: Verificar binarios en Windows (principiante)
+  mine-on-pool: Cómo minar en una pool con xmr-stak-cpu
+  solo-mine: Cómo hacer minado en modo solo con la interfaz gráfica de usuario (GUI)
+  mine-docker: Minar con Docker y XMRig
+  locked-funds: Cómo recuperar/reparar fondos bloqueados
+  restore-account: Cómo restablecer tu cuenta
+  qubes: Aislamiento de monedero de Consola de Comandos con Qubes + Whonix
+  cli-wallet: Empezando con el monedero de Consola de Comandos
+  remote-node-gui: Cómo conectarse a un nodo remoto en el monedero de interfaz gráfica
+  view-only: Cómo hacer un monedero de visualización únicamente
+  prove-payment: Cómo comprobar un pago
+  restore-from-keys: Restaurar monedero desde claves
+  nicehash: Cómo minar Monero XMR sin un equipo de minado
+  ledger-wallet-cli: Cómo generar un monedero Ledger Monero con la consola de comandos (monero-wallet-cli)
 
 roadmap:
-  translated: "no"
-  completed: Completed task
-  ongoing: Ongoing task
-  upcoming: Upcoming task
-  future: Future
+  translated: "Yes"
+  completed: Tareas terminadas
+  ongoing: Tareas en proceso
+  upcoming: Tareas futuras
+  future: Futuro
 
 
 research-lab:
-  translated: "no"
-  intro: Monero is not only committed to making a fungible currency, but also to continued research into the realm of financial privacy as it involves cryptocurrencies. Below you'll find the work of our very own Monero Research Lab, with more papers to come.
-  mrl_papers: Monero Research Lab Papers (English)
-  abstract: Abstract
-  introduction: Introduction
-  read-paper: Read Paper
-  mrl1: A Note on Chain Reactions in Traceability in CryptoNote 2.0
-  mrl1_abstract: This research bulletin describes a plausible attack on a ring-signature based anonymity system. We use as motivation the cryptocurrency protocol CryptoNote 2.0 ostensibly published by Nicolas van Saberhagen in 2012. It has been previously demonstrated that the untraceability obscuring a one-time key pair can be dependent upon the untraceability of all of the keys used in composing that ring signature. This allows for the possibility of chain reactions in traceability between ring signatures, causing a critical loss in untraceability across the whole network if parameters are poorly chosen and if an attacker owns a sufficient percentage of the network. The signatures are still one-time, however, and any such attack will still not necessarily violate the anonymity of users. However, such an attack could plausibly weaken the resistance CryptoNote demonstrates against blockchain analysis. This research bulletin has not undergone peer review, and reflects only the results of internal investigation.
-  mrl2: Counterfeiting via Merkle Tree Exploits within Virtual Currencies Employing the CryptoNote Protocol
-  mrl2_abstract: On 4 September 2014, an unusual and novel attack was executed against the Monero cryptocurrency network. This attack partitioned the network into two distinct subsets which refused to accept the legitimacy of the other subset. This had myriad effects, not all of which are yet known. The attacker had a short window of time during which a sort of counterfeiting could occur, for example. This research bulletin describes deficiencies in the CryptoNote reference code allowing for this attack, describes the solution initially put forth by Rafal Freeman from Tigusoft.pl and subsequently by the CryptoNote team, describes the current fix in the Monero code base, and elaborates upon exactly what the offending block did to the network. This research bulletin has not undergone peer review, and reflects only the results of internal investigation.
-  mrl3: Monero is Not That Mysterious
-  mrl3_abstract: Recently, there have been some vague fears about the CryptoNote source code and protocol floating around the internet based on the fact that it is a more complicated protocol than, for instance, Bitcoin. The purpose of this note is to try and clear up some misconceptions, and hopefully remove some of the mystery surrounding Monero Ring Signatures. I will start by comparing the mathematics involved in CryptoNote ring signatures (as described in [CN]) to the mathematics in [FS], on which CryptoNote is based. After this, I will compare the mathematics of the ring signature to what is actually in the CryptoNote codebase.
-  mrl4: Improving Obfuscation in the CryptoNote Protocol
-  mrl4_abstract: We identify several blockchain analysis attacks available to degrade the untraceability of the CryptoNote 2.0 protocol. We analyze possible solutions, discuss the relative merits and drawbacks to those solutions, and recommend improvements to the Monero protocol that will hopefully provide long-term resistance of the cryptocurrency against blockchain analysis. Our recommended improvements to Monero include a protocol-level network-wide minimum mix-in policy of n = 2 foreign outputs per ring signature, a protocol-level increase of this value to n = 4 after two years, and a wallet-level default value of n = 4 in the interim. We also recommend a torrent-style method of sending Monero output. We also discuss a non-uniform, age-dependent mix-in selection method to mitigate the other forms of blockchain analysis identified herein, but we make no formal recommendations on implementation for a variety of reasons. The ramifications following these improvements are also discussed in some detail. This research bulletin has not undergone peer review, and reflects only the results of internal investigation.
-  mrl5: Ring Signature Confidential Transactions
-  mrl5_abstract: This article introduces a method of hiding transaction amounts in the strongly decentralized anonymous cryptocurrency Monero. Similar to Bitcoin, Monero is a cryptocurrency which is distributed through a proof of work “mining” process. The original Monero protocol was based on CryptoNote, which uses ring signatures and one-time keys to hide the destination and origin of transactions. Recently the technique of using a commitment scheme to hide the amount of a transaction has been discussed and implemented by Bitcoin Core Developer Gregory Maxwell. In this article, a new type of ring signature, A Multi-layered Linkable Spontaneous Anonymous Group signature is described which allows for hidden amounts, origins and destinations of transactions with reasonable efficiency and verifiable, trustless coin generation. Some extensions of the protocol are provided, such as Aggregate Schnorr Range Proofs, and Ring Multisignature. The author would like to note that early drafts of this were publicized in the Monero Community and on the bitcoin research irc channel. Blockchain hashed drafts are available in [14] showing that this work was started in Summer 2015, and completed in early October 2015. An eprint is also available at http://eprint.iacr.org/2015/1098.
-  mrl6: Subadresses
-  mrl6_abstract: Users of the Monero cryptocurrency who wish to reuse wallet addresses in an unlinkable way must maintain separate wallets, which necessitates scanning incoming transactions for each one. We document a new address scheme that allows a user to maintain a single master wallet address and generate an arbitary number of unlinkable subaddresses. Each transaction needs to be scanned only once to determine if it is destinated for any of the user’s subaddresses. The scheme additionally supports multiple outputs to other subaddresses, and is as efficient as traditional wallet transactions.
-  cryptonote: Cryptonote Whitepapers
-  cryptonote-whitepaper: Cryptonote Whitepaper
-  cryptonote-whitepaper_para: This is the original cryptonote paper written by the cryptonote team. Reading it will give an understanding about how the cryptonote algorithm works in general.
-  annotated: Annotated Whitepaper
-  annotated_para: The Monero Research Lab released an annotated version of the cryptonote whitepaper. This is sort of like an informal review of the claims that are made line-by-line of the whitepaper. It also explains some of the harder concepts in relatively easy to understand terms.
-  brandon: Brandon Goodell's Whitepaper Review
-  brandon_para: This paper is a formal review of the original cryptonote paper by MRL researcher Brandon Goodell. He takes an in-depth look at the claims and mathematics presented in the cryptonote paper.
+  translated: "yes"
+  intro: Monero no está comprometido solamente a hacer una moneda fungible, sino también a una continua investigación en el reino de la privacidad financiera ya que esto debe implicar una criptomoneda. A continuación encontrarás el trabajo de nuestro propio Laboratorio de Investigación de Monero, con más trabajos por delante.
+  mrl_papers: Papeles del Laboratorio de Investigación de Monero (en inglés)
+  abstract: Abstracto
+  introduction: Introducción
+  read-paper: Leer el papel
+  mrl1: Una nota en Reacciones en Cadena en Trazabilidad en CryptoNote 2.0
+  mrl1_abstract: Este boletín de investigación describe un ataque plausible en un sistema de anonimato basado en firma circular. Utilizamos como motivación el protocolo de criptomoneda CryptoNote 2.0 aparentemente publicado por Nicolas van Saberhagen en 2012. Ha sido previamente demostrado que la imposibilidad de rastrear un par de llaves de un solo uso puede ser dependiente sobre la imposibilidad de rastrear toda llave utilizada en componer esa firma circular. Esto permite la posibilidad de reacciones en cadena en trazabilidad entre firmas circulares, causando una pérdida crítica en imposibilidad de rastreo a través de la red entera si los parámetros son mal seleccionados y si un agresor posee un porcentaje suficiente de la red. La firma es todavía de un solo uso, no obstante, cualquier ataque de este tipo no necesariamente violará el anonimato de los usuarios. Además, tal ataque podría debilitar plausiblemente la resistencia que CryptoNote ha demostrado en contra de análisis a la blockchain. Este boletín de investigación no ha sido revisado más de una vez, y refleja sólo los resultados de investigación interna.
+  mrl2: Falsificación a través de Merkle Tree Exploits dentro de monedas virtuales que emplean el protocolo CryptoNote
+  mrl2_abstract: El 4 de septiembre del 2014, un nuevo y raro ataque fue efectuado en contra de la red de la criptomoneda Monero. Este ataque dividió la red en dos subconjuntos distintos que se negaban a aceptar la legitimidad del otro conjunto. Esto tuvo efectos gigantescos, los cuales se desconocen en su totalidad. El agresor tuvo un corto periodo de tiempo en el cual tal clase de falsificación pudo ocurrir. Este boletín de investigación describe deficiencias en el código de referencia CryptoNote que permitieron este ataque, describe la solución inicial propuesta por Rafal Freeman  de Tigusoft.pl y posteriormente por el equipo de CryptoNote, así como el arreglo actual en el código base de Monero, y elabora exactamente lo que el bloque ofensor hizo a la red. Este boletín de investigación no ha sido revisado más de una vez, y refleja sólo los resultados de investigación interna.
+  mrl3: Monero no es tan misterioso
+  mrl3_abstract: Recientemente, han habido ciertas dudas respecto al código fuente y protocolo de CryptoNote que transita por internet basadas en el hecho de que es un protocolo más complicado que, por ejemplo, el de Bitcoin. El propósito de este artículo es el de intentar clarificar malentendidos, y con suerte, eliminar los misteriosos conceptos de las firmas circulares de Monero. Comenzaré comparando las matemáticas envueltas en las firmas circulares de CryptoNote (descritas en [CN]) a las matemáticas en [FS], en la cual CryptoNote está basado. Después de esto, compararé las matemáticas de las firmas circulares a lo que actualmente existe en el código base de CryptoNote.
+  mrl4: Mejorando la ofuscación en el protocolo CryptoNote
+  mrl4_abstract: Hemos identificado considerables ataques de identificación en la blockchain para degradar la imposibilidad de rastreo del protocolo 2.0 de CryptoNote. Analizamos posibles soluciones discutiendo sus méritos e inconvenientes, y recomendamos mejoras al protocolo de Monero que con suerte proveerán resistencia a largo plazo en la criptomoneda para identificación de la blockchain. Nuestras mejoras sugeridas a Monero incluyen una política mixta del nivel de protocolo mínimo en toda la red de n = 2 salidas por firma circular, un aumento en el nivel de protocolo de este valor a n = 4 después de dos años, y un valor del nivel de monedero de n = 4 por defecto de manera provisional. También recomendamos un método de envío de Monero estilo torrent. Además, discutimos un método de mezclado no uniforme y dependiente del tiempo para mitigar las demás formas de identificación de blockchain utilizadas, pero no realizamos recomendaciones formales para implementaciones debido a varias razones. Las ramificaciones resultantes de estas mejoras también son discutidas en detalle. Este boletín de investigación no ha sido revisado más de una vez, y refleja sólo los resultados de investigación interna.
+  mrl5: Transaciones confidenciales de firmas circulares
+  mrl5_abstract: Este artículo presenta un método para ocultar la cantidad en una transacción en la criptomoneda descentralizada y anónima Monero. Similar a Bitcoin, Monero es una criptomoneda que se distribuye a través del minado por prueba-de-trabajo. El protocolo original de Monero estuvo basado en CryptoNote, que utiliza firmas circulares y llaves de un solo uso para ocultar el origen y destino de sus transacciones. Recientemente, la técnica de utilizar un esquema de compromiso para ocultar la cantidad de una transacción ha sido discutida e implementada por el desarrollador del equipo central de Bitcoin, Gregory Maxwell. En este artículo, un nuevo tipo de firma circular, de grupo de enlace multicapa espontánea anónima, es descrita en la forma en que se utiliza para ocultar cantidades, orígenes y destinos en transacciones con buena eficiencia y verificabilidad, con una generación de monedas sin dependencia. Algunas extensiones del protocolo de transacciones son provistas, tales como pruebas agregadas del rango Schnorr (Aggregate Schnorr Range Proofs), y multi-firmas circulares (Ring Multisignature). El autor quisiera que se tenga en cuenta que borradores previos de esto fueron publicitados en la Comunidad de Monero y en canal de investigación de Bitcoin en IRC. Borradores de hash de la Blockchain están disponibles en [14] mostrando que este trabajo empezó en el verano del 2015, y completado en octubre del mismo año. Una impresión digital está disponible en http://eprint.iacr.org/2015/1098.
+  mrl6: Subdirecciones
+  mrl6_abstract: Usuarios de la criptomoneda Monero que desean reutilizar direcciones del monedero de una forma separada deben mantener monederos separados, lo que necesita escanear transacciones de entrada para cada uno. Documentamos un nuevo esquema de direcciones que permite al usuario mantener una simple dirección de monedero maestra y generar un número arbitrario de subdirecciones desvinculables. Cada transacción necesita ser escaneada sólo una vez para determinar si está destinada para cualquiera de las subdirecciones del usuario. El esquema soporta adicionalmente múltiples salidas a otras subdirecciones, y es tan eficiente como las transacciones tradicionales de un monedero.  
+  cryptonote: Libros Blancos de Cryptonote
+  cryptonote-whitepaper: Libro Blanco de Cryptonote
+  cryptonote-whitepaper_para: Este es el libro blanco original de CryptoNote escrito por el equipo de CryptoNote. Leerlo dará un entendimiento acerca de cómo funciona el algoritmo CryptoNote en general.
+  annotated: Libro Blanco con Notas
+  annotated_para: El Laboratorio de Investigación de Monero publicó una versión con notas adicionales del libro blanco de CryptoNote. Es un tipo de reseña informal de los resultados contenidos del libro blanco, línea por línea. También explica algunos de los conceptos más complejos en una forma relativamente sencilla de entender.
+  brandon: Reseña de Brandon Goodell's del Libro Blanco
+  brandon_para: Este documento es una reseña formal del libro blanco original de CryptoNote escrito por el miembro del Laboratorio de Investigación de Monero, el investigador Brandon Goodell. El escritor aborda a fondo las matemáticas y los resultados presentes en el libro blanco original.
 
 specs:
-  translated: "no"
-  fair_title: No premine, no instamine, no token
-  fair_premine: Monero had no premine or instamine
-  fair_token: Monero did not sell any token
-  fair_presale: Monero had no presale of any kind
-  pow_title: Proof of Work
+  translated: "yes"
+  fair_title: Sin minado previo, sin minado instantáneo, sin token
+  fair_premine: Monero no tuvo pre minado ni minado instantáneo
+  fair_token: Monero no vendió ningún token
+  fair_presale: Monero no tuvo preventa de ninguna clase
+  pow_title: Prueba de Trabajo
   pow_name: CryptoNight
-  pow_disclaimer: may change in the future
-  diff_title: Difficulty retarget
-  diff_freq: every block
-  diff_base: based on the last 720 blocks, excluding 20% of the timestamp outliers
-  block_time_title: Block time
-  block_time_duration: 2 minutes
-  block_time_disclaimer: may change in the future as long as emission curve is preserved
-  block_reward_title: Block reward
-  block_reward_amount: smoothly decreasing and subject to penalties for blocks greater than median size of the last 100 blocks (M100)
-  block_reward_example1: see the
-  block_reward_example_link: latest block
-  block_reward_example2: coinbase transaction amount for current reward
-  block_size_title: Block size
-  block_size: dynamic, maximum of 2 * M100
-  block_emission_title: Emission curve
-  block_emission_main: "first, main curve: ~18.132 million coins by the end of May 2022"
-  block_emission_tail: "then, tail curve: 0.6 XMR per 2-minute block, kicks in once main emission is done, translates to <1% inflation decreasing over time"
-  block_emission_disclaimer1: see
-  block_emission_disclaimer_link: charts and details
-  block_emission_disclaimer2:
-  supply_title: Max supply
-  supply_amount: infinite
-  sender_privacy_title: Sender privacy
-  sender_privacy_mode: Ring signatures
-  recipient_privacy_title: Recipient privacy
-  recipient_privacy_mode: Stealth addresses
-  amount_hidden_title: Amount obfuscation
-  amount_hidden_mode: Ring confidential transactions
+  pow_disclaimer: Puede cambiar en un futuro
+  diff_title: Reajuste de Dificultad
+  diff_freq: En cada bloque
+  diff_base: Basado en los últimos 720 bloques, excluyendo 20% de valores atípicos en la estampa de tiempo
+  block_time_title: Tiempo de Bloque
+  block_time_duration: 2 minutos
+  block_time_disclaimer: Puede cambiar en un futuro siempre y cuando la curva de emisión se conserve
+  block_reward_title: Recompensa de Bloque
+  block_reward_amount: Descendiendo ligeramente y sujeta a sanciones por bloques mayores que el tamaño promedio de los últimos 100 bloques (M100)
+  block_reward_example1: Vea la última transacción del
+  block_reward_example_link: último bloque
+  block_reward_example2: de Coinbase para la recompensa actual
+  block_size_title: Tamaño de Bloque
+  block_size: dinámico, con un máximo de 2 * M100
+  block_emission_title: Curva de emisión
+  block_emission_main: "primero, curva principal: ~18.132 millones de monedas para el final de mayo del 2022"
+  block_emission_tail: "después, cola de curva: 0.6 XMR por cada bloque (2 minutos), y comienza una vez se realiza la emisión principal, que se traduce en un <1% de reducción de inflación a través del tiempo"
+  block_emission_disclaimer1: Ver las
+  block_emission_disclaimer_link: gráficas y detalles
+  block_emission_disclaimer2: ""
+  supply_title: Suministro Máximo
+  supply_amount: Infinito
+  sender_privacy_title: Privacidad del Emisor
+  sender_privacy_mode: Firmas circulares
+  recipient_privacy_title: Privacidad del Receptor
+  recipient_privacy_mode: Direcciones sigilo
+  amount_hidden_title: Encubrimiento de Cantidades
+  amount_hidden_mode: Transacciones confidenciales circulares
 
 library:
-  translated: "no"
-  description: "Below are some publications, books or magazines available for you to download."
+  translated: "yes"
+  description: "A continuación se encuentran algunas publicaciones, libros y revistas disponibles para descargar."
   books:
-  - category: Books
+  - category: Libros
     publications:
     - name: "Zero to Monero"
       file: "Zero-to-Monero-1-0-0.pdf"
       abstract: >
-        A comprehensive conceptual (and technical) explanation of Monero.<br>
-        We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+        Una explicación conceptual, comprensiva (y técnica) de Monero.<br>
+        Nos esforzamos por enseñar a cualquiera que conozca álgebra básica y conceptos simples de ciencias de la computación, como ‘representación de bits’ de un número, no solamente cómo funciona Monero a un nivel profundo y completo, sino también qué tan útil y bella puede ser la criptografía.
     - name: "Mastering Monero (Preview)"
       file: "Mastering-Monero-Preview.pdf"
       abstract: >
-        A guide through the seemingly complex world of Monero.<br>
-        It includes:
-        <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
-        <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
-        <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
-        <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
-        <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
-        <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
-        See <a href="https://masteringmonero.com/">Mastering Monero</a> website for info about full version.
-  - category: Magazines
+        Una guía a través del aparentemente complejo mundo de Monero.<br>
+        Incluye:
+        <ul><li>Una amplia introducción a blockchains y la importancia de la privacidad - ideal para usuarios no técnicos.</li>
+        <li>Discusión de las deficiencias de Bitcoin y soluciones específicas proporcionadas por Monero.</li>
+        <li>Historias de usuarios (ilustrando cómo Monero protege tu privacidad), analogías, ejemplos, discusiones legales/éticas, y fragmentos de código ilustrando conceptos técnicos clave.</li>
+        <li>Detalles de la red descentralizada de Monero, arquitectura de igual a igual, ciclo de vida de una transacción, y principios de seguridad.</li>
+        <li>Introducción a los fundamentos técnicos de Monero, destinado a desarrolladores, ingenieros, arquitectos de software, y usuarios curiosos.</li>
+        <li>Nuevos desarrollos como Kovri, Bulletproofs, Multifirmas, Monederos Hardware, entre otros.</li></ul>
+        Ver el sitio web de <a href="https://masteringmonero.com/">Mastering Monero</a> para información acerca de la versión completa.
+  - category: Revistas
     publications:
     - name: "Revuo Monero Q4 2017"
       file: "Revuo-2017-Q4.pdf"
       abstract: >
-        Quarterly Monero magazine, Q4 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, and community.
+        Revista trimestral de Monero, edición Q4, 2017.<br>
+        En esta publicacióne, actualizaciones acerca de: desarrollo, Laboratorio de Investigación de Monero, Kovri, y comunidad.
     - name: "Revuo Monero Q3 2017"
       file: "Monero-Revuo-3Q-2017.pdf"
       abstract: >
-        Quarterly Monero magazine, Q3 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
+        Revista trimestral de Monero, edición Q3, 2017.<br>
+        En esta publicacióne, actualizaciones acerca de: desarrollo, Laboratorio de Investigación de Monero, Kovri, y comunidad, Hardware, y Monerujo.
 
 moneropedia:
   translated: "no"
@@ -537,14 +537,14 @@ moneropedia:
   add_new_text2: or submit changes via pull request
 
 blog:
-  title_1: All
-  title_2: Blog
-  title_3: Posts
-  tagged: Tagged under
-  author: Posted by
-  date: Posted at
-  forum: Click here to join the discussion for this entry on the Monero Forum
+  title_1: Todas
+  title_2: las
+  title_3: Publicaciones
+  tagged: Etiquetado como
+  author: Publicado por
+  date: Publicado en
+  forum: Presiona aquí para unirte a la discusión para esta entrada en el Foro Monero
 
 tags:
-  all: Articles by Tag
-  notags: There are no posts for this tag.
+  all: Artículos por etiqueta
+  notags: No hay artículos para esta etiqueta.


### PR DESCRIPTION
I'm not sure if there's an issue about this update/request. Hope that I'm not causing any troubles, thank you in advance guys.

As you must know, the es.yml file contains most of the content for the getmonero dot org site. There are other files that needs translation and I'll be working on them too. I experienced just one problem when testing the file: the Stack Exchange section didn't translated, which corresponds to line 104. Maybe that line depends on other file in the es folder but I'm not aware of that now. 

A minor problem is the space used when translating some of the titles in the Team page (Research Lab, which translates into Laboratorio de Investigación, actually I just put "Lab. de Investigación" but it's still too long, and Special Thanks - Agradecimientos Especiales. Those titles look like they need more space to fit it.