### PR TITLE
update genfund donation to subaddress -- still same wallet

### DIFF
--- a/_i18n/ar/resources/moneropedia/address.md
+++ b/_i18n/ar/resources/moneropedia/address.md
@@ -6,7 +6,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 {% include untranslated.html %}
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/de/resources/moneropedia/address.md
+++ b/_i18n/de/resources/moneropedia/address.md
@@ -6,7 +6,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 {% include untranslated.html %}
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/en/resources/moneropedia/address.md
+++ b/_i18n/en/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/es/resources/moneropedia/address.md
+++ b/_i18n/es/resources/moneropedia/address.md
@@ -6,7 +6,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 {% include untranslated.html %}
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/fr/resources/moneropedia/address.md
+++ b/_i18n/fr/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "soit un alias, comme donate.getmonero.org, ou un lot de 95 caractères
 
 ### Les Bases
 
-Lorsque vous envoyez des Moneroj à quelqu'un, vous n'avez besoin que de cette information, et c'est son adresse Monero. Une adresse Monero *brut* est un lot de 95 caractères commençant par un '4'. L'adresse de dons de Monero, par exemple, est <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+Lorsque vous envoyez des Moneroj à quelqu'un, vous n'avez besoin que de cette information, et c'est son adresse Monero. Une adresse Monero *brut* est un lot de 95 caractères commençant par un '4'. L'adresse de dons de Monero, par exemple, est <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Comme ces adresses sont longues et complexes, vous rencontrerez souvent une adresse @OpenAlias à la place. Par exemple, les dons à Monero peuvent être envoyés à <span class="long-term">donate@getmonero.org</span> ou <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/it/resources/moneropedia/address.md
+++ b/_i18n/it/resources/moneropedia/address.md
@@ -6,7 +6,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 {% include untranslated.html %}
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/nl/resources/moneropedia/address.md
+++ b/_i18n/nl/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/pl/resources/moneropedia/address.md
+++ b/_i18n/pl/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "Alias nazwy adresu, np. donate.getmonero.org lub zestaw 95 znaków zac
 
 ### Podstawy
 
-Gdy wysyłasz do kogoś Monero, potrzebujesz jedynie jednej informacji, a jest nią adres Monero tej osoby. Jest to ciąg 95 znaków zaczynający się od "4". Przykładowo adres darowizn Monero to <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+Gdy wysyłasz do kogoś Monero, potrzebujesz jedynie jednej informacji, a jest nią adres Monero tej osoby. Jest to ciąg 95 znaków zaczynający się od "4". Przykładowo adres darowizn Monero to <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Ponieważ adresy są długie i skomplikowane, często zamiast niego spotkasz adres @OpenAlias, na przykład darowizny Monero mogą być wysyłane na adres <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/pt-br/resources/moneropedia/address.md
+++ b/_i18n/pt-br/resources/moneropedia/address.md
@@ -6,7 +6,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 {% include untranslated.html %}
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/ru/resources/moneropedia/address.md
+++ b/_i18n/ru/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "Место отправления либо назначения пла
 
 ### Основная информация
 
-Если вы хотите отправить кому-нибудь Monero, то вам для этого понадобится знать только адрес Monero этого человека. *Необработанный* адрес Monero представляет собой ряд из 95 символов, начинающийся с 4. Адрес для сбора пожертвований Monero, например, выглядит так: <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+Если вы хотите отправить кому-нибудь Monero, то вам для этого понадобится знать только адрес Monero этого человека. *Необработанный* адрес Monero представляет собой ряд из 95 символов, начинающийся с 4. Адрес для сбора пожертвований Monero, например, выглядит так: <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Поскольку такие адреса являются длинными и сложными, вы часто будете сталкиваться с адресами @OpenAlias, используемыми вместо них. Например, пожертвования Monero можно отправлять на адрес <span class="long-term">donate@getmonero.org</span> или <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/tr/resources/moneropedia/address.md
+++ b/_i18n/tr/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/zh-cn/resources/moneropedia/address.md
+++ b/_i18n/zh-cn/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/_i18n/zh-tw/resources/moneropedia/address.md
+++ b/_i18n/zh-tw/resources/moneropedia/address.md
@@ -5,7 +5,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</span>.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
 

--- a/get-started/contributing/index.md
+++ b/get-started/contributing/index.md
@@ -65,7 +65,7 @@ permalink: /get-started/contributing/index.html
                     <div class="row start-xs">
                         <div class="col-xs-12">
                             <h3>{% t contributing.donate-xmr %}</h3>
-                            <p>{% t contributing.donate-xmr_para %} donate.getmonero.org {% t contributing.or %} 44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A</p>
+                            <p>{% t contributing.donate-xmr_para %} donate.getmonero.org {% t contributing.or %} 888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</p>
                         </div>
                     </div>
                     <div class="row start-xs">


### PR DESCRIPTION
Use a subaddress for donations instead of the 4.. address.

It is the same wallet, so the publicly known view key remains valid.

Fixes #985 