### PR TITLE
index: fix video in Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ permalink: index.html
                     <div class="col-lg-7 col-md-7 col-xs-12 main-video">
                         <div class="monero-video">
                             <!--iframe width="560" height="315" src="https://www.youtube.com/embed/TZi9xx6aiuY" frameborder="0" allowfullscreen></iframe-->
-                            <video controls poster="/img/monero-community.png" onclick="this.paused ? this.play() : this.pause();" preload="none">
+                            <video controls poster="/img/monero-community.png" preload="metadata">
                                 <source src={% if site.lang == 'en' %}"/media/Monero_Promo.m4v"{% else %}"/media/{{ site.lang }}/Monero_Promo.m4v"{% endif %}>
                             </video>
                         </div>


### PR DESCRIPTION
This fixes video playback in Safari. 

~~Do not merge because it now requires to click on the play button in the bottom left corner to start the video in Chrome.~~