### PR TITLE
navigation: remove 'technical-specs' tab for all languages

### DIFF
--- a/_data/lang/ar/navigation.yml
+++ b/_data/lang/ar/navigation.yml
@@ -50,5 +50,3 @@
     url: resources/user-guides
   - page: دليل المُطور
     url: resources/developer-guides
-  - page: المواصفات التقنيه
-    url: technical-specs

--- a/_data/lang/de/navigation.yml
+++ b/_data/lang/de/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Anleitungen für Entwickler
     url: resources/developer-guides
-  - page: Technische Spezifikationen
-    url: technical-specs
   - page: Bibliothek
     url: library
   - page: Press Kit

--- a/_data/lang/es/navigation.yml
+++ b/_data/lang/es/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Guías de desarrolladores
     url: resources/developer-guides
-  - page: Especificaciones técnicas
-    url: technical-specs
   - page: Librería
     url: library
   - page: Press Kit

--- a/_data/lang/fr/navigation.yml
+++ b/_data/lang/fr/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Guides du Dévelopeur
     url: resources/developer-guides
-  - page: Spécifications Techniques
-    url: technical-specs
   - page: Librairie
     url: library
   - page: Press Kit

--- a/_data/lang/it/navigation.yml
+++ b/_data/lang/it/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Guide Sviluppatore
     url: resources/developer-guides
-  - page: Specifiche Tecniche
-    url: technical-specs
   - page: Libreria
     url: library
   - page: Press Kit

--- a/_data/lang/nl/navigation.yml
+++ b/_data/lang/nl/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Handleidingen voor ontwikkelaars
     url: resources/developer-guides
-  - page: Technische specificaties
-    url: technical-specs
   - page: Bibliotheek
     url: library
   - page: Press Kit

--- a/_data/lang/pl/navigation.yml
+++ b/_data/lang/pl/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Przewodniki dla deweloperów
     url: resources/developer-guides
-  - page: Właściwości techniczne
-    url: technical-specs
   - page: Księgarnia
     url: library
   - page: Press Kit

--- a/_data/lang/pt-br/navigation.yml
+++ b/_data/lang/pt-br/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Guias do Desenvolvedor
     url: resources/developer-guides
-  - page: Especificações Técnicas
-    url: technical-specs
   - page: Biblioteca
     url: library
   - page: Press Kit

--- a/_data/lang/ru/navigation.yml
+++ b/_data/lang/ru/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Руководства для разработчиков
     url: resources/developer-guides
-  - page: Техническая спецификация
-    url: technical-specs
   - page: Библиотека
     url: library
   - page: Press Kit

--- a/_data/lang/tr/navigation.yml
+++ b/_data/lang/tr/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: Geliştirici Rehberleri
     url: resources/developer-guides
-  - page: Teknik Özellikler
-    url: technical-specs
   - page: Kütüphane
     url: library
   - page: Press Kit

--- a/_data/lang/zh-cn/navigation.yml
+++ b/_data/lang/zh-cn/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: 开发者指南
     url: resources/developer-guides
-  - page: 技术说明书
-    url: technical-specs
   - page: 文库
     url: library
   - page: Press Kit

--- a/_data/lang/zh-tw/navigation.yml
+++ b/_data/lang/zh-tw/navigation.yml
@@ -50,8 +50,6 @@
     url: resources/user-guides
   - page: 開發者指引
     url: resources/developer-guides
-  - page: 技術規格
-    url: technical-specs
   - page: 圖書出版品
     url: library
   - page: Press Kit


### PR DESCRIPTION
It's an empty tab. It was removed for English, but not for the other languages.