### PR TITLE
User guides: specify 'Importing blockchain' is for Windows

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -489,7 +489,7 @@ user-guides:
   wallets: Wallets
   offline-backup: How to make an offline backup
   vps-node: How to run a node on VPS
-  import-blockchain: Importing the Monero blockchain
+  import-blockchain: Importing the Monero blockchain (Windows)
   monero-tools: Monero Tools
   purchasing-storing: Securely purchasing and storing Monero
   verify-allos: Verify binaries on Linux, Mac, or Windows command line (advanced)


### PR DESCRIPTION
Closes #908 

I didn't specify *for the gui wallet* because works also for the CLI.

This guide could be updated. The GUI offers a native way to import a blockchain now.