### PR TITLE
Minor French Update + NiceHash guide re-re-added

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -103,6 +103,7 @@ hangouts:
   irc_para: The Monero community utilizes a lot of IRC channels that each serve different purposes. Some to work, and some just to hang out. You'll find the more popular ones below.
   stack_exchange: Stack Exchange
   stack_exchange_para: The Monero Stack Exchange is a quick and easy way to ask questions and get answers. Below you'll find some high quality question/answer pairs to some frequently asked questions.
+  stack_exchange_link: Visit Stack Exchange
   irc_channels:
   - channel: monero
     description: This channel is used to discuss all things Monero related.
@@ -412,6 +413,7 @@ user-guides:
   view-only: How to make a view-only wallet
   prove-payment: How to prove payment
   restore-from-keys: Restoring wallet from keys
+  nicehash: How to mine Monero XMR without a mining equipment
 
 roadmap:
   translated: "yes"

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -103,6 +103,7 @@ hangouts:
   irc_para: The Monero community utilizes a lot of IRC channels that each serve different purposes. Some to work, and some just to hang out. You'll find the more popular ones below.
   stack_exchange: Stack Exchange
   stack_exchange_para: The Monero Stack Exchange is a quick and easy way to ask questions and get answers. Below you'll find some high quality question/answer pairs to some frequently asked questions.
+  stack_exchange_link: Visit Stack Exchange
   irc_channels:
   - channel: monero
     description: This channel is used to discuss all things Monero related.
@@ -412,6 +413,7 @@ user-guides:
   view-only: How to make a view-only wallet
   prove-payment: How to prove payment
   restore-from-keys: Restoring wallet from keys
+  nicehash:
 
 roadmap:
   translated: "no"

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -104,6 +104,7 @@ hangouts:
   irc_para: La communauté Monero s'appuie sur différents canaux IRC qui répondent à des besoins spécifiques. Certains pour travailler, et d'autres simplement pour se rencontrer. Vous trouverez les plus populaires d'entre eux ci-dessous.
   stack_exchange: Stack Exchange
   stack_exchange_para: Le Stack Exchange de Monero est un moyen simple et rapide de poser des questions et trouver des réponses. Vous trouverez ci-dessous quelques-unes des meilleures questions/réponses qui sont fréquemment recherchées.
+  stack_exchange_link: Aller sur Stack Exchange
   irc_channels:
   - channel: monero
     description: Ce canal permet de discuter de toutes choses liées à Monero.
@@ -164,7 +165,7 @@ downloads:
   intro3: pour une réponse rapide, puis sélectionner va version appropriée pour votre système d'exploitation ci-dessous.
   note1: "Remarque : les sommes de contrôle SHA256 sont indiquées à côté des téléchargements par commodité, mais une liste signée par GPG des sommes de contrôle est disponible à"
   note2: et devrait être traitée de manière canonique, en vérifiant la signature vis-à-vis de la clef GPG appropriée dans le code source (dans /utils/gpg_keys).
-  currentversion: Current Version
+  currentversion: Version Actuelle
   sourcecode: Code Source
   blockchain1: Si vous préférez utiliser une amorce de la chaîne de blocs, plutôt que de synchroniser à partir de zéro, vous pouvez
   blockchain2: utiliser ce lien pour obtenir l'amorce la plus récente.
@@ -176,7 +177,7 @@ downloads:
   mobilelight1: Ci-dessous des portefeuilles mobiles ou légers jugés sûrs par des membres de confiance de la communauté. Si un portefeuille n'est pas cité ici, vous pouvez demander à la communauté de le vérifier. Allez à la page
   mobilelight2: Rencontres
   mobilelight3:  pour voir où nous sommes.
-  clionly: Command-Line Tools Only
+  clionly: Outils Ligne de Commande uniquement
 
 monero-project:
   translated: "yes"
@@ -193,11 +194,11 @@ press-kit:
   intro4: ici.
   noback: Sans fond
   whiteback: Fond blanc
-  symbol: Monero Symbol
+  symbol: Symbole Monero
   logo: Symbole Monero
-  small: Small
-  medium: Medium
-  large: Large
+  small: Petit
+  medium: Moyen
+  large: Grand
   symbol_file: Symbole au format .ai
   logo_file: Logo au format .ai
 
@@ -363,7 +364,7 @@ what-is-monero:
   grassroots_para5: Monero n'est pas une société. Il est développé par des experts en cryptographie et en systèmes distribués du monde entier qui donnent de leur temps ou sont financés par des dons communautaires. Cela signifie que Monero ne peut être fermé par un pays et n'est soumis à aucune juridiction légale particulière
   electronic: Monero est de l'argent électronique qui permet des paiements rapides et peu couteux dans le monde entier.
   electronic_para1: Il n'y a pas de frais de garde et aucun risque de rétrofacturation frauduleuse. Il est à l'abri des « contrôles de capitaux » - qui sont des mesures limitant les flux de monnaies traditionnelles, parfois à un degré extrême, dans des pays en proie à une instabilité économique.
-  videos: Vidéos Monero (English)
+  videos: Vidéos Monero (Anglais)
 
 about:
   translated: "yes"
@@ -414,6 +415,7 @@ user-guides:
   view-only: Comment créer un portefeuille en lecture seule
   prove-payment: Comment vérifier un paiement
   restore-from-keys: Restaurer un portefeuille depuis les clefs
+  nicehash: Comment miner Monero sans équipement d'extraction minière
 
 roadmap:
   translated: "yes"

--- a/_i18n/fr/resources/user-guides/securely_purchase.md
+++ b/_i18n/fr/resources/user-guides/securely_purchase.md
@@ -4,7 +4,7 @@ Voici un guide d'achat et de conservation en toute sécurité de Monero à la da
 
 #### Étape 1 : Acheter des Bitcoins
 
-Il y a plusieurs façon d'acheter des Bitcoins. Deux sociétés à peu près fiables pour le moment sont Xapo <http://www.xapo.com/> et Coinbase <http://www.coinbase.com/>. Le processus impliquera de fournir votre identité (carte d'identité, passeport, etc.) et prendra entre 2 et 1à jours (voire plus). Vérifier leur réputation sur Reddit avant d'effectuer des achats conséquents.  Xapo utilise des virements directs et Coinbase utilise des virements standards (ACH aux États-unis, SEPA en Europe).  Xapo devrait donc être plus rapide que Coinbase.  Coinbase propose également de petits achats "instantanés" par carte bancaire mais ajoute des frais importants à cette option. Une fois que vous avez acheté des Bitcoins, vous êtes prêts à les convertir en Moneroj !
+Il y a plusieurs façon d'acheter des Bitcoins. Deux sociétés à peu près fiables pour le moment sont Xapo <http://www.xapo.com/> et Coinbase <http://www.coinbase.com/>. Le processus impliquera de fournir votre identité (carte d'identité, passeport, etc.) et prendra entre 2 et 10 jours (voire plus). Vérifier leur réputation sur Reddit avant d'effectuer des achats conséquents.  Xapo utilise des virements directs et Coinbase utilise des virements standards (ACH aux États-unis, SEPA en Europe).  Xapo devrait donc être plus rapide que Coinbase.  Coinbase propose également de petits achats "instantanés" par carte bancaire mais ajoute des frais importants à cette option. Une fois que vous avez acheté des Bitcoins, vous êtes prêts à les convertir en Moneroj !
 
 #### Étape 2 : Télécharger et créer un portefeuille papier sur un ordinateur sécurisé et isolé
 

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -103,6 +103,7 @@ hangouts:
   irc_para: The Monero community utilizes a lot of IRC channels that each serve different purposes. Some to work, and some just to hang out. You'll find the more popular ones below.
   stack_exchange: Stack Exchange
   stack_exchange_para: The Monero Stack Exchange is a quick and easy way to ask questions and get answers. Below you'll find some high quality question/answer pairs to some frequently asked questions.
+  stack_exchange_link: Visit Stack Exchange
   irc_channels:
   - channel: monero
     description: This channel is used to discuss all things Monero related.
@@ -412,6 +413,7 @@ user-guides:
   view-only: How to make a view-only wallet
   prove-payment: How to prove payment
   restore-from-keys: Restoring wallet from keys
+  nicehash:
 
 roadmap:
   translated: "no"

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -104,6 +104,7 @@ hangouts:
   irc_para: Społeczność Monero używa wielu kanałów IRC, a każdy z nich jest przeznaczony do czegoś innego. Niektóre z nich służą do pracy, a niektóre do pogadania. Najpopularniejsze z nich znajdziesz poniżej.
   stack_exchange: Stack Exchange
   stack_exchange_para: Stack Exchange Monero jest szybkim i prostym sposobem na zadanie pytania i uzyskanie odpowiedzi. Poniżej znajdziesz kilka istotnych odpowiedzi na często zadawane pytania.
+  stack_exchange_link: Odwiedź Stack Exchange
   irc_channels:
   - channel: monero
     description: This channel is used to discuss all things Monero related.
@@ -413,6 +414,7 @@ user-guides:
   view-only: Jak założyć portfel tylko do wyświetlania
   prove-payment: Jak udowodnić płatność
   restore-from-keys: Przywracanie portfela za pomocą kluczy
+  nicehash: Jak wydobywać Monero (XMR) bez sprzętu wydobywczego
 
 roadmap:
   translated: "yes"

--- a/community/hangouts/index.md
+++ b/community/hangouts/index.md
@@ -77,10 +77,10 @@ permalink: /community/hangouts/index.html
                <div class="right one-third col-lg-4 col-md-4 col-sm-12 col-xs-12">
                         <div class="info-block">
                             <div class="row center-xs">
-                                <div class="col"><h2>Stack Exchange</h2></div>
+                                <div class="col"><h2>{% t hangouts.stack_exchange %}</h2></div>
                             </div>
                             <div class="row start-xs">
-                                <p>The Monero Stack Exchange is a quick and easy way to ask questions and get answers. Below you'll find some high quality question/answer pairs to some frequently asked questions.</p>
+                                <p>{% t hangouts.stack_exchange_para %}</p>
                             </div>
                             <div class="row start-xs sequestions">
                                 <a href="https://monero.stackexchange.com/questions/4277/why-does-monero-have-higher-transaction-fees-than-bitcoin">Why does monero have higher transaction fees than bitcoin?</a>
@@ -90,7 +90,7 @@ permalink: /community/hangouts/index.html
                                 <a href="https://monero.stackexchange.com/questions/4377/hiding-tcp-traffic-for-monero-miners">Hiding TCP traffic for Monero miners?</a>
                             </div>  
                             <div class="row center-xs">
-                                <p><a href="https://monero.stackexchange.com" class="btn-link btn-auto">Visit Stack Exchange</a></p>
+                                <p><a href="https://monero.stackexchange.com" class="btn-link btn-auto">{% t hangouts.stack_exchange_link %}</a></p>
                             </div>
                         </div>
                </div>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -43,7 +43,7 @@ permalink: /downloads/index.html
         {% for data_downloads in site.data.downloads %}
             <section class="container full" id="{{ data_downloads.id}}">
                 <div class="info-block">
-                    <h2> 
+                    <h2>
                         {% if data_downloads.icon != null %}
                             <span class="{{data_downloads.icon}}"></span>  
                         {% endif %}
@@ -69,7 +69,7 @@ permalink: /downloads/index.html
                     {% elsif data_downloads.id == "mobilelight" %}
                         <div class="row">
                             <div class="col-md-8 col-md-offset-2 col-sm-12 col-xs-12">
-                                <p>{% t downloads.mobilelight1 %} <a href="/community/hangouts/">{% t downloads.mobilelight2 %}</a>{% t downloads.mobilelight3 %}</p>
+                                <p>{% t downloads.mobilelight1 %} <a href="/community/hangouts/"> {% t downloads.mobilelight2 %}</a>{% t downloads.mobilelight3 %}</p>
                             </div>
                         </div>
                         <div class="row center-xs">
@@ -94,7 +94,7 @@ permalink: /downloads/index.html
                          </div>
                         <div class="row">
                             <div class="col-md-8 col-md-offset-2 col-sm-12 col-xs-12">
-                                <p><strong>SHA256 Hash:</strong></p> 
+                                <p><strong>SHA256 Hash:</strong></p>
                                 <p class="hash"> {{ data_downloads.cli_hash }}</p>
                             </div>
                         </div>

--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -37,6 +37,7 @@ title: titles.userguides
                             <a href="{{site.baseurl}}/resources/user-guides/mine-to-pool.html">{% t user-guides.mine-on-pool %}</a>
                             <a href="{{site.baseurl}}/resources/user-guides/solo_mine_GUI.html">{% t user-guides.solo-mine %}</a>
                             <a href="{{site.baseurl}}/resources/user-guides/mining_with_xmrig_and_docker.html">{% t user-guides.mine-docker %}</a>
+                            <a href="{{site.baseurl}}/resources/user-guides/How-to-mine-Monero-XMR-without-a-mining-equipment.html">{% t user-guides.nicehash %}</a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
This is a small update for fr.yml on which some sentences were missing translation since relocalization (why in hell didn't i see that before??)
This try (another time) to add the nicehash guide "How to mine Monero XMR without a mining equipement" which has always been here, but never been accessible through user-guide index page.