### PR TITLE
Fix z-index of language dropdown

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1886,7 +1886,7 @@ img.monero-logo {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    z-index: 1;
+    z-index: 2;
     -webkit-transition: all .3s ease;
        -moz-transition: all .3s ease;
         -ms-transition: all .3s ease;


### PR DESCRIPTION
Some languages in the dropdown menu were not clickable when the elements behind it had the same z-index. Rised the z-index of the language dropdown, so we are always sure it has priority over other elements.

Before:
![before](https://user-images.githubusercontent.com/28106476/80909959-aedcba00-8d2c-11ea-8e3b-c28b663ee3c9.gif)


After:
![after](https://user-images.githubusercontent.com/28106476/80909962-b2704100-8d2c-11ea-962d-ac50bb1e5cb8.gif)
