### PR TITLE
workflows: disable fast fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.4', '2.5', '2.6', '2.7' ]
     name: Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
> When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true