### PR TITLE
Lang tag correction

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -3,7 +3,6 @@ layout: full-text
 title: titles.allposts
 ---
 
-{% t global.lang_tag %}
 {% for post in paginator.posts %}
   <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
   <p>

--- a/press-kit/index.md
+++ b/press-kit/index.md
@@ -3,7 +3,7 @@ layout: custom
 title: titles.presskit
 permalink: /press-kit/index.html
 ---
-{% t global.lang_tag %}
+
 <div class="text-center container description">
     <p>{% t press-kit.intro1 %} <strong>{% t press-kit.intro1 %}</strong> {% t press-kit.intro3 %} <a href="/press-kit/monero-press-kit.zip">{% t press-kit.intro4 %}</a></p>
 </div>


### PR DESCRIPTION
@lh1008 reported me the lang tag (ex: `@lang_tag_en`) was displayed on the "all blog post" and "press kit" page.

For some reason, those pages are not process by Jekyll Moneropedia plugin who's responsible for the tag removal.
As a workaround, i remove the tag from those pages, since there are hopefully no moneropedia entries on them, it's not really a problem.

However, if anyone has any clue why the files are not going through the ruby script, please let me know.