### PR TITLE
Wikipedia link corrected in Moneropedia articles

### DIFF
--- a/_i18n/ar/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/ar/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that w
 
 A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/etc/hosts)
+- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
 - an internal-network resolver (which eventually pulls from external sources)
 
 ### Notes

--- a/_i18n/ar/resources/moneropedia/locally-unique-host.md
+++ b/_i18n/ar/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "A host defined by you and resolved only by you"
 {% include untranslated.html %}
 ### The Basics
 
-A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) is implemented. Not to be confused with @canonically-unique-host.
+A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) is implemented. Not to be confused with @canonically-unique-host.
 
 ### In-depth information
 

--- a/_i18n/ar/resources/moneropedia/subscription.md
+++ b/_i18n/ar/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ A subscription is a file which contains a list of `.i2p` hosts paired with their
 
 ### In-depth information
 
-Similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) can map an Internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
+Similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) can map an Internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
 
 More specifically, a subscription pairs a @locally-unique-host to @base64-address.
 

--- a/_i18n/en/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/en/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that w
 
 A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/etc/hosts)
+- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
 - an internal-network resolver (which eventually pulls from external sources)
 
 ### Notes

--- a/_i18n/en/resources/moneropedia/locally-unique-host.md
+++ b/_i18n/en/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "A host defined by you and resolved only by you"
 
 ### The Basics
 
-A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) is implemented. Not to be confused with @canonically-unique-host.
+A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) is implemented. Not to be confused with @canonically-unique-host.
 
 ### In-depth information
 

--- a/_i18n/en/resources/moneropedia/subscription.md
+++ b/_i18n/en/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ A subscription is a file which contains a list of `.i2p` hosts paired with their
 
 ### In-depth information
 
-Similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
+Similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
 
 More specifically, a subscription pairs a @locally-unique-host to @base64-address.
 

--- a/_i18n/es/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/es/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that w
 
 A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/etc/hosts)
+- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
 - an internal-network resolver (which eventually pulls from external sources)
 
 ### Notes

--- a/_i18n/es/resources/moneropedia/locally-unique-host.md
+++ b/_i18n/es/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "A host defined by you and resolved only by you"
 
 ### The Basics
 
-A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) is implemented. Not to be confused with @canonically-unique-host.
+A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) is implemented. Not to be confused with @canonically-unique-host.
 
 ### In-depth information
 

--- a/_i18n/es/resources/moneropedia/subscription.md
+++ b/_i18n/es/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ A subscription is a file which contains a list of `.i2p` hosts paired with their
 
 ### In-depth information
 
-Similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
+Similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
 
 More specifically, a subscription pairs a @locally-unique-host to @base64-address.
 

--- a/_i18n/fr/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/fr/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that w
 
 A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/etc/hosts)
+- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
 - an internal-network resolver (which eventually pulls from external sources)
 
 ### Notes

--- a/_i18n/fr/resources/moneropedia/locally-unique-host.md
+++ b/_i18n/fr/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "A host defined by you and resolved only by you"
 
 ### The Basics
 
-A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) is implemented. Not to be confused with @canonically-unique-host.
+A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) is implemented. Not to be confused with @canonically-unique-host.
 
 ### In-depth information
 

--- a/_i18n/fr/resources/moneropedia/subscription.md
+++ b/_i18n/fr/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ A subscription is a file which contains a list of `.i2p` hosts paired with their
 
 ### In-depth information
 
-Similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
+Similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
 
 More specifically, a subscription pairs a @locally-unique-host to @base64-address.
 

--- a/_i18n/it/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/it/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that w
 
 A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/etc/hosts)
+- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
 - an internal-network resolver (which eventually pulls from external sources)
 
 ### Notes

--- a/_i18n/it/resources/moneropedia/locally-unique-host.md
+++ b/_i18n/it/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "A host defined by you and resolved only by you"
 
 ### The Basics
 
-A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) is implemented. Not to be confused with @canonically-unique-host.
+A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) is implemented. Not to be confused with @canonically-unique-host.
 
 ### In-depth information
 

--- a/_i18n/it/resources/moneropedia/subscription.md
+++ b/_i18n/it/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ A subscription is a file which contains a list of `.i2p` hosts paired with their
 
 ### In-depth information
 
-Similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
+Similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) can map an internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
 
 More specifically, a subscription pairs a @locally-unique-host to @base64-address.
 

--- a/_i18n/pl/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/pl/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ Zasadniczy unikalny host jest [Pełną, Jednoznaczną Nazwą Domenową] (https:/
 
 Zasadniczy unikalny host jest definiowany przez zdalne autorytatywne źródła,  przeważnie za pomocą [Systemu Nazw Domenowych](https://en.wikipedia.org/wiki/DNS). Podczas rozwiązywania nazwy hosta peera najprawdopodobniej użyjesz zewnętrznego źródła do rozwiązania, chyba że zaimplementowano jedno z następujących:
 
-- plik bazy danych podobny do [plików hosta](https://en.wikipedia.org/wiki/etc/hosts)
+- plik bazy danych podobny do [plików hosta](https://en.wikipedia.org/wiki/Hosts_(file))
 - rezolwera wewnętrznej sieci (który pobiera z zewnętrznych źródeł).
 
 ### Adnotacje

--- a/_i18n/pl/resources/moneropedia/locally-unique-host.md
+++ b/_i18n/pl/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "Host zdefiniowany i ustalony wyłącznie przez ciebie."
 
 ### Podstawy
 
-Lokalnie unikalny host jest [Pełną, Jendoznaczną Nazwą Domenową](https://en.wikipedia.org/wiki/FQDN) definiowaną przez **ciebie** i ustaloną wyłącznie przez ciebie, podobnie do tego, jak wdrażane są [pliki hosts](https://en.wikipedia.org/wiki/etc/hosts). Nie należy go mylić z @zasadniczym-unikalnym-hostem.
+Lokalnie unikalny host jest [Pełną, Jendoznaczną Nazwą Domenową](https://en.wikipedia.org/wiki/FQDN) definiowaną przez **ciebie** i ustaloną wyłącznie przez ciebie, podobnie do tego, jak wdrażane są [pliki hosts](https://en.wikipedia.org/wiki/Hosts_(file)). Nie należy go mylić z @zasadniczym-unikalnym-hostem.
 
 ### Szczegółowe informacje
 

--- a/_i18n/pl/resources/moneropedia/subscription.md
+++ b/_i18n/pl/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ Subskrypcja jest plikiem, który zawiera listę hostów `.i2p` sparowanych z odp
 
 ### Szczegółowe informacje
 
-Podobnie do tego, jak [plik hostów](https://en.wikipedia.org/wiki/etc/hosts) łączy nazwę hostu internetowego z konkretnym adresem, subskrypcja przypisuje adres `.i2p` do @adresu-base64 poprzez użycie następującego formatu (bez spacji): `host=address`
+Podobnie do tego, jak [plik hostów](https://en.wikipedia.org/wiki/Hosts_(file)) łączy nazwę hostu internetowego z konkretnym adresem, subskrypcja przypisuje adres `.i2p` do @adresu-base64 poprzez użycie następującego formatu (bez spacji): `host=address`
 
 Dokładniej, subskrypcja paruje @lokalnie-unikalny-host z @adresem-base64.
 

--- a/resources/moneropedia/canonically-unique-host.md
+++ b/resources/moneropedia/canonically-unique-host.md
@@ -14,7 +14,7 @@ A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that w
 
 A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/etc/hosts)
+- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
 - an internal-network resolver (which eventually pulls from external sources)
 
 ### Notes

--- a/resources/moneropedia/locally-unique-host.md
+++ b/resources/moneropedia/locally-unique-host.md
@@ -8,7 +8,7 @@ summary: "A host defined by you and resolved only by you"
 
 ### The Basics
 
-A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) is implemented. Not to be confused with @canonically-unique-host.
+A locally-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) defined by **you** and resolved only by you; similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) is implemented. Not to be confused with @canonically-unique-host.
 
 ### In-depth information
 

--- a/resources/moneropedia/subscription.md
+++ b/resources/moneropedia/subscription.md
@@ -12,7 +12,7 @@ A subscription is a file which contains a list of `.i2p` hosts paired with their
 
 ### In-depth information
 
-Similar to how a [hosts file](https://en.wikipedia.org/wiki/etc/hosts) can map an Internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
+Similar to how a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file)) can map an Internet hostname to a specified address, a subscription matches a `.i2p` address to @base64-address by using the following format (no spaces allowed): `host=address`
 
 More specifically, a subscription pairs a @locally-unique-host to @base64-address.
 


### PR DESCRIPTION
While translating Moneropedia, i found out that the link to wikipedia `/etc/hosts` page was wrong.
The page is not under `https://en.wikipedia.org/wiki/Etc/hosts` anymore but under `https://en.wikipedia.org/wiki/Hosts_(file)`

This correct the link for all occurence of it in all moneropedia article of all languages:

- cannonicaly-unique host
- locally-unique host
- subscription