### PR TITLE
Logs from 2018-06-23 Community meeting

### DIFF
--- a/_posts/2018-06-23-logs-for-the-Community-meeting-held-on-2018-06-23.md
+++ b/_posts/2018-06-23-logs-for-the-Community-meeting-held-on-2018-06-23.md
@@ -1,0 +1,279 @@
+---
+layout: post
+title: Logs for the Community Meeting Held on 2018-06-23
+summary: Community highlights, Community workgroup developments, Forum Funding System updates, Localization workgroup report, Outreach workgroup report, and miscellaneous
+tags: [community, crypto]
+author: el00ruobuob / SamsungGalaxyPlayer
+---
+
+# Logs  
+
+**\<sgp\_>** Meeting time!  
+**\<sgp\_>** We would like to welcome everyone to this Monero Community Meeting!  
+**\<sgp\_>** Link to agenda on GitHub: https://github.com/monero-project/meta/issues/246  
+**\<sgp\_>** Monero Community meetings are a discussion place for anything going on in the Monero Community, including other Monero workgroups. We use meetings to encourage the community to share ideas and provide support. Stay up to date with the latest events by subscribing to this calendar: https://xmr.ncrypt.sh/index.php/apps/calendar/p/8dP6z6XQDnkPREo4/Monero-Meetings  
+**\<sgp\_>** 1. Greetings  
+**\<el00ruobuob\_[m]>** Hi guys!  
+**\<rehrar>** ho  
+**\<anonimal>** Hi  
+**\<xmrmatterbridge> \<xmrscott>** Hi  
+**\<xmrmatterbridge> \<xmrscott>**  
+**\<\_Slack> \<sean>** Hey  
+**\<erciccione\_[m]>** Hello  
+**\<\_Slack> \<alexmu>** Hi  
+**\<sgp\_>** 2. Community highlights  
+**\<sgp\_>** I somehow missed this excellent introductory video about Monero from February: https://www.youtube.com/watch?v=fHLXm2YBPDs  
+**\<monerobux>** [ Monero - ultimate beginner's guide! Animated coin review. - YouTube ] - www.youtube.com  
+**\<sgp\_>** Monero was added to the Debian “unstable” repository: https://tracker.debian.org/pkg/monero  
+**\<suraeNoether>** howdy  
+**\<sgp\_>** Vikrant Sharma talked about Monero and its relationship to Cake Wallet: https://www.youtube.com/watch?v=joAZQXp69Kw  
+**\<monerobux>** [ Vikrant Sharma – Founder of the Cake Wallet for Monero (XMR) - YouTube ] - www.youtube.com  
+**\<sgp\_>** ErCiccione (with the help of others) built an unofficial GUI for 0.12.2: https://www.reddit.com/r/Monero/comments/8rkwyt/unofficial\_release\_of\_gui\_wallet\_version\_0122/  
+**\<monerobux>** [REDDIT] UNOFFICIAL release of GUI wallet version 0.12.2 - 'Impatient' (self.Monero) | 69 points (91.0%) | 86 comments | Posted by ErCiccione | Created at 2018-06-16 - 17:35:55  
+**\<sgp\_>** Monerujo was updated to include subaddresses: https://www.reddit.com/r/Monero/comments/8sz02k/update\_monerujo\_159\_maximum\_nacho/  
+**\<monerobux>** [REDDIT] [UPDATE] Monerujo 1.5.9 "Maximum Nacho" (self.Monero) | 80 points (96.0%) | 42 comments | Posted by m2049r | Created at 2018-06-22 - 05:59:06  
+**\<sgp\_>** X Wallet was updated to include a fee estimator: https://www.reddit.com/r/Monero/comments/8qv90g/x\_wallet\_v15\_now\_available\_for\_download/  
+**\<monerobux>** [REDDIT] X Wallet v1.5 now available for download (self.Monero) | 65 points (91.0%) | 6 comments | Posted by xmr-rusticbison | Created at 2018-06-13 - 19:25:44  
+**\<oneiric\_>** hi  
+**\<sgp\_>** Does anyone else have community updates to share?  
+**\<\_Slack> \<sean>** The PR&OE name change  
+**\<el00ruobuob\_[m]>** Zero to monero released on the website  
+**\<sgp\_>** el00ruobuob do you have a link handy?  
+**\<el00ruobuob\_[m]>** not merged yet  
+**\<el00ruobuob\_[m]>** https://github.com/monero-project/monero-site/pull/772  
+**\<sgp\_>** All right. There's a pull request to organize important works like these into a library. Great idea imo  
+**\<sgp\_>** Anything else?  
+**\<el00ruobuob\_[m]>** rehrar idea to be honest  
+**\<sgp\_>** 3. Community workgroup developments  
+**\<sgp\_>** We have some exciting news regarding the workgroup. First, we are creating a database of all the workgroups in the Monero ecosystem. Here is an example for the Community workgroup: https://xmr.ncrypt.sh/index.php/s/xo3ttmqPTE93Pc3  
+**\<sgp\_>** We hope to work with other workgroup organizers to create more of these. We often receive feedback that new users have no idea how to find workgroups and get involved. We hope these materials will help.  
+**\<sgp\_>** Does anyone have feedback on the overall content?  
+**\<ErCiccione>** uh nice, will prepare something like that for the localizations one  
+**\<sgp\_>** I have a template I'll PM you and others in the next few days  
+**\<el00ruobuob\_[m]>** looks nice to me  
+**\<sgp\_>** Second, I have created a Taiga page for this workgroup (finally) where I have listed a number of initial tasks: https://taiga.getmonero.org/project/sgp-monero-community-workgroup/kanban  
+**\<ErCiccione>** perfect, thanks sgp\_  
+**\<sgp\_>** We would like to get more support from other community members to handle various tasks, including keeping the website and subreddit up-to-date. If you have some time and would like to help, here are some completely non-technical ways you can.  
+**\<sgp\_>** Does anyone have any questions?  
+**\<suraeNoether>** any small tasks I can help with before defcon?  
+**\<rehrar>** get some coffee for us?  
+**\<sgp\_>** surae what type of things are you looking for?  
+**\<suraeNoether>** haha anything, honestly. i don't have a lot of time, but i can put a few hours of some work  
+**\<sgp\_>** All right, I'll PM you as few ideas this evening unless anyone else has some  
+**\<sgp\_>** 4. FFS updates  
+**\<sgp\_>** There are several Forum Funding System (FFS) updates. Workgroup reports now have their own section.  
+**\<sgp\_>** ErCiccione is raising funds to coordinate the Localization workgroup: https://forum.getmonero.org/8/funding-required/90271/coordinator-of-the-localization-workgroup-3-more-months-erciccione  
+**\<sgp\_>** oneiric is raising funds to work on Kovri part-time: https://forum.getmonero.org/8/funding-required/90300/oneiric-june-august-part-time-kovri-junior-developer  
+**\<sgp\_>** 3b7ameed is raising funds to contribute Arabic translations: https://forum.getmonero.org/8/funding-required/90357/3b7ameed-arabic-translation  
+**\<sgp\_>** el00ruobuob is raising funds to work on Monero for another quarter: https://forum.getmonero.org/8/funding-required/90318/el00ruobuob-part-time-for-another-quarter-jully-september  
+**\<sgp\_>** Does anyone else have a FFS update, or comments about any of these FFS proposals?  
+**\<rehrar>** Fund them all.  
+**\<el00ruobuob\_[m]>** yeh fund us all :D  
+**\<rehrar>** We've had a remarkable number of FFS proposals about male enhancement  
+**\<rehrar>** I'm thinking there is demand for this.  
+**\<anonimal>** ^  
+**\<anonimal>** better cash in while we can  
+**\<oneiric\_>** :) enhance all the males  
+**\<sgp\_>** rehrar can you remind us about the state of the new FFS? It's been held up for a loooong time now  
+**\<rehrar>** Yes, it has. I asked core team about it the other day (requires their help to hook in to the ffs wallet) and they are now looking for a new PHP guy  
+**\<rehrar>** sometimes you gotta give core team a prod or thirty  
+**\<suraeNoether>** Oh i have a question  
+**\<sgp\_>** I think in this case it's 300  
+**\<sgp\_>** go ahead  
+**\<suraeNoether>** Re: the first monero conference and this FFS  
+**\<suraeNoether>** the event organizer I'm speaking with is working on an FFS proposal  
+**\<anonimal>** Are we talking about https://forum.getmonero.org/6/ideas/90356/defcon-speaker-ffs ?  
+**\<rehrar>** no, we're talking about the completely new FFS  
+**\<rehrar>** getmonero.org/forum-funding-system  
+**\<rehrar>** moving away from this "forum" and onto something git based to reduce spam  
+**\<suraeNoether>** should this monero conference FFS be listed as one of the community workgroup FFS proposals?  
+**\<suraeNoether>** (I think she'll be done with it early this week or next)  
+**\<rehrar>** hey that's kinda cool  
+**\<rehrar>** something of that magnitude though will probably need a decent amount of discussion  
+**\<sgp\_>** I don't believe there's a special distinction for the "community" FFS proposals  
+**\<suraeNoether>** oh, we're just listing live FFS requests, then? okay, :P then I don't have a question, but a comment: expect a new FFS proposal later this week for community discussion to decide how to proceed to organize such a conference.  
+**\<suraeNoether>** or perhaps early the week after  
+**\<sgp\_>** Yes suraeNoether, all FFS proposals are welcome here  
+**\<suraeNoether>** I've instructed her to sort of lay out all the options so we can get a sense of a range of prices and expectations, and what we would get for what we pay for in various scenarios. if we don't like her proposal, we can go with someone else  
+**\<sgp\_>** Anyone else have something to say before we move on?  
+**\<nioc>** How do we get the current FFS that are open funded?  
+**\<oneiric\_>** very excited for a monero conference  
+**\<nioc>** do action for days  
+**\<nioc>** no  
+**\<anonimal>** monero conference = the colorado conference ?  
+**\<rehrar>** nioc probably repost on the reddit  
+**\<rehrar>** if it's not in the forefront of people's attention, they don't think to look  
+**\<sgp\_>** Do these FFS proposals get mentioned in Telegram ever?  
+**\<rehrar>** the telegram people are their own special breed  
+**\<msvb-lab>** Please give the hardware team early notice if things are halfway arranged so we can prepare if badges or other conference devices are wanted.  
+**\<el00ruobuob\_[m]>** where is this conference supposed to be anyway?  
+**\<el00ruobuob\_[m]>** suraeNoether?  
+**\<suraeNoether>** Denver, CO, probably late June 2019  
+**\<rottensalty07>** rehrar: Right - IRC channels outperform Telegram group chats by a long shot.  
+**\<sgp\_>** Let's postpone discussion on the conference until after the FFS goes live  
+**\<rottensalty07>** suraeNoether: Is there a Taiga group or anything to follow up on the conference?  
+**\<suraeNoether>** rottensalty07: there will be!  
+**\<sgp\_>** nioc: if we still have time in open ideas time, we can reopen discussion on encouraging FFS contributions  
+**\<nioc>** ok  
+**\<sgp\_>** 5. Workgroup report  
+**\<sgp\_>** This is a separate section where other workgroups can report on all that they are working on. If you would like for your workgroup to be represented, please contact me at least a few hours before the meeting.  
+**\<sgp\_>** a. Localization workgroup  
+**\<sgp\_>** ErCiccione, take it away  
+**\<el00ruobuob\_[m]>** ErCiccione is re-localizing himself ;)  
+**\<ErCiccione>** ok, nothing too important to be honest. The only big thing is that i finished to test Pootle (the localization platform) locally, and now i'm waiting instructions from pigeons to start testing it live (it will be hosted on getmonero's server)  
+**\<ErCiccione>** also  
+**\<ErCiccione>** Monerujo and Kovri are always looking for translators, those are my focus in this period, so if somebody want to help they just need to contact me  
+**\<ErCiccione>** nothing else popping up in my mind (sorry i'm also not in a great mood today for personal reasons) so if somebody have questions, please go ahead  
+**\<sgp\_>** Thanks ErCiccione  
+**\<ErCiccione>** oh, forgot to remind that as always all the work of the localization workgroup can be tracked on taiga: https://taiga.getmonero.org/project/erciccione-monero-localization/  
+**\<sgp\_>** b. Outreach workgroup  
+**\<sgp\_>** xmrhaelan posted a recent update on the Outreach workgroup: https://www.reddit.com/r/Monero/comments/8t7012/introducing\_monero\_outreach\_workgroup/  
+**\<monerobux>** [REDDIT] Introducing: Monero Outreach workgroup (self.Monero) | 50 points (95.0%) | 8 comments | Posted by xmrhaelan | Created at 2018-06-23 - 02:48:00  
+**\<sgp\_>** Do any other workgroups have a report?  
+**\<sgp\_>** All right then, we have half the meeting for the really fun stuff  
+**\<sgp\_>** 6. Open ideas time  
+**\<sgp\_>** It’s open ideas time! Feel free to propose your ideas to this discussion group, and feel free to comment on others’ ideas. If you disagree with the idea, please reply with constructive criticism. Thank you!  
+**\<el00ruobuob\_[m]>** i think the outreach workgroup had pushed a journalism file on getmoner  
+**\<el00ruobuob\_[m]>** getmonero  
+**\<sgp\_>** Yes, it is mentioned in the Reddit post  
+**\<el00ruobuob\_[m]>** quick cheat fact or something  
+**\<el00ruobuob\_[m]>** but no link yet  
+**\<vp11>** hey there everyone. so, about point 3 "We often receive feedback that new users have no idea how to find workgroups and get involved."  
+**\<vp11>** we should totally organize ourselves and find a way to add them in getmonero.org  
+**\<vp11>** probably in the "community" section  
+**\<sgp\_>** el00ruobuob\_[m]: https://taiga.getmonero.org/media/attachments/5/7/4/5/7d6f57b35ee6dc6df9f74534cf9a3693a3d04741d0c97cfca2837692fcda/quickfacts\_v2\_g.pdf  
+ sgp\_ suraeNoether sneurlax Snipa sarang scoobybejesus selsta sgp\_[m] shillobear SlyFerret sn0wmonster sneurlax1  
+**\<el00ruobuob\_[m]>** yes sgp\_  
+**\<vp11>** links to the taiga projects / telegram and other communication channels for each group would vastly increase the visibility for them  
+**\<sgp\_>** vp11: the "Hangouts" page is getting a redesign to include this info :)  
+**\<el00ruobuob\_[m]>** but there is no link from the press kit page for it  
+**\<vp11>** amazing :)  
+**\<sgp\_>** el00ruobuob\_[m]: I see what you mean. It apparently needs to added. I'm not familiar with the status  
+**\<el00ruobuob\_[m]>** i believed rehrar was supposed to add it, but had no time to do  
+**\<sgp\_>** vp11 the first step is to collect the content (hence the template I made). Then we can make the Hangouts page more meaningful  
+**\<msvb-lab>** If anybody is working on press and journalism, please come to the Defcon project.  
+**\<vp11>** sgp\_, makes sense. if it's already planned, then wonderful.  
+**\<msvb-lab>** We have no press and need it quite a lot.  
+**\<vp11>** so about localization of the getmonero.org website, this might be a question more to ErCiccione but I guess I will say it here...  
+**\<rehrar>** No, the Team page is being redone to a workgroup page  
+**\<vp11>** in the "community" part, should the translation completely respect the channels that are there? or is there the possibility to \*add\* local channels? e.g. the italian translation might add the #monero-it channel, telegram group, etc... so italians can find the italian community.  
+**\<sgp\_>** rehrar I must have mixed them up  
+**\<el00ruobuob\_[m]>** vp11, i did it  
+**\<el00ruobuob\_[m]>** in https://github.com/monero-project/monero-site/pull/773  
+**\<el00ruobuob\_[m]>** added the monero-fr channel  
+**\<el00ruobuob\_[m]>** only on french page  
+**\<rottensalty07>** msvb-lab: Out of curiosity only... What is the DEFCON project specifically looking for in journalism?  
+**\<ErCiccione>** yes the "hangouts" part has been recently fixed by el00ruobuob\_ and that can be totally be done once it will be merged  
+**\<vp11>** I just checked the french page and didn't see it, it wasn't merged yet then. but alright, this gives precedent to add local channels as well. are there limitations on the type of channel? can we add slack, telegram, etc? should one just apply common sense and make the pr?  
+**\<el00ruobuob\_[m]>** not merged yet  
+**\<msvb-lab>** rottensalty07: We have a very appealing position at Defcon as being the only cryptocurrency well represented, and so we can use this to drive coverage with reporters.  
+**\<el00ruobuob\_[m]>** i think we could add a telegram section  
+**\<el00ruobuob\_[m]>** and a slack one  
+**\<ErCiccione>** no slack please  
+**\<\_Slack> \<sean>** :(  
+**\<vp11>** there's already a "slack" button on the page  
+**\<rottensalty07>** msvb-lab: Hmm... I think I still have the contact with a journalist who was doing internships in few American newspapers not long ago...  
+**\<el00ruobuob\_[m]>** we could add whatever section we have concensus on :D  
+**\<rottensalty07>** I should see whether I can get ahold of her.  
+**\<vp11>** what's the problem of adding another one just below with "SLACK FR" ?  
+**\<rottensalty07>** Question being, do you need informal journalism or actual, legitimate mainstream direct coverage?  
+**\<ErCiccione>** it's no friend of FOSS projects and we decided time ago to don't suggest it. It's still there, but we should push people away from it  
+**\<ErCiccione>** also, slack itself is not open source  
+**\<rehrar>** We should have a mastadon acount  
+**\<anonimal>** Some skidiot got ahold of taiga https://taiga.getmonero.org/discover  
+**\<rottensalty07>** #mastadon  
+**\<anonimal>** Not sure if that was discussed yet  
+**\<rehrar>** thanks anonimal, I'll clear it out now.  
+**\<sgp\_>** Good catch anonimal  
+**\<vp11>** although I agree it's not FOSS-friendly I think we should be very critical of our main goal with this. the community section is about bringing people together. we can't force Japanese people to stop using LINE for example.  
+**\<msvb-lab>** rottensalty07: We need a person to create our press message, invite reporters, prepare a AP paragraph, schedule interviews, and coordinate all press and journalism on their own.  
+**\<oneiric\_>** Kovri is still working hard toward the alpha release by DefCon. Currently working on the core refactors to signing cryptography, testnet API, RouterInfo refactors, fixing Coverity bugs, and various build system upgrades. The hunt for i2pd (pre-fork) bugs continues, and we have some new contributors doing awesome work Wuodan and tmoravec.  
+**\<vp11>** so in theory we should respect what local communities are using as main communication platform and try to create a monero channel/group there.  
+**\<el00ruobuob\_[m]>** oh! lol!  
+**\<rehrar>** I'm torn vp11. I completely agree  
+**\<ErCiccione>** vp11: that's why it's still there, but i don't see any reason to advertise it when we have many open source alternatives  
+**\<rehrar>** and hate the closed source stuff  
+**\<rottensalty07>** msvb-lab: That's a heavy task to take on... I'll try to get ahold of this reporter - she was quite friendly and very interested in crypto - it was a back-of-the-room meetup of BTC last year where I first saw her...  
+**\<ErCiccione>** why not just relay slack on freenode or riot or mattermost and advertise those instead? should we really push slack? why?  
+**\<vp11>** I hate closed source but I can't stop using WhatsApp, otherwise I will have no contact with my family and friends in South America. I can try to educate them about open source and alternatives, but I will not cross my arms and stop talking to them about Monero in WhatsApp because I believe making the project known is more important about the technology behind the communication platform.  
+**\<sgp\_>** Yeah, I expect it will still be supported. There is talk of adding another relay for Discord too. There's no real harm in adding more platforms as long as they can talk to each other  
+**\<vp11>** Slack was just an example, really.  
+**\<vp11>** It can be anything.  
+**\<sgp\_>** ErCiccicione we will not "advertise" these options, just make them available  
+**\<rottensalty07>** msvb-lab: On an unrelated note, did the DEFCON meeting agree on anything regarding other cryptocurrencies talks? It's pegged. The same back-room meetup I attend to, happens to have the connections with Zcash people and reporters doing internships...  
+**\<vp11>** I don't know what people use in Romania, maybe it's Telegram. so it would make sense to have a Romanian Monero channel in Telegram.  
+**\<ErCiccione>** yes, but you are a single, not an open source project vp11, i think our choice on this matter is important :)  
+**\<el00ruobuob\_[m]>** discussions for hangouts page to be continued here https://github.com/monero-project/monero-site/issues/775  
+**\<sgp\_>** ErCiccioen you can choose to organize your group in a Mattermost group and force your contributors to use it, but this channel should reach as far as possible  
+**\<msvb-lab>** rottensalty07: I think there was neither agreement nor disagreement about the topic. Try posting to the mailing list, if you don't want to wait until next week's meeting.  
+**\<vp11>** the best example that I have for that is the Brazilian community. I tried very hard to push for IRC there. right now there are 9 people in the #monero-br (3 are bots) but 200+ people in WhatsApp.  
+**\<ErCiccione>** i honestly think we shouldn't put any more slack, but if i'm the only one who as this problem whatever.  
+**\<vp11>** so it would make sense to add a link to the WhatsApp group, since the chances that a Brazilian visit the website and use IRC is almost zero, but the chances of the user having whatsapp are pretty much 100%.  
+**\<\_Slack> \<sean>** ErCiccione: I agree about moving away from Slack. That ease-of-use tho.  
+**\<vp11>** I think this is an important discussion since it goes directly into the getmonero.org website :)  
+**\<sgp\_>** ErCiccione some contributors still use Slack, so it's important to maintain for the time being, even if we don't want to specifically target attracting new users to it  
+**\<msvb-lab>** rottensalty07: All the speaking slots are filled, but there may be other areas of collaboration.  
+**\<rottensalty07>** msvb-lab: That's the best way for me to work with y'all for the time being - class is in the middle of our meetings, unfortunately. Would you mind passing on the e-mail address I should send the e-mail to in order for me to reach everyone? (I'll save it in my notes not to forget ever again, lol.)  
+**\<msvb-lab>** Maybe a simple form of outreach so that they know we are there and they are welcome.  
+**\<ErCiccione>** sgp\_ i don't say they shouldn't exist, just that we shouldn't advertise them. #monero-translations is also on slack, i just point interested people on other platforms  
+**\<ErCiccione>** and if they ask for a slack channel i point to it  
+**\<rehrar>** this Taiga spammer made so many garbage projects >\_>  
+**\<ErCiccione>** but nobody ever asked for it :)  
+**\<rottensalty07>** msvb-lab: Hmm, if all speaking slots are filled already it wouldn't make much sense to propose other cryptocurrency persons...  
+**\<rottensalty07>** Okay, noted.  
+**\<msvb-lab>** monero-defcon@lists.getmonero.org  
+**\<rottensalty07>** Danke.  
+**\<ErCiccione>** sgp\_ i never suggested to drop it  
+**\<el00ruobuob\_[m]>** Bitte  
+**\<anonimal>** Thanks for speaking up, oneiric\_. The report seems to have gotten lost in the chatter.  
+**\<oneiric\_>** No problem, I'll prepare more for next meeting.  
+**\<anonimal>** sgp\_: do you need more time for your dc presentation?  
+**\<sgp\_>** dc presentation?  
+**\<anonimal>** Are you doing a defcon presentation? I'm trying to find the link on taiga of timeslots  
+**\<msvb-lab>** https://taiga.getmonero.org/project/michael-vegas-august-2018/wiki/agenda/  
+**\<anonimal>** ty  
+**\<msvb-lab>** There is sgp, then our 360.cn friend, then anonimal.  
+**\<sgp\_>** anonimal I am giving 2 short talks and moderating the panel you're on  
+**\<rottensalty07>** msvb-lab: Oh, oh. She's actually writing for Cointelegraph...  
+**\<rottensalty07>** I definitely will first ask her for the contact information and sort of introduce the idea... but respecting what you've said in the past regarding extending formal invitations, I'll leave that for rehrar and the other man in charge...  
+**\<anonimal>** I'm willing to reduce my 2 hours timeslot to 1 hour if others need more time. sgp if interested.  
+**\<sgp\_>** I don't anticipate using more time  
+**\<sgp\_>** Thanks for the offer though  
+**\<anonimal>** Is Zhiniang Peng here?  
+**\<msvb-lab>** anonimal: No, his timezone is about midnight or so.  
+**\<msvb-lab>** We can meet him the day before our village starts, get to know him and ask if he wants some creative time change or merging with anonimal's workshop.  
+**\<anonimal>** ok  
+**\<msvb-lab>** Things can get creative because the physical areas are different.  
+**\<anonimal>** Sounds good  
+**\<rehrar>** Taiga will probably be down for maintenance soon.  
+**\<rehrar>** this guy made a mess of things  
+**\<rehrar>** I was hoping to never have to lock signups to invite only, but if this happens again, we might have to  
+**\<sgp\_>** rehrar is there a way to limit the number of projects people can make in one day?  
+**\<oneiric\_>** re: taiga skid, what a troll  
+**\<rehrar>** Don't think so.  
+**\<anonimal>** Can't we apply a captcha?  
+**\<anonimal>** Do they have a plugin for that?  
+**\<anonimal>** (non-google captcha)  
+**\<rehrar>** captcha for making each project sounds like a sane thing to implement  
+**\<anonimal>** I used to use this years back but I don't know if it's still any good https://www.phpcaptcha.org/  
+**\<sgp\_>** yeah, nearly anything is better than invite-only  
+**\<el00ruobuob\_[m]>** talking about invite,  
+**\<el00ruobuob\_[m]>** sgp\_, could you invite me on your sgp-monero-community-workgroup  
+**\<sgp\_>** added  
+**\<el00ruobuob\_[m]>** thx  
+**\<sgp\_>** Last chance to make your voice heard about something  
+**\<oneiric\_>** thanks for reminder el00ruobuob\_, anonimal can I get an invite to the Kovri taiga workgroup?  
+**\<sgp\_>** 7. Confirm next meeting date/time  
+**\<sgp\_>** The next community meeting will be two weeks from today on the 7 July at 17:00 UTC. The next Coffee Chat will be on the 14 July.  
+**\<sgp\_>** 8. Conclusion  
+**\<sgp\_>** That’s all! Thanks for attending this Monero Community meeting, and we hope to see you on /r/MoneroCommunity and #monero-community. Take care, and know that change starts with YOU.  
+**\<anonimal>** oneiric\_: yes. I thought it was open to all, it should be. I'll send the invite.  
+**\<oneiric\_>** thanks for the meeting sgp\_  
+**\<el00ruobuob\_[m]>** thank to all of you for being you!  
+**\<oneiric\_>** anonimal: many thanks  
+**\<vp11>** thanks all  
+**\<vp11>** never forget that you're awesome :)  
+**\<anonimal>** Dang sgp\_ that was a 7 second window to confirm the next meeting ;)  
+**\<oneiric\_>** it might be open to all, I'm not good at taiga  
+**\<rehrar>** I will probably be disabling Taiga registrations for the time being while we sort this out  
+**\<msvb-lab>** sgp\_: Thanks for a hour of moderation, good job.


### PR DESCRIPTION
Tested on the following platforms:

  | Edge | IE 11 | Chrome | Firefox | Opera | Vivaldi
-- | -- | -- | -- | -- | -- | --
Windows 7 | - | OK | OK | OK | OK | OK
Windows 10 | KO | OK | OK | OK | OK | OK
Ubuntu 18.04 | - | - | OK | OK | OK | OK
CentOS 7 | - | - | - | OK | OK | OK

Edge is displaying the content box larger than it should.
It is because of long link `https://taiga.getmonero.org/media/attachments/5/7/4/5/7d6f57b35ee6dc6df9f74534cf9a3693a3d04741d0c97cfca2837692fcda/quickfacts_v2_g.pdf` not been split, so perhaps CSS should be corrected here. Any clue @rehrar?
Should i split the link in two to avoid this mess?