### PR TITLE
Correct Kovri user guide link from moneropedia articles

### DIFF
--- a/_i18n/ar/resources/moneropedia/eepsite.md
+++ b/_i18n/ar/resources/moneropedia/eepsite.md
@@ -27,4 +27,4 @@ Alternate names include:
 
 ### Notes
 
-To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/ar/resources/moneropedia/subscription.md
+++ b/_i18n/ar/resources/moneropedia/subscription.md
@@ -44,4 +44,4 @@ A *private* subscription:
 You can use a @jump-service to manually update your private subscription. The updated subscription will then be fed into the @address-book for you to use.
 
 ### Notes
-To learn how to subscribe to multiple subscriptions, see the [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to subscribe to multiple subscriptions, see the [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/en/resources/moneropedia/eepsite.md
+++ b/_i18n/en/resources/moneropedia/eepsite.md
@@ -26,4 +26,4 @@ Alternate names include:
 
 ### Notes
 
-To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/en/resources/moneropedia/subscription.md
+++ b/_i18n/en/resources/moneropedia/subscription.md
@@ -43,4 +43,4 @@ A *private* subscription:
 You can use a @jump-service to manually update your private subscription. The updated subscription will then be fed into the @address-book for you to use.
 
 ### Notes
-To learn how to subscribe to multiple subscriptions, see the [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to subscribe to multiple subscriptions, see the [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/es/resources/moneropedia/eepsite.md
+++ b/_i18n/es/resources/moneropedia/eepsite.md
@@ -27,4 +27,4 @@ Alternate names include:
 
 ### Notes
 
-To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/es/resources/moneropedia/subscription.md
+++ b/_i18n/es/resources/moneropedia/subscription.md
@@ -44,4 +44,4 @@ A *private* subscription:
 You can use a @jump-service to manually update your private subscription. The updated subscription will then be fed into the @address-book for you to use.
 
 ### Notes
-To learn how to subscribe to multiple subscriptions, see the [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to subscribe to multiple subscriptions, see the [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/fr/resources/moneropedia/eepsite.md
+++ b/_i18n/fr/resources/moneropedia/eepsite.md
@@ -27,4 +27,4 @@ Alternate names include:
 
 ### Notes
 
-To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/fr/resources/moneropedia/subscription.md
+++ b/_i18n/fr/resources/moneropedia/subscription.md
@@ -44,4 +44,4 @@ A *private* subscription:
 You can use a @jump-service to manually update your private subscription. The updated subscription will then be fed into the @address-book for you to use.
 
 ### Notes
-To learn how to subscribe to multiple subscriptions, see the [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to subscribe to multiple subscriptions, see the [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/it/resources/moneropedia/eepsite.md
+++ b/_i18n/it/resources/moneropedia/eepsite.md
@@ -27,4 +27,4 @@ Alternate names include:
 
 ### Notes
 
-To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to setup an Eepsite (Hidden Service, Garlic Site, Garlic Service) visit the @Kovri [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/it/resources/moneropedia/subscription.md
+++ b/_i18n/it/resources/moneropedia/subscription.md
@@ -44,4 +44,4 @@ A *private* subscription:
 You can use a @jump-service to manually update your private subscription. The updated subscription will then be fed into the @address-book for you to use.
 
 ### Notes
-To learn how to subscribe to multiple subscriptions, see the [user-guide](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+To learn how to subscribe to multiple subscriptions, see the [user-guide](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).

--- a/_i18n/pl/resources/moneropedia/eepsite.md
+++ b/_i18n/pl/resources/moneropedia/eepsite.md
@@ -24,4 +24,4 @@ Innymi nazwami eepsite są
 
 ### Adnotacje
 
-Aby dowiedzieć się, jak skonfigurować Eepsite (Ukryty Serwis, Stronę Czosnkową, Serwis Czosnkowy), przejdź do [przewodnika dla użytkowników](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md) @Kovri.
+Aby dowiedzieć się, jak skonfigurować Eepsite (Ukryty Serwis, Stronę Czosnkową, Serwis Czosnkowy), przejdź do [przewodnika dla użytkowników](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md) @Kovri.

--- a/_i18n/pl/resources/moneropedia/subscription.md
+++ b/_i18n/pl/resources/moneropedia/subscription.md
@@ -44,4 +44,4 @@ Możesz skorzystać z @opcji-przeskakiwania, aby ręcznie zaktualizować swoją 
 
 ### Adnotacje
 
-Aby dowiedzieć się, w jaki sposób zapisać się do wielu subskrypcji, przejdź do [przewodnika dla użytkowników](https://github.com/monero-project/kovri/blob/master/doc/USER_GUIDE.md).
+Aby dowiedzieć się, w jaki sposób zapisać się do wielu subskrypcji, przejdź do [przewodnika dla użytkowników](https://gitlab.com/kovri-project/kovri-docs/blob/master/i18n/en/user_guide.md).


### PR DESCRIPTION
I found this while translating "subscription" article.
Link is refering to an old tree and is therfore "file not found" on the other end.

Should we link to getkovri, or github is still the target @anonimal?