### PR TITLE
Meta tags: Change opengraph logo and add possiblity to use custom one

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ author: YOUR NAME OR HANDLE HERE
 ---
 ```
 
+If you want to add a personalized picture to a blog post that will show as logo on social networks, add `image: /blog/assets/$FOLDER/$IMAGE` to the front matter. Where `$FOLDER` is the name of the folder you created to contain the image related to your blog post and `$IMAGE` is the name of the image.
+
 ### 3. Write
 After the front matter is finished you are free to write the remainder of your blog post in markdown.
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,7 +28,8 @@
     {% elsif page.summary %}{{ page.summary }}
     {% else %}{% t global.titlemeta %}
     {% endif %}">
-    <meta property="og:image" content="{% if page.icon %}http://static.getmonero.org/images/opengraph/{{ page.icon }}.png{% else %}http://static.getmonero.org/images/opengraph/logo.png{% endif %}">
+    <!-- If the page specifies a dedicated image we use that one, otherwise we use the classic Monero logo -->
+    <meta property="og:image" content="{% if page.image %}https://getmonero.org{{ page.image }}{% else %}https://getmonero.org/press-kit/symbols/monero-symbol-on-white-480.png{% endif %}">
     <meta property="og:site_name" content="{% t global.sitename %}">
     <meta property="og:url" content="https://getmonero.org{{ page.url }}">
     <meta property="og:type" content="website">


### PR DESCRIPTION
The old logo showing on social medias is too large and end up being trimmed:

Twitter:
![twitter](https://user-images.githubusercontent.com/28106476/82752187-95bfaa00-9dbc-11ea-94c8-c4c6a665d0c4.png)

Reddit:
![reddit](https://user-images.githubusercontent.com/28106476/82752191-99533100-9dbc-11ea-9b7c-f5810841c7e7.png)

Replaced it with the simple Monero Logo. If a logo is specified using 'image:' in the front matter, jekyll will show this one instead. This also allow us to easily make specific meta-images for each blog post. I will add the possibility to add the image in the body of the post in a subsequent PR.