### PR TITLE
Roadmap update to match bulletproofs & kovri updates

### DIFF
--- a/_data/lang/ar/roadmap.yml
+++ b/_data/lang/ar/roadmap.yml
@@ -95,13 +95,16 @@
     - name: ترجمه الموقع إلي الفرنسيه والبولنديه
       date: 2018-04-24
       status: completed
+    - name: الإصدار الأول لمشروع كوفري
+      date: 2018-08-01
+      status: completed
     - name: إعاده تصميم نظام التمويل بالمنتدي
       date:
       status: ongoing
-    - name: نظام "مدي التأكيد" أكثر كفأً لمعاملات الحقل السري لتقليل حجم المعاملات
+    - name: Implementation of BulletProofs instead of RingCT to reduce transaction sizes
       date:
-      status: upcoming
-    - name: الإصدار الأول لمشروع كوفري
+      status: ongoing
+    - name: Kovri beta release
       date:
       status: upcoming
 - year: 2019

--- a/_data/lang/en/roadmap.yml
+++ b/_data/lang/en/roadmap.yml
@@ -98,13 +98,16 @@
     - name: Ledger Hardware Wallets Support
       date: 2018-06-04
       status: completed
+    - name: Kovri alpha release
+      date: 2018-08-01
+      status: completed
     - name: Forum Funding System redesign
       date:
       status: ongoing
-    - name: More efficient range proofs for RingCT to reduce transaction sizes
+    - name: Implementation of BulletProofs instead of RingCT to reduce transaction sizes
       date:
-      status: upcoming
-    - name: Kovri alpha release
+      status: ongoing
+    - name: Kovri beta release
       date:
       status: upcoming
 - year: 2019

--- a/_data/lang/es/roadmap.yml
+++ b/_data/lang/es/roadmap.yml
@@ -98,13 +98,16 @@
     - name: Ledger Hardware Wallets Support
       date: 2018-06-04
       status: completed
+    - name: Kovri alpha release
+      date: 2018-08-01
+      status: completed
     - name: Forum Funding System redesign
       date:
       status: ongoing
-    - name: More efficient range proofs for RingCT to reduce transaction sizes
+    - name: Implementation of BulletProofs instead of RingCT to reduce transaction sizes
       date:
-      status: upcoming
-    - name: Kovri alpha release
+      status: ongoing
+    - name: Kovri beta release
       date:
       status: upcoming
 - year: 2019

--- a/_data/lang/fr/roadmap.yml
+++ b/_data/lang/fr/roadmap.yml
@@ -98,13 +98,16 @@
     - name: Support des portefeuilles matériel Ledger
       date: 2018-06-04
       status: completed
+    - name: Version alpha de Kovri
+      date: 2018-08-01
+      status: completed
     - name: Refonte du Forum Funding System (FFS)
       date:
       status: ongoing
-    - name: Preuves à divulgation nulle de connaissance plus efficaces pour les transactions confidentielles de cercle (RingCT) afin de réduire la taille des transactions
+    - name: Mise en place des *BulletProofs* à la place des transactions confidentielles de cercle (RingCT) afin de réduire la taille des transactions
       date:
-      status: upcoming
-    - name: Version alpha de Kovri
+      status: ongoing
+    - name: Version beta de Kovri
       date:
       status: upcoming
 - year: 2019

--- a/_data/lang/it/roadmap.yml
+++ b/_data/lang/it/roadmap.yml
@@ -98,13 +98,16 @@
     - name: Supporto per hardware wallet Ledger
       date: 2018-06-04
       status: completed
+    - name: Rilascio versione alpha di Kovri
+      date:
+      status: completed
     - name: Redesign del Forum Funding System
       date:
       status: ongoing
-    - name: Range proofs più efficiente per RingCT - Ridurre dimensione delle transazioni
+    - name: Implementation of BulletProofs instead of RingCT - Ridurre dimensione delle transazioni
       date:
-      status: upcoming
-    - name: Rilascio versione alpha di Kovri
+      status: ongoing
+    - name: Rilascio versione beta di Kovri
       date:
       status: upcoming
 - year: 2019

--- a/_data/lang/pl/roadmap.yml
+++ b/_data/lang/pl/roadmap.yml
@@ -98,13 +98,16 @@
     - name: Support dla portfeli Ledger Hardware
       date: 2018-06-04
       status: completed
+    - name: Wypuszczenie systemu Kovri Alpha
+      date: 2018-08-01
+      status: completed
     - name: Zmiana wyglądu Forumowego Systemu Finansowania
       date:
       status: ongoing
-    - name: Efektywniejsze dowody zasięgu dla RingCT w celu zmniejszenia rozmiarów transakcji
+    - name: Implementation of BulletProofs instead of RingCT w celu zmniejszenia rozmiarów transakcji
       date:
-      status: upcoming
-    - name: Wypuszczenie systemu Kovri Alpha
+      status: ongoing
+    - name: Wypuszczenie systemu Kovri Beta
       date:
       status: upcoming
 - year: 2019

--- a/_data/lang/template/roadmap.yml
+++ b/_data/lang/template/roadmap.yml
@@ -98,13 +98,16 @@
     - name: Ledger Hardware Wallets Support
       date: 2018-06-04
       status: completed
+    - name: Kovri alpha release
+      date: 2018-08-01
+      status: completed
     - name: Forum Funding System redesign
       date:
       status: ongoing
-    - name: More efficient range proofs for RingCT to reduce transaction sizes
+    - name: Implementation of BulletProofs instead of RingCT to reduce transaction sizes
       date:
-      status: upcoming
-    - name: Kovri alpha release
+      status: ongoing
+    - name: Kovri beta release
       date:
       status: upcoming
 - year: 2019


### PR DESCRIPTION
This solves #805
All languages needs to be reviewed (or retranslated) @erciccione.

This should not be merged before 8/1 as it states kovri alpha release is completed at this date.
Is it still the goal @anonimal?