### PR TITLE
Add possibility to go back to the Moneropedia page under each Moneropedia entry

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -626,6 +626,7 @@ moneropedia:
   add_new_text1: If there is an entry you'd like to modify or be added, please
   add_new_link: open an issue on this website's GitLab repository
   add_new_text2: or submit changes via pull request
+  back: Back to the Moneropedia
   entries:
     account: Account
     address-book: Address Book

--- a/_layouts/moneropedia.html
+++ b/_layouts/moneropedia.html
@@ -10,6 +10,7 @@ layout: base
                     <div>
                         {{content}}
                     </div>
+                    <p style="text-align: right;"><a href="{{site.baseurl}}/resources/moneropedia/">&laquo; {% t moneropedia.back %}</a></p>
                 </div>
         </section>
     <!-- END FULL WIDTH BLOCK -->


### PR DESCRIPTION
We don't offer navigation buttons in the Moneropedia and other parts of the webste. This becomes a problem when people click on a Moneropedia entry and then want to go back to the index. The only way to do so at the moment is to go up to the navigation menu and click resources -> moneropedia. Users should have the possibility to quickly go back to the Moneropedia index directly from each entry.

I added a simple *&laquo; Back to the Moneropedia* "button" in the `moneropedia` layout, so that every entry will show it at the bottom right:

![back](https://user-images.githubusercontent.com/28106476/82048999-e9900c00-96b5-11ea-8690-ac5e047810d7.png)
