### PR TITLE
blog: fix wrong link to page 1

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -44,7 +44,7 @@ title: titles.allposts
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ '/blog' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ site.baseurl_root }}/blog">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: '/' | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
The link is invalid, which causes a 404 error when people try to navigate to page 1 from any other page of the blog.