### PR TITLE
Refactor 'Library' section to be easily parsed by Weblate

### DIFF
--- a/_i18n/ar.yml
+++ b/_i18n/ar.yml
@@ -546,38 +546,32 @@ specs:
 
 library:
   description: "Below are some publications, books or magazines available for you to download."
-  books:
-  - category: Books
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        A comprehensive conceptual (and technical) explanation of Monero.<br>
-        We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        A guide through the seemingly complex world of Monero.<br>
-        It includes:
-        <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
-        <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
-        <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
-        <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
-        <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
-        <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
-        See <a href="https://masteringmonero.com/">Mastering Monero</a> website for info about full version.
-  - category: Magazines
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q4 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, and community.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q3 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
+  books: Books
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    A guide through the seemingly complex world of Monero.<br>
+    It includes:
+    <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
+    <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
+    <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
+    <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
+    <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
+    <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
+    See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
+  magazines: Magazines
+  revuoq4p: >
+    Quarterly Monero magazine, Q4 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, and community.
+  revuoq3p: >
+    Quarterly Monero magazine, Q3 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
 
 moneropedia:
   add_new_button: Add New Entry

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -547,38 +547,32 @@ specs:
 
 library:
   description: "Unten gibt es Veröffentlichungen, Bücher und Magazine für dich zum Download."
-  books:
-  - category: Bücher
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Eine verständliche Erklärung des Konzeptes (und der Technik) hinter Monero<br>
-        Unser Wunsch ist es, jedem mit einem Grundverständnis von Algebra und Grundlagen der Computertechnik, wie beispielsweise der Repräsentation von Zahlen im Binärsystem, nicht nur verständlich beizubringen, wie Monero im Detail funktioniert, sondern auch, wie nützlich und schön Kryptographie sein kann.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Ein Begleiter durch die scheinbar komplizierte Welt Moneros<br>
-        Er enthält:
-        <ul><li>Eine weitreichende Einführung in Blockchains und den Wert von Privatsphäre – ideal für Nutzer ohne technischen Hintergrund</li>
-        <li>Diskussion der Schwachstellen Bitcoins und spezifische Lösungen dieser durch Monero</li>
-        <li>Nutzererfahrungen (die zeigen, wie Monero deine Daten schützt), Vergleiche, Beispiele, rechtliche und ethische Diskussionen und Quellcodeauszüge, die grundlegende, technische Konzepte darlegen</li>
-        <li>Details des dezentralisierten Monero-Netzwerkes, der Peer-to-Peer-Architektur, dem Ablauf von Transaktionen und Grundlagen der Sicherheit</li>
-        <li>Einführung in das technische Fundament Moneros – für Entwickler, Ingenieure, Softwarearchitekten und neugierige Nutzer</li>
-        <li>Neue Entwicklungen wie beispielsweise Kovri, Bulletproofs, Multisignaturen, Hardware-Wallets etc.</li></ul>
-        Auf der Webseite von <a href="https://masteringmonero.com/">Mastering Monero</a> gibt es Informationen zur vollen Version.
-  - category: Magazine
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Quartalsweise erscheinendes Monero-Magazin, Ausgabe Q4 2017<br>
-        In dieser Ausgabe: Neuigkeiten zur Entwicklung, dem Monero Research Lab, Kovri und der Community
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Quartalsweise erscheinendes Monero-Magazin, Ausgabe Q3 2017<br>
-        In dieser Ausgabe: Neuigkeiten zur Entwicklung, dem Monero Research Lab, Kovri, der Community, Hardware und Monerujo
+  books: Bücher
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Ein Begleiter durch die scheinbar komplizierte Welt Moneros<br>
+    Er enthält:
+    <ul><li>Eine weitreichende Einführung in Blockchains und den Wert von Privatsphäre – ideal für Nutzer ohne technischen Hintergrund</li>
+    <li>Diskussion der Schwachstellen Bitcoins und spezifische Lösungen dieser durch Monero</li>
+    <li>Nutzererfahrungen (die zeigen, wie Monero deine Daten schützt), Vergleiche, Beispiele, rechtliche und ethische Diskussionen und Quellcodeauszüge, die grundlegende, technische Konzepte darlegen</li>
+    <li>Details des dezentralisierten Monero-Netzwerkes, der Peer-to-Peer-Architektur, dem Ablauf von Transaktionen und Grundlagen der Sicherheit</li>
+    <li>Einführung in das technische Fundament Moneros – für Entwickler, Ingenieure, Softwarearchitekten und neugierige Nutzer</li>
+    <li>Neue Entwicklungen wie beispielsweise Kovri, Bulletproofs, Multisignaturen, Hardware-Wallets etc.</li></ul>
+    Auf der Webseite von <a href="https://masteringmonero.com/">Mastering Monero</a> gibt es Informationen zur vollen Version.
+  magazines: Magazines
+  revuoq4p: >
+    Quartalsweise erscheinendes Monero-Magazin, Ausgabe Q4 2017<br>
+    In dieser Ausgabe: Neuigkeiten zur Entwicklung, dem Monero Research Lab, Kovri und der Community
+  revuoq3p: >
+    Quartalsweise erscheinendes Monero-Magazin, Ausgabe Q3 2017<br>
+    In dieser Ausgabe: Neuigkeiten zur Entwicklung, dem Monero Research Lab, Kovri, der Community, Hardware und Monerujo
 
 moneropedia:
   add_new_button: Neuen Eintrag erstellen

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -603,43 +603,35 @@ specs:
 
 library:
   description: "Below are some publications, books or magazines available for you to download."
-  books:
-  - category: Books
-    publications:
-    - name: "Zero to Monero: Second Edition"
-      file: "Zero-to-Monero-2-0-0.pdf"
-      abstract: >
-        Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
-        A comprehensive conceptual (and technical) explanation of Monero.<br>
-        We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
-    - name: "Zero to Monero: First Edition"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        A guide through the seemingly complex world of Monero.<br>
-        It includes:
-        <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
-        <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
-        <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
-        <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
-        <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
-        <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
-        See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
-  - category: Magazines
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q4 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, and community.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q3 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
+  books: Books
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonero: "Mastering Monero"
+  masteringmonerop: >
+    A guide through the seemingly complex world of Monero.<br>
+    It includes:
+    <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
+    <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
+    <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
+    <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
+    <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
+    <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
+    See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
+  magazines: Magazines
+  revuoq4: "Revuo Monero Q4 2017"
+  revuoq4p: >
+    Quarterly Monero magazine, Q4 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, and community.
+  revuoq3: "Revuo Monero Q3 2017"
+  revuoq3p: >
+    Quarterly Monero magazine, Q3 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
 
 moneropedia:
   add_new_button: Add New Entry

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -612,7 +612,6 @@ library:
   zerotomonerov1: "Zero to Monero: First Edition"
   zerotomonerov1p: >
     Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
-  masteringmonero: "Mastering Monero"
   masteringmonerop: >
     A guide through the seemingly complex world of Monero.<br>
     It includes:
@@ -624,11 +623,9 @@ library:
     <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
     See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
   magazines: Magazines
-  revuoq4: "Revuo Monero Q4 2017"
   revuoq4p: >
     Quarterly Monero magazine, Q4 2017 edition.<br>
     In this issue, updates about: development, Monero Research Lab, Kovri, and community.
-  revuoq3: "Revuo Monero Q3 2017"
   revuoq3p: >
     Quarterly Monero magazine, Q3 2017 edition.<br>
     In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -547,38 +547,32 @@ specs:
 
 library:
   description: "A continuación se encuentran algunas publicaciones, libros y revistas disponibles para descargar."
-  books:
-  - category: Libros
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Una explicación conceptual, comprensiva (y técnica) de Monero.<br>
-        Nos esforzamos por enseñar a cualquiera que conozca álgebra básica y conceptos simples de ciencias de la computación, como ‘representación de bits’ de un número, no solamente cómo funciona Monero a un nivel profundo y completo, sino también qué tan útil y bella puede ser la criptografía.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Una guía a través del aparentemente complejo mundo de Monero.<br>
-        Incluye:
-        <ul><li>Una amplia introducción a blockchains y la importancia de la privacidad - ideal para usuarios no técnicos.</li>
-        <li>Discusión de las deficiencias de Bitcoin y soluciones específicas proporcionadas por Monero.</li>
-        <li>Historias de usuarios (ilustrando cómo Monero protege tu privacidad), analogías, ejemplos, discusiones legales/éticas, y fragmentos de código ilustrando conceptos técnicos clave.</li>
-        <li>Detalles de la red descentralizada de Monero, arquitectura de igual a igual, ciclo de vida de una transacción, y principios de seguridad.</li>
-        <li>Introducción a los fundamentos técnicos de Monero, destinado a desarrolladores, ingenieros, arquitectos de software, y usuarios curiosos.</li>
-        <li>Nuevos desarrollos como Kovri, Bulletproofs, Multifirmas, Monederos Hardware, entre otros.</li></ul>
-        Ver el sitio web de <a href="https://masteringmonero.com/">Mastering Monero</a> para información acerca de la versión completa.
-  - category: Revistas
-    publications:
-    - name: "Revuo Monero 4T 2017"
-      file: "Revuo-2017-Q4_es.pdf"
-      abstract: >
-        Revista trimestral de Monero, edición 4T, 2017.<br>
-        En esta publicación, actualizaciones acerca de: desarrollo, el Laboratorio de Investigación de Monero, Kovri y la comunidad.
-    - name: "Revuo Monero 3T 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Revista trimestral de Monero, edición 3T, 2017.<br>
-        En esta publicación, actualizaciones acerca de: desarrollo, el Laboratorio de Investigación de Monero, Kovri, la comunidad, Hardware y Monerujo.
+  books: Libros
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Una guía a través del aparentemente complejo mundo de Monero.<br>
+    Incluye:
+    <ul><li>Una amplia introducción a blockchains y la importancia de la privacidad - ideal para usuarios no técnicos.</li>
+    <li>Discusión de las deficiencias de Bitcoin y soluciones específicas proporcionadas por Monero.</li>
+    <li>Historias de usuarios (ilustrando cómo Monero protege tu privacidad), analogías, ejemplos, discusiones legales/éticas, y fragmentos de código ilustrando conceptos técnicos clave.</li>
+    <li>Detalles de la red descentralizada de Monero, arquitectura de igual a igual, ciclo de vida de una transacción, y principios de seguridad.</li>
+    <li>Introducción a los fundamentos técnicos de Monero, destinado a desarrolladores, ingenieros, arquitectos de software, y usuarios curiosos.</li>
+    <li>Nuevos desarrollos como Kovri, Bulletproofs, Multifirmas, Monederos Hardware, entre otros.</li></ul>
+    Ver el sitio web de <a href="https://masteringmonero.com/">Mastering Monero</a> para información acerca de la versión completa.
+  magazines: Revistas
+  revuoq4p: >
+    Revista trimestral de Monero, edición 4T, 2017.<br>
+    En esta publicación, actualizaciones acerca de: desarrollo, el Laboratorio de Investigación de Monero, Kovri y la comunidad.
+  revuoq3p: >
+    Revista trimestral de Monero, edición 3T, 2017.<br>
+    En esta publicación, actualizaciones acerca de: desarrollo, el Laboratorio de Investigación de Monero, Kovri, la comunidad, Hardware y Monerujo.
 
 moneropedia:
   add_new_button: Crear Nueva Entrada

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -548,38 +548,32 @@ specs:
 
 library:
   description: "Vous trouverez ci-dessous des publications, livres ou revues disponibles au téléchargement."
-  books:
-  - category: Livres
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Une explication conceptuelle (et technique) compréhensible de Monero.<br>
-        Nous nous efforçons d'enseigner à tous ceux qui connaissent les bases de l'algèbre et les concepts des sciences de l'informatique simple, comme la ‘représentation binaire’ d'un nombre, non seulement comment fonctionne Monero dans le détail et de manière compréhensible, mais également quelle peut être l'utilité et la beauté de la cryptographie.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: |
-        Un guide à travers le monde apparemment complexe de Monero.<br>
-        Il contient :
-        <ul><li>Une vaste introduction aux chaînes de blocs et à l\'importance de la confidentialité, idéale pour les utilisateurs non-techniques.</li>
-        <li>La discussion des lacunes de Bitcoin et les solutions spécifiques apportées par Monero.</li>
-        <li>Des scénarios utilisateurs (illustrant de quelle manière Monero protège votre confidentialité), des analogies, des exemples, des discussions juridiques/éthiques et des bribes de code illustrant les concepts techniques clef.</li>
-        <li>Des détails sur le réseau décentralisé de Monero, l\'architecture pair à pair, le cycle de vie des transactions et les principes de sécurité.</li>
-        <li>Une introduction aux fondations techniques de Monero, à destination des développeurs, ingénieurs, architectes logiciel et utilisateurs curieux.</li>
-        <li>Les nouveaux développements, tel que Kovri, les Bulletproofs, les Multisignature, les Portefeuilles Materiel, etc.</li></ul>
-        Voir le site web de <a href="https://masteringmonero.com/">Mastering Monero</a> pour plus d'informations sur la version complète.
-  - category: Magazines
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Magazine trimestriel de Monero, édition Q4 2017.<br>
-        Dans cette parution, des nouvelles concernant : le développement, le laboratoire de Recherche Monero, Kovri et la communauté.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Magazine trimestriel de Monero, édition Q3 2017.<br>
-        Dans cette parution, des nouvelles concernant : le développement, le laboratoire de Recherche Monero, Kovri, la communauté, le matériel et Monerujo.
+  books: Livres
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Un guide à travers le monde apparemment complexe de Monero.<br>
+    Il contient :
+    <ul><li>Une vaste introduction aux chaînes de blocs et à l\'importance de la confidentialité, idéale pour les utilisateurs non-techniques.</li>
+    <li>La discussion des lacunes de Bitcoin et les solutions spécifiques apportées par Monero.</li>
+    <li>Des scénarios utilisateurs (illustrant de quelle manière Monero protège votre confidentialité), des analogies, des exemples, des discussions juridiques/éthiques et des bribes de code illustrant les concepts techniques clef.</li>
+    <li>Des détails sur le réseau décentralisé de Monero, l\'architecture pair à pair, le cycle de vie des transactions et les principes de sécurité.</li>
+    <li>Une introduction aux fondations techniques de Monero, à destination des développeurs, ingénieurs, architectes logiciel et utilisateurs curieux.</li>
+    <li>Les nouveaux développements, tel que Kovri, les Bulletproofs, les Multisignature, les Portefeuilles Materiel, etc.</li></ul>
+    Voir le site web de <a href="https://masteringmonero.com/">Mastering Monero</a> pour plus d'informations sur la version complète.
+  magazines: Magazines
+  revuoq4p: >
+    Magazine trimestriel de Monero, édition Q4 2017.<br>
+    Dans cette parution, des nouvelles concernant : le développement, le laboratoire de Recherche Monero, Kovri et la communauté.
+  revuoq3p: >
+    Magazine trimestriel de Monero, édition Q3 2017.<br>
+    Dans cette parution, des nouvelles concernant : le développement, le laboratoire de Recherche Monero, Kovri, la communauté, le matériel et Monerujo.
 
 moneropedia:
   add_new_button: Ajouter une Nouvelle Entrée

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -545,38 +545,32 @@ specs:
 
 library:
   description: "Qui sotto sono elencate alcuni fra pubblicazioni, riviste e libri per il download:"
-  books:
-  - category: Libri
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Una spiegazione concettuale (e tecnica) di Monero.<br>
-        Proviamo ad insegnare a chiunque conosca l'algebra di base e semplici concetti di informatica come la "rappresentazione di bit" di un numero non solo come Monero funziona in profondità, ma anche come può essere utile e bella la crittografia.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Una guida sul mondo apparentemente complesso di Monero.<br>
-        Include:
-        <ul><li>Una introduzione alle blockchain e all'importanza della privacy - ideale per utenti non tecnici.</li>
-        <li>Discussione sui limiti di Bitcoin e soluzioni specifiche apportate da Monero.</li>
-        <li>Storie degli utilizzatori (come Monero protegge la tua privacy), analogie, esempi, discussioni tecnico-legali, e frammenti di codice che illustrano gli aspetti tecnici principali.</li>
-        <li>Dettagli della rete decentralizzata Monero, l'architettura p2p, il ciclo di vita della transazione e i principi di sicurezza.</li>
-        <li>Introduzione ai fondamenti tecnici di Monero, rivolto a sviluppatori, ingegneri, architetti software ed utenti curiosi.</li>
-        <li>Nuovi sviluppi come Kovri, Bulletproofs, Multifirma, Portafogli hardware etc.</li></ul>
-        Visita il sito <a href="https://masteringmonero.com/">Mastering Monero</a> per informazioni sulla versione completa.
-  - category: Riviste
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Rivista Monero trimestrale, edizione Q4 2017.<br>
-        In questo numero, aggiornamenti su: sviluppo, Monero Research Lab, Kovri e comunità.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Rivista Monero trimestrale, edizione Q3 2017.<br>
-      In questo numero, aggiornamenti su: sviluppo, Monero Research Lab, Kovri, comunità, Hardware e Monerujo.
+  books: Books
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Pubblicato: 4 Aprile 2020, <a href="https://github.com/UkoeHB/Monero-RCT-report">codice sorgente LaTeX qui</a><br>
+    Una spiegazione concettuale (e tecnica) di Monero.<br>
+    Proviamo ad insegnare a chiunque conosca l'algebra di base e semplici concetti di informatica come la "rappresentazione di bit" di un numero non solo come Monero funziona in profondità, ma anche come può essere utile e bella la crittografia.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Una guida sul mondo apparentemente complesso di Monero.<br>
+    Include:
+    <ul><li>Una introduzione alle blockchain e all'importanza della privacy - ideale per utenti non tecnici.</li>
+    <li>Discussione sui limiti di Bitcoin e soluzioni specifiche apportate da Monero.</li>
+    <li>Storie degli utilizzatori (come Monero protegge la tua privacy), analogie, esempi, discussioni tecnico-legali, e frammenti di codice che illustrano gli aspetti tecnici principali.</li>
+    <li>Dettagli della rete decentralizzata Monero, l'architettura p2p, il ciclo di vita della transazione e i principi di sicurezza.</li>
+    <li>Introduzione ai fondamenti tecnici di Monero, rivolto a sviluppatori, ingegneri, architetti software ed utenti curiosi.</li>
+    <li>Nuovi sviluppi come Kovri, Bulletproofs, Multifirma, Portafogli hardware etc.</li></ul>
+    Visita il sito <a href="https://masteringmonero.com/">Mastering Monero</a> per informazioni sulla versione completa.
+  magazines: Riviste
+  revuoq4p: >
+    Rivista Monero trimestrale, edizione Q4 2017.<br>
+    In questo numero, aggiornamenti su: sviluppo, Monero Research Lab, Kovri e comunità.
+  revuoq3p: >
+    Rivista Monero trimestrale, edizione Q3 2017.<br>
+    In questo numero, aggiornamenti su: sviluppo, Monero Research Lab, Kovri, comunità, Hardware e Monerujo.
 
 moneropedia:
   add_new_button: Aggiungi nuova voce

--- a/_i18n/nl.yml
+++ b/_i18n/nl.yml
@@ -548,38 +548,32 @@ specs:
 
 library:
   description: "Hier volgen publicaties, boeken en tijdschriften die je kunt downloaden."
-  books:
-  - category: Boeken
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Een uitgebreide conceptuele en technische uitleg van Monero.<br>
-        We proberen voor iedereen die elementaire algebra en eenvoudige informaticabegrippen zoals de weergave van cijfers in bits begrijpt, diepgaand en compleet uit te leggen hoe Monero werkt en hoe nuttig en mooi cryptografie kan zijn.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Een handleiding tot de schijnbaar ingewikkelde wereld van Monero.<br>
-        Met onder meer:
-        <ul><li>Een algemene inleiding tot blockchains en het belang van privacy, geschikt voor niet-technische lezers.</li>
-        <li>Bespreking van de tekortkomingen van Bitcoin en specifieke oplossingen die worden geboden door Monero.</li>
-        <li>User stories (scenario's waarin wordt geïllustreerd hoe Monero je privacy beschermt), vergelijkingen, voorbeelden, juridische en ethische discussies, en codefragmenten om technische kernbegrippen te demonstreren.</li>
-        <li>Details over het gedecentraliseerde netwerk van Monero, de architectuur van het peer-to-peernetwerk, de levenscyclus van een transactie en beveilingsprincipes.</li>
-        <li>Inleiding tot de technische grondslagen van Monero, bedoeld voor ontwikkelaars, programmeurs, software-architecten en nieuwsgierige gebruikers.</li>
-        <li>Nieuwe ontwikkelingen zoals Kovri, Bulletproofs, multisignature, hardware wallets etc.</li></ul>
-        Zie de website <a href="https://masteringmonero.com/">Mastering Monero</a> voor informatie over de volledige versie.
-  - category: Tijdschriften
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Kwartaalblad over Monero, vierde kwartaal 2017.<br>
-        In dit nummer nieuws over: ontwikkeling, Monero Research Lab, Kovri en de community.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Kwartaalblad over Monero, derde kwartaal 2017.<br>
-        In dit nummer nieuws over: ontwikkeling, Monero Research Lab, Kovri, community, hardware en Monerujo.
+  books: Boeken
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Een handleiding tot de schijnbaar ingewikkelde wereld van Monero.<br>
+    Met onder meer:
+    <ul><li>Een algemene inleiding tot blockchains en het belang van privacy, geschikt voor niet-technische lezers.</li>
+    <li>Bespreking van de tekortkomingen van Bitcoin en specifieke oplossingen die worden geboden door Monero.</li>
+    <li>User stories (scenario's waarin wordt geïllustreerd hoe Monero je privacy beschermt), vergelijkingen, voorbeelden, juridische en ethische discussies, en codefragmenten om technische kernbegrippen te demonstreren.</li>
+    <li>Details over het gedecentraliseerde netwerk van Monero, de architectuur van het peer-to-peernetwerk, de levenscyclus van een transactie en beveilingsprincipes.</li>
+    <li>Inleiding tot de technische grondslagen van Monero, bedoeld voor ontwikkelaars, programmeurs, software-architecten en nieuwsgierige gebruikers.</li>
+    <li>Nieuwe ontwikkelingen zoals Kovri, Bulletproofs, multisignature, hardware wallets etc.</li></ul>
+    Zie de website <a href="https://masteringmonero.com/">Mastering Monero</a> voor informatie over de volledige versie.
+  magazines: Tijdschriften
+  revuoq4p: >
+    Kwartaalblad over Monero, vierde kwartaal 2017.<br>
+    In dit nummer nieuws over: ontwikkeling, Monero Research Lab, Kovri en de community.
+  revuoq3p: >
+    Kwartaalblad over Monero, derde kwartaal 2017.<br>
+    In dit nummer nieuws over: ontwikkeling, Monero Research Lab, Kovri, community, hardware en Monerujo.
 
 moneropedia:
   add_new_button: Nieuw trefwoord toevoegen

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -547,38 +547,32 @@ specs:
 
 library:
   description: "Below are some publications, books or magazines available for you to download."
-  books:
-  - category: Books
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        A comprehensive conceptual (and technical) explanation of Monero.<br>
-        We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        A guide through the seemingly complex world of Monero.<br>
-        It includes:
-        <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
-        <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
-        <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
-        <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
-        <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
-        <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
-        See <a href="https://masteringmonero.com/">Mastering Monero</a> website for info about full version.
-  - category: Magazines
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q4 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, and community.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q3 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
+  books: Books
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    A guide through the seemingly complex world of Monero.<br>
+    It includes:
+    <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
+    <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
+    <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
+    <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
+    <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
+    <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
+    See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
+  magazines: Magazines
+  revuoq4p: >
+    Quarterly Monero magazine, Q4 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, and community.
+  revuoq3p: >
+    Quarterly Monero magazine, Q3 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
 
 moneropedia:
   add_new_button: Add New Entry

--- a/_i18n/pt-br.yml
+++ b/_i18n/pt-br.yml
@@ -548,38 +548,32 @@ specs:
 
 library:
   description: "Abaixo estão algumas publicações, livros e revistas disponíveis para download."
-  books:
-  - category: Livros
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Uma explicação conceitual abrangente (e técnica) do Monero.<br>
-        Nos esforçamos para ensinar a qualquer um que entenda álgebra básica e conceitos simples de ciência da computação (como a representação em bits de um número), não somente como o Monero funciona de maneira profunda e abrangente, mas também o quão bela e útil pode ser a criptografia.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Um guia através do aparentemente complexo mundo do Monero.<br>
-        Inclui:
-        <ul><li>Uma ampla introdução aos blockchains e à importância da privacidade - ideal para usuários não técnicos.</li>
-        <li>Discussão das deficiências do Bitcoin e soluções específicas fornecidas pelo Monero.</li>
-        <li>Histórias de usuários (ilustrando como o Monero protege sua privacidade), analogias, exemplos, discussões legais/éticas e trechos de código que ilustram conceitos técnicos importantes.</li>
-        <li>Detalhes da rede descentralizada do Monero, arquitetura pessoa para pessoa (peer-to-peer), ciclo de vida da transação e princípios de segurança.</li>
-        <li>Introduções às bases técnicas do Monero, destinadas a desenvolvedores, engenheiros, arquitetos de software e usuários curiosos.</li>
-        <li>Novos desenvolvimentos como Kovri, Bulletproofs, Assinatura múltipla (multisig), carteiras hardware, etc.</li></ul>
-        Veja o website do <a href="https://masteringmonero.com/">Mastering Monero</a> para mais informações da versão completa.
-  - category: Revistas
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Revista trimestral sobre o Monero, edição Q4 2017.<br>
-        Nesta edição, atualizações sobre: desenvolvimento, Laboratório de Pesquisa Monero, Kovri, e comunidade.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Revista trimestral sobre o Monero, edição Q4 2017.<br>
-        Nesta edição, atualizações sobre: desenvolvimento, Laboratório de Pesquisa Monero, Kovri, comunidade, hardware e Monerujo.
+  books: Livros
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Um guia através do aparentemente complexo mundo do Monero.<br>
+    Inclui:
+    <ul><li>Uma ampla introdução aos blockchains e à importância da privacidade - ideal para usuários não técnicos.</li>
+    <li>Discussão das deficiências do Bitcoin e soluções específicas fornecidas pelo Monero.</li>
+    <li>Histórias de usuários (ilustrando como o Monero protege sua privacidade), analogias, exemplos, discussões legais/éticas e trechos de código que ilustram conceitos técnicos importantes.</li>
+    <li>Detalhes da rede descentralizada do Monero, arquitetura pessoa para pessoa (peer-to-peer), ciclo de vida da transação e princípios de segurança.</li>
+    <li>Introduções às bases técnicas do Monero, destinadas a desenvolvedores, engenheiros, arquitetos de software e usuários curiosos.</li>
+    <li>Novos desenvolvimentos como Kovri, Bulletproofs, Assinatura múltipla (multisig), carteiras hardware, etc.</li></ul>
+    Veja o website do <a href="https://masteringmonero.com/">Mastering Monero</a> para mais informações da versão completa.
+  magazines: Revistas
+  revuoq4p: >
+    Revista trimestral sobre o Monero, edição Q4 2017.<br>
+    Nesta edição, atualizações sobre: desenvolvimento, Laboratório de Pesquisa Monero, Kovri, e comunidade.
+  revuoq3p: >
+    Revista trimestral sobre o Monero, edição Q4 2017.<br>
+    Nesta edição, atualizações sobre: desenvolvimento, Laboratório de Pesquisa Monero, Kovri, comunidade, hardware e Monerujo.
 
 moneropedia:
   add_new_button: Adicionar Nova Entrada

--- a/_i18n/ru.yml
+++ b/_i18n/ru.yml
@@ -552,38 +552,32 @@ specs:
 
 library:
   description: "Ниже приведены публикации, книги и журналы, доступные для скачивания."
-  books:
-  - category: Книги
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Полное концептуальное (и техническое) объяснение Monero.<br>
-        Мы стремимся научить любого, кто знаком с базовой алгеброй и простыми понятиями информатики, такими как "битовое представление" числа, не только тому, как Monero работает на глубоком и всеобъемлющем уровне, но также и тому, насколько полезной и красивой может быть криптография.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Руководство по, казалось бы, сложному миру Monero.<br>
-        Оно включает:
-        <ul><li>Внедрение в блокчейн и обьяснение важности конфиденциальности.</li>
-        <li>Обсуждение недостатков Bitcoin и решения этих проблем со стороны Monero.</li>
-        <li>Истории пользователей (иллюстрирующие, как Monero защищает вашу конфиденциальность), примеры из личного опыта, юридические / этические обсуждения и фрагменты кода, отображающие ключевые технические концепции.</li>
-        <li>Подробная информация о децентрализованной сети Monero, одноранговой архитектуре, жизненном цикле транзакций и общих принципах безопасности.</li>
-        <li>Введение в технические основы Monero, предназначенные для разработчиков, инженеров, архитекторов программного обеспечения или просто любопытных пользователей.</li>
-        <li>Вся информация о новых, и внедреннымх технологиях, таких как Kovri, Bulletproofs (пуленепробиваемый), Multisignature (мультиподписи), аппаратные кошельки и других.</li></ul>
-        Посетите <a href="https://masteringmonero.com/">Mastering Monero</a> для просмотра полной версии.
-  - category: Журналы
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Ежеквартальный журнал Monero, выпуск за Q4 2017.<br>
-        Читатайте в этом выпуске: обновления от разработкиков, исследовательской лаборатории Monero, сообщества Monero и Kovri.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Ежеквартальный журнал Monero, выпуск за Q3 2017<br>
-        Читатйте в этом выпуске: обновления от разработкиков, исследовательской лаборатории Monero, сообщества Monero, мобильного кошелька Monerujo и Kovri.
+  books: Книги
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Руководство по, казалось бы, сложному миру Monero.<br>
+    Оно включает:
+    <ul><li>Внедрение в блокчейн и обьяснение важности конфиденциальности.</li>
+    <li>Обсуждение недостатков Bitcoin и решения этих проблем со стороны Monero.</li>
+    <li>Истории пользователей (иллюстрирующие, как Monero защищает вашу конфиденциальность), примеры из личного опыта, юридические / этические обсуждения и фрагменты кода, отображающие ключевые технические концепции.</li>
+    <li>Подробная информация о децентрализованной сети Monero, одноранговой архитектуре, жизненном цикле транзакций и общих принципах безопасности.</li>
+    <li>Введение в технические основы Monero, предназначенные для разработчиков, инженеров, архитекторов программного обеспечения или просто любопытных пользователей.</li>
+    <li>Вся информация о новых, и внедреннымх технологиях, таких как Kovri, Bulletproofs (пуленепробиваемый), Multisignature (мультиподписи), аппаратные кошельки и других.</li></ul>
+    Посетите <a href="https://masteringmonero.com/">Mastering Monero</a> для просмотра полной версии.
+  magazines: Журналы
+  revuoq4p: >
+    Ежеквартальный журнал Monero, выпуск за Q4 2017.<br>
+    Читатайте в этом выпуске: обновления от разработкиков, исследовательской лаборатории Monero, сообщества Monero и Kovri.
+  revuoq3p: >
+    Ежеквартальный журнал Monero, выпуск за Q3 2017<br>
+    Читатйте в этом выпуске: обновления от разработкиков, исследовательской лаборатории Monero, сообщества Monero, мобильного кошелька Monerujo и Kovri.
 
 moneropedia:
   add_new_button: Добавить новую запись

--- a/_i18n/tr.yml
+++ b/_i18n/tr.yml
@@ -547,38 +547,32 @@ specs:
 
 library:
   description: "Aşağı indirebileceğiniz bazı yayınlar, kitaplar ve dergiler yer almaktadır."
-  books:
-  - category: Kitaplar
-    publications:
-    - name: "Sıfırdan Monero'ya"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        Monero'nun kapsamlı kavramsal (ve teknik) bir açıklaması.<br>
-        Temel cebir ve bir sayının 'bit temsili' gibi basit bilgisayar bilimi kavramları bilen herkese sadece Monero'nun derin ve kapsamlı bir seviyede nasıl işlediğini değil, ayrıca kriptografinin ne kadar kullanışlı ve güzel olabileceğini öğretmeye çabalıyoruz.
-    - name: "Monero'da Ustalaşmak"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        Monero'nun karışık görünen dünyasına bir rehber.<br>
-        Şunları içerir:
-        <ul><li>Blokzincirlere ve gizliliğin önemine geniş bir giriş - teknik olmayan kullanıcılar için idealdir.</li>
-        <li>Bitcoin'in eksikliklerinin ve Monero tarafından sunulan belirli çözümlerin tartışması.</li>
-        <li>(Monero'nun gizliliğinizi nasıl koruduğunu sergileyen) kullanıcı hikayeleri, analojiler, örnekler, yasal/etik tartışmalar ve temel teknik kavramları sergileyen kod parçacıkları.</li>
-        <li>Monero merkeziyetsiz ağının, eşler-arası mimarinin, işlem yaşam döngüsünün ve güvenlik prensiplerinin detayları.</li>
-        <li>Geliştiricilere, mühendislere, yazılım mimarlarına ve meraklı kullanıcılara yönelik Monero'nun teknik temellerinin tanıtımları.</li>
-        <li>Kovri, Kurşun-geçirmezler, Çoklu-imzalar, Donanım Cüzdanları vs. gibi yeni gelişmeler.</li></ul>
-        Tam sürümü hakkında bilgi için <a href="https://masteringmonero.com/">Monero'da Ustalaşmak</a> internet sayfasını görüntüleyin.
-  - category: Dergiler
-    publications:
-    - name: "Revuo Monero 2017 Ç4"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Aylık Monero dergisi, 2017 Ç4 baskısı.<br>
-        Bu sayıdaki güncellemeler: gelişim, Monero Araştırma Laboratuvarı, Kovri ve topluluk.
-    - name: "Revuo Monero 2017 Ç3"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Aylık Monero dergisi, 2017 Ç3 baskısı.<br>
-        Bu sayıdaki güncellemeler: gelişim, Monero Araştırma Laboratuvarı, Kovri, topluluk, Donanım ve Monerujo.
+  books: Kitaplar
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    Monero'nun karışık görünen dünyasına bir rehber.<br>
+    Şunları içerir:
+    <ul><li>Blokzincirlere ve gizliliğin önemine geniş bir giriş - teknik olmayan kullanıcılar için idealdir.</li>
+    <li>Bitcoin'in eksikliklerinin ve Monero tarafından sunulan belirli çözümlerin tartışması.</li>
+    <li>(Monero'nun gizliliğinizi nasıl koruduğunu sergileyen) kullanıcı hikayeleri, analojiler, örnekler, yasal/etik tartışmalar ve temel teknik kavramları sergileyen kod parçacıkları.</li>
+    <li>Monero merkeziyetsiz ağının, eşler-arası mimarinin, işlem yaşam döngüsünün ve güvenlik prensiplerinin detayları.</li>
+    <li>Geliştiricilere, mühendislere, yazılım mimarlarına ve meraklı kullanıcılara yönelik Monero'nun teknik temellerinin tanıtımları.</li>
+    <li>Kovri, Kurşun-geçirmezler, Çoklu-imzalar, Donanım Cüzdanları vs. gibi yeni gelişmeler.</li></ul>
+    Tam sürümü hakkında bilgi için <a href="https://masteringmonero.com/">Monero'da Ustalaşmak</a> internet sayfasını görüntüleyin.
+  magazines: Dergiler
+  revuoq4p: >
+    Aylık Monero dergisi, 2017 Ç4 baskısı.<br>
+    Bu sayıdaki güncellemeler: gelişim, Monero Araştırma Laboratuvarı, Kovri ve topluluk.
+  revuoq3p: >
+    Aylık Monero dergisi, 2017 Ç3 baskısı.<br>
+    Bu sayıdaki güncellemeler: gelişim, Monero Araştırma Laboratuvarı, Kovri, topluluk, Donanım ve Monerujo.
 
 moneropedia:
   add_new_button: Yeni Girdi Ekleyin

--- a/_i18n/zh-cn.yml
+++ b/_i18n/zh-cn.yml
@@ -546,38 +546,32 @@ specs:
 
 library:
   description: "以下是一些可供您下载的出版物，书籍和杂志。"
-  books:
-  - category: 书籍
-    publications:
-    - name: "从零开始：门罗币"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        门罗币全面的技术和概念层面的解释。<br>
-        我们在此书中将协助您从最基本的代数和简单的计算机概念学起，比如一个数字如何用比特的方式进行表达。我们还会协助您从更深和更全面的角度理解门罗币是如何运作的，同时我们也希望您能在此书中体会到加密算法的有用之处，并感受到这不仅仅是计算机技术，更是一门美妙且精确的艺术。
-    - name: "精通门罗币"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        一本能让你在看似复杂的门罗世界里畅游无阻的指南。<br>
-        其中包括:
-        <ul><li>区块链的广泛介绍和隐私的重要性——对不懂技术的用户来说，这是个好的入手点。</li>
-        <li>对比特币的缺点的讨论和门罗币为此提供的具体解决方案。</li>
-        <li>其他用户的小故事（以此来说名门罗是如何保护您的隐私），类比、事例、法律／道德层面的讨论和对于一些关键技术代码的讨论。</li>
-        <li>门罗币的去中心化网络、点对点结构、交易周期和安全原则的详细信息。</li>
-        <li>针对开发人员，工程师，软件架构师等人的对门罗技术基础的介绍</li>
-        <li>新项目介绍：防弹证明，科维，多重签名和硬件钱包</li></ul>
-        有关完整版，请参见 <a href="https://masteringmonero.com/">Mastering Monero</a> 网站
-  - category: 杂志
-    publications:
-    - name: "Revuo Monero 2017 冬"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        门罗季刊，2017年冬<br>
-        在本期中谈到了: 最新进展，门罗研究组，科维和社区
-    - name: "Revuo Monero 2017 秋"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        门罗季刊，2017年秋<br>
-        在本期中谈到了: 最新进展，门罗研究组，科维，社区，硬件和Monerujo。
+  books: 书籍
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    一本能让你在看似复杂的门罗世界里畅游无阻的指南。<br>
+    其中包括:
+    <ul><li>区块链的广泛介绍和隐私的重要性——对不懂技术的用户来说，这是个好的入手点。</li>
+    <li>对比特币的缺点的讨论和门罗币为此提供的具体解决方案。</li>
+    <li>其他用户的小故事（以此来说名门罗是如何保护您的隐私），类比、事例、法律／道德层面的讨论和对于一些关键技术代码的讨论。</li>
+    <li>门罗币的去中心化网络、点对点结构、交易周期和安全原则的详细信息。</li>
+    <li>针对开发人员，工程师，软件架构师等人的对门罗技术基础的介绍</li>
+    <li>新项目介绍：防弹证明，科维，多重签名和硬件钱包</li></ul>
+    有关完整版，请参见 <a href="https://masteringmonero.com/">Mastering Monero</a> 网站
+  magazines: 杂志
+  revuoq4p: >
+    门罗季刊，2017年冬<br>
+    在本期中谈到了: 最新进展，门罗研究组，科维和社区
+  revuoq3p: >
+    门罗季刊，2017年秋<br>
+    在本期中谈到了: 最新进展，门罗研究组，科维，社区，硬件和Monerujo。
 
 moneropedia:
   add_new_button: 添加新条目

--- a/_i18n/zh-tw.yml
+++ b/_i18n/zh-tw.yml
@@ -545,38 +545,32 @@ specs:
 
 library:
   description: "以下是一些出版物、書籍或雜誌提供下載。"
-  books:
-  - category: 書籍
-    publications:
-    - name: "Zero to Monero"
-      file: "Zero-to-Monero-1-0-0.pdf"
-      abstract: >
-        A comprehensive conceptual (and technical) explanation of Monero.<br>
-        We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
-    - name: "Mastering Monero"
-      file: "https://masteringmonero.com/free-download.html"
-      abstract: >
-        A guide through the seemingly complex world of Monero.<br>
-        It includes:
-        <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
-        <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
-        <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
-        <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
-        <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
-        <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
-        See <a href="https://masteringmonero.com/">Mastering Monero</a> website for info about full version.
-  - category: 雜誌
-    publications:
-    - name: "Revuo Monero Q4 2017"
-      file: "Revuo-2017-Q4.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q4 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, and community.
-    - name: "Revuo Monero Q3 2017"
-      file: "Monero-Revuo-3Q-2017.pdf"
-      abstract: >
-        Quarterly Monero magazine, Q3 2017 edition.<br>
-        In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
+  books: 書籍
+  zerotomonerov2: "Zero to Monero: Second Edition"
+  zerotomonerov2p: >
+    Published: April 4, 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    A comprehensive conceptual (and technical) explanation of Monero.<br>
+    We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
+  zerotomonerov1: "Zero to Monero: First Edition"
+  zerotomonerov1p: >
+    Published: June 26, 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+  masteringmonerop: >
+    A guide through the seemingly complex world of Monero.<br>
+    It includes:
+    <ul><li>A broad introduction to blockchains and the importance of privacy - ideal for non-technical users.</li>
+    <li>Discussion of Bitcoin’s shortcomings and specific solutions provided by Monero.</li>
+    <li>User stories (illustrating how Monero protects your privacy), analogies, examples, legal/ethical discussions, and code snippets illustrating key technical concepts.</li>
+    <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
+    <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
+    <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
+    See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
+  magazines: 雜誌
+  revuoq4p: >
+    Quarterly Monero magazine, Q4 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, and community.
+  revuoq3p: >
+    Quarterly Monero magazine, Q3 2017 edition.<br>
+    In this issue, updates about: development, Monero Research Lab, Kovri, community, Hardware, and Monerujo.
 
 moneropedia:
   add_new_button: 新增條目

--- a/library/index.md
+++ b/library/index.md
@@ -5,24 +5,31 @@ permalink: /library/index.html
 ---
 {% t global.lang_tag %}
 <div class="about-monero">
-  <div class="center-xs container description">
-    <p class="text-center">{% t library.description %}</p>
-  </div>
-  {% for book in site.translations[site.lang].library.books %}
+    <div class="center-xs container description">
+      <p class="text-center">{% t library.description %}</p>
+    </div>
     <section class="container full">
-      <div class="info-block text-adapt">
-        <h2>{{ book.category }}</h2>
-        <div>
-          {% for publication in book.publications %}
-            {% if publication.file contains 'https' %}
-              <h3><a href="{{ publication.file }}">{{ publication.name }}</a></h3>
-            {% else %}
-              <h3><a href="{{ site.baseurl_root }}/library/{{ publication.file }}">{{ publication.name }}</a></h3>
-            {% endif %}
-            <p>{{ publication.abstract }}</p>
-          {% endfor %}
+        <div class="info-block text-adapt">
+            <h2>{% t library.books %}</h2>
+            <div>
+                <h3><a href="Zero-to-Monero-2-0-0.pdf">{% t library.zerotomonerov2 %}</a></h3>
+                    <p>{% t library.zerotomonerov2p %}</p>
+                <h3><a href="Zero-to-Monero-1-0-0.pdf">{% t library.zerotomonerov1 %}</a></h3>
+                    <p>{% t library.zerotomonerov1p %}</p>
+                <h3><a href="https://masteringmonero.com/free-download.html">Mastering Monero</a></h3>
+                    <p>{% t library.masteringmonerop %}</p> 
+            </div>
         </div>
-      </div>
     </section>
-  {% endfor %}
+    <section class="container full">
+        <div class="info-block text-adapt">
+            <h2>{% t library.magazines %}</h2>
+            <div>
+                <h3><a href="{{ site.baseurl_root }}/library/Revuo-2017-Q4.pdf">Revuo Monero Q4 2017</a></h3>
+                    <p>{% t library.revuoq4p %}</p>
+                <h3><a href="{{ site.baseurl_root }}/library/Monero-Revuo-3Q-2017.pdf">Revuo Monero Q3 2017</a></h3>
+                    <p>{% t library.revuoq3p %}</p>
+            </div>
+        </div>
+    </section>
 </div>


### PR DESCRIPTION
This is necessary because the old structure is not fully compatible with Weblate, which struggle to parse it and gets confused if the order of the entries is changed. I transferred the translations for all languages to the new structure.

Some more sections will need refactoring for the same reason (IRC channel list, press-kit and probably more)