### PR TITLE
Dont't use jekyll's 'post_url' for linking to a blog post

### DIFF
--- a/get-started/faq/index.md
+++ b/get-started/faq/index.md
@@ -157,7 +157,7 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.a12-1 %}</p>
                         <p>{% t faq.a12-2 %}</p>
                         <p>{% t faq.a12-3 %}</p>
-                        <p>{% t faq.additional %} <a href="{% post_url 2020-01-17-auditability %}">About supply auditability</a></p>
+                        <p>{% t faq.additional %} <a href="{{ site.baseurl_root }}/2020/01/17/auditability.html">About supply auditability</a></p>
                     </div>
                 </div>
                 <div class="tab" id="anchor-light-normal">


### PR DESCRIPTION
in #967 i used jekyll's native way to link to a blog post: `post_url`. The prolem is that to test the website, it's usually a good idea to limit the amount of loaded blog posts to only one by using `--limit-posts 1` or the build time will basically double. If `--limit-posts 1` is used in concomitance with `post_url` the build will fail, since jekyll won't be able to find the linked blog post (unless it's the last one).

This doesn't matter from a functional point of view, but loading all blog posts while testing it's a waste of time. This PR replaces `post_url` with a simpler direct link to the blog post. This will avoid the failure of the build when using `--limit-posts`.

Sorry for the double PR, i wasn't aware of this incompatibility.