### PR TITLE
Update Pedersen Commitment Moneropedia terms

### DIFF
--- a/_i18n/ar/resources/moneropedia/pedersen-commitment.md
+++ b/_i18n/ar/resources/moneropedia/pedersen-commitment.md
@@ -1,6 +1,6 @@
 ---
 entry: "Pedersen Commitment"
-terms: ["commitments", "commitment", "pedersen"]
+terms: ["commitments", "commitment", "pedersen", "pedersen-commitment", "pedersen-commitments"]
 summary: "Pedersen commitments are cryptographic algorythms that allow a prover to commit to a certain value without revealing it or being able to change it"
 ---
 

--- a/_i18n/en/resources/moneropedia/pedersen-commitment.md
+++ b/_i18n/en/resources/moneropedia/pedersen-commitment.md
@@ -1,6 +1,6 @@
 ---
 entry: "Pedersen Commitment"
-terms: ["commitments", "commitment", "pedersen"]
+terms: ["commitments", "commitment", "pedersen", "pedersen-commitment", "pedersen-commitments"]
 summary: "Pedersen commitments are cryptographic algorythms that allow a prover to commit to a certain value without revealing it or being able to change it"
 ---
 

--- a/_i18n/es/resources/moneropedia/pedersen-commitment.md
+++ b/_i18n/es/resources/moneropedia/pedersen-commitment.md
@@ -1,6 +1,6 @@
 ---
 entry: "Pedersen Commitment"
-terms: ["commitments", "commitment", "pedersen"]
+terms: ["commitments", "commitment", "pedersen", "pedersen-commitment", "pedersen-commitments"]
 summary: "Pedersen commitments are cryptographic algorythms that allow a prover to commit to a certain value without revealing it or being able to change it"
 ---
 

--- a/_i18n/fr/resources/moneropedia/pedersen-commitment.md
+++ b/_i18n/fr/resources/moneropedia/pedersen-commitment.md
@@ -1,6 +1,6 @@
 ---
 entry: "Pedersen Commitment"
-terms: ["commitments", "commitment", "pedersen"]
+terms: ["commitments", "commitment", "pedersen", "pedersen-commitment", "pedersen-commitments"]
 summary: "Pedersen commitments are cryptographic algorythms that allow a prover to commit to a certain value without revealing it or being able to change it"
 ---
 

--- a/_i18n/it/resources/moneropedia/pedersen-commitment.md
+++ b/_i18n/it/resources/moneropedia/pedersen-commitment.md
@@ -1,6 +1,6 @@
 ---
 entry: "Pedersen Commitment"
-terms: ["commitments", "commitment", "pedersen"]
+terms: ["commitments", "commitment", "pedersen", "pedersen-commitment", "pedersen-commitments"]
 summary: "Pedersen commitments are cryptographic algorythms that allow a prover to commit to a certain value without revealing it or being able to change it"
 ---
 

--- a/_i18n/pl/resources/moneropedia/pedersen-commitment.md
+++ b/_i18n/pl/resources/moneropedia/pedersen-commitment.md
@@ -1,6 +1,6 @@
 ---
 entry: "Zobowiązanie Pedersena"
-terms: ["commitments", "commitment", "pedersen", "zobowiązanie", "zobowiązania", "zobowiązaniu", "zobowiązaniom", "zobowiązanie-pedersena", "zobowiązaniu-pedersena", "zobowiązaniem-pedersena"]
+terms: ["commitments", "commitment", "pedersen", "pedersen-commitment", "pedersen-commitments", "zobowiązanie", "zobowiązania", "zobowiązaniu", "zobowiązaniom", "zobowiązanie-pedersena", "zobowiązaniu-pedersena", "zobowiązaniem-pedersena"]
 summary: "Algorytmy kryptograficzne pozwalające osobie udowadniającej na zobowiązanie się do pewnej wartości bez ujawniania jej ani nie będąc w stanie jej zmienić."
 ---
 


### PR DESCRIPTION
The Pedersen commitment Moneropedia entry was only using the "pedersen" and "commitment(s)" terms.  
I added the "pedersen-commitment(s)" variant so a link could be created not only on pedersen or commitment, but on the whole pedersen-commitment at once.