### PR TITLE
Add config file for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  publish = "_site/"
+  command = "jekyll build --trace --limit-posts 10 --baseurl ''"
+
+[build.environment]
+  RUBY_VERSION = "2.6"
+
+[build.processing]
+  skip_processing = true


### PR DESCRIPTION
This configuration file is needed before we activate Netlify for building and deploying a preview of the incoming PRs (and master) on this repository.

Netlify will allow us to build and deploy incoming pull requests in this repo. A bot will post a comment in the PR with a link to the preview of the built PR. This is particularly useful for contributors who don't have a build environment for getmonero, but want to see how their changes will look like once merged. A PR gets usually built and deployed in ~3-5 minutes.

I opened a test PR in my repository which contains the revamped homepage as proposed in #948. You can take a look at my PR to see netlify at work and the preview of the new homepage built and available: https://github.com/erciccione/monero-site/pull/17

## Actions needed
To have this working we need to [subscribe to netlify](https://www.netlify.com/) and connect a github account to it. This account will be able to edit some configurations (if they don't conflict with this config file, which always has the priority) and manage the Netlify builds.  
The connected GitHub account doesn't need push access, but if it doesn't have it, the owner needs to ask permission to the maintainers of the repo to connect the netlify app. I volunteer to manage netlify myself, but if the maintainers prefer to do it, it's fine.

Netlify will need read access to the code and metadata and **write access** to checks, commit statuses, and pull requests.

### UI configurations
Some settings need to be specified in the UI on netlify.com. Adding them here in case i won't be the one managing Netlify:

#### Sensitive variable policy
*(Deploys -> Deploy settings -> Environment -> Sensitive variable policy)*  
Deploy without restrictions

#### Deploy notifications
*(Deploys -> Deploy settings -> Environment -> Deploy notifications ->)*  
Add notification -> GitHub pull request comment -> add "Deploy preview succeeded" (no custom message)

#### Remove email notifications

## What's not included
At the moment a build is triggered every time something is changing in the repo. Ideally, since we have a limited number of minutes we can use for free each month (300), we shouldn't build a PR if contains only changes to meta files not related to getmonero itself. We have 3: `README.md` `CONTRIBUTING.md` `LICENSE`. Netlify gives the possibility to not build the website [if some conditions are met](https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds), but i haven't extensively tested this feature and we can add it later on.