### PR TITLE
Blog: Use only one 'Blog' menu and add category selector

### DIFF
--- a/_data/lang/ar/navigation.yml
+++ b/_data/lang/ar/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: التنزيلات
   url: downloads/
-- title: آخر الأخبار
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: الإصدارات
-      url: blog/tags/releases.html
-    - page: Community
-      url: blog/tags/community.html
-    - page: سجل الإجتماعات
-      url: blog/tags/dev%20diaries.html
-    - page: جميع المشاركات
-      url: blog
+- title: Blog
+  url: blog
 - title: المجتمع
   subfolderitems:
   - page: الفريق

--- a/_data/lang/de/navigation.yml
+++ b/_data/lang/de/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Downloads
   url: downloads/
-- title: Neuigkeiten
-  subfolderitems:
-    - page: Dringend
-      url: blog/tags/urgent.html
-    - page: Versionen
-      url: blog/tags/releases.html
-    - page: Gemeinschaft
-      url: blog/tags/community.html
-    - page: Protokolle
-      url: blog/tags/dev%20diaries.html
-    - page: Alle Einträge
-      url: blog
+- title: Blog
+  url: blog
 - title: Community
   subfolderitems:
   - page: Team

--- a/_data/lang/en/navigation.yml
+++ b/_data/lang/en/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Downloads
   url: downloads/
-- title: Recent News
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: Releases
-      url: blog/tags/releases.html
-    - page: Community
-      url: blog/tags/community.html
-    - page: Meeting Logs
-      url: blog/tags/dev%20diaries.html
-    - page: All Posts
-      url: blog
+- title: Blog
+  url: blog
 - title: Community
   subfolderitems:
   - page: Team

--- a/_data/lang/es/navigation.yml
+++ b/_data/lang/es/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Descargas
   url: downloads
-- title: Noticias
-  subfolderitems:
-    - page: Urgente
-      url: blog/tags/urgent.html
-    - page: Lanzamientos
-      url: blog/tags/releases.html
-    - page: Comunidad
-      url: blog/tags/community.html
-    - page: Transcripciones de reuniones
-      url: blog/tags/dev%20diaries.html
-    - page: Todas publicaciones
-      url: blog
+- title: Blog
+  url: blog
 - title: Comunidad
   subfolderitems:
   - page: Equipo

--- a/_data/lang/fr/navigation.yml
+++ b/_data/lang/fr/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Téléchargements
   url: downloads/
-- title: Actualités
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: Versions
-      url: blog/tags/releases.html
-    - page: Communauté
-      url: blog/tags/community.html
-    - page: Comptes-rendus de Réunions
-      url: blog/tags/dev%20diaries.html
-    - page: Toutes
-      url: blog
+- title: Blog
+  url: blog
 - title: Communauté
   subfolderitems:
   - page: Équipe

--- a/_data/lang/it/navigation.yml
+++ b/_data/lang/it/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Download
   url: downloads/
-- title: Notizie recenti
-  subfolderitems:
-    - page: Urgente
-      url: blog/tags/urgent.html
-    - page: Uscite
-      url: blog/tags/releases.html
-    - page: Comunità
-      url: blog/tags/community.html
-    - page: Log dei meeting
-      url: blog/tags/dev%20diaries.html
-    - page: Tutti i post
-      url: blog
+- title: Blog
+  url: blog
 - title: Comunità
   subfolderitems:
   - page: Team

--- a/_data/lang/nl/navigation.yml
+++ b/_data/lang/nl/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Downloads
   url: downloads/
-- title: Nieuws
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: Releases
-      url: blog/tags/releases.html
-    - page: Community
-      url: blog/tags/community.html
-    - page: Vergaderingen
-      url: blog/tags/dev%20diaries.html
-    - page: Alles
-      url: blog
+- title: Blog
+  url: blog
 - title: Community
   subfolderitems:
   - page: Team

--- a/_data/lang/pl/navigation.yml
+++ b/_data/lang/pl/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Downloads
   url: downloads/
-- title: Najnowsze
-  subfolderitems:
-    - page: Ważne
-      url: blog/tags/urgent.html
-    - page: Aktualizacje
-      url: blog/tags/releases.html
-    - page: Społeczność
-      url: blog/tags/community.html
-    - page: Zapisy z czatów
-      url: blog/tags/dev%20diaries.html
-    - page: Wszystkie wpisy
-      url: blog
+- title: Blog
+  url: blog
 - title: Społeczność
   subfolderitems:
   - page: Zespół

--- a/_data/lang/pt-br/navigation.yml
+++ b/_data/lang/pt-br/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Downloads
   url: downloads/
-- title: Notícias
-  subfolderitems:
-    - page: Urgente
-      url: blog/tags/urgent.html
-    - page: Lançamentos
-      url: blog/tags/releases.html
-    - page: Comunidade
-      url: blog/tags/community.html
-    - page: Logs das Reuniões
-      url: blog/tags/dev%20diaries.html
-    - page: Todos os Posts
-      url: blog
+- title: Blog
+  url: blog
 - title: Comunidade
   subfolderitems:
   - page: Equipe

--- a/_data/lang/ru/navigation.yml
+++ b/_data/lang/ru/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: Загрузки
   url: downloads/
-- title: Последние новости
-  subfolderitems:
-    - page: Срочные
-      url: blog/tags/urgent.html
-    - page: Релизы
-      url: blog/tags/releases.html
-    - page: Сообщество
-      url: blog/tags/community.html
-    - page: Журналы встреч
-      url: blog/tags/dev%20diaries.html
-    - page: Все новости
-      url: blog
+- title: Blog
+  url: blog
 - title: Сообщество
   subfolderitems:
   - page: Команда

--- a/_data/lang/tr/navigation.yml
+++ b/_data/lang/tr/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: İndirmeler
   url: downloads/
-- title: Son Haberler
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: Bültenler
-      url: blog/tags/releases.html
-    - page: Community
-      url: blog/tags/community.html
-    - page: Toplantı Kayıtları
-      url: blog/tags/dev%20diaries.html
-    - page: Tüm Gönderiler
-      url: blog
+- title: Blog
+  url: blog
 - title: Topluluk
   subfolderitems:
   - page: Ekip

--- a/_data/lang/zh-cn/navigation.yml
+++ b/_data/lang/zh-cn/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: 下载
   url: downloads/
-- title: 最新资讯
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: 发布
-      url: blog/tags/releases.html
-    - page: Community
-      url: blog/tags/community.html
-    - page: 会议记录
-      url: blog/tags/dev%20diaries.html
-    - page: 所有文章
-      url: blog
+- title: Blog
+  url: blog
 - title: 社区
   subfolderitems:
   - page: 团队

--- a/_data/lang/zh-tw/navigation.yml
+++ b/_data/lang/zh-tw/navigation.yml
@@ -14,18 +14,8 @@
     url: get-started/faq
 - title: 下載
   url: downloads/
-- title: 最新消息
-  subfolderitems:
-    - page: Urgent
-      url: blog/tags/urgent.html
-    - page: 版本發佈
-      url: blog/tags/releases.html
-    - page: Community
-      url: blog/tags/community.html
-    - page: 會議記錄
-      url: blog/tags/dev%20diaries.html
-    - page: 所有文章
-      url: blog
+- title: Blog
+  url: blog
 - title: 社群
   subfolderitems:
   - page: 合作團隊

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -670,12 +670,15 @@ moneropedia:
     wallet: Wallet
 
 blog:
-  title_1: All
-  title_2: Blog
-  title_3: Posts
+  allposts: All Posts
+  urgent: Urgent
+  releases: Releases
+  community: Community
+  meetinglogs: Meeting Logs
   author: Posted by
   date: Posted at
-  forum: Click here to join the discussion for this entry on the Monero Forum
+  filter: "Filter by category:"
+
 
 tags:
   notags: There are no posts for this tag.

--- a/_layouts/blog_by_tag.html
+++ b/_layouts/blog_by_tag.html
@@ -9,21 +9,55 @@ layout: custom
 	{% endif %}
   {% endfor %}
 
+<div class="blog">
+  <!-- Category selector: desktop -->
+    <div class="container full desktop-only">
+        <div class="info-block blog-nav row">
+            <div class="col"><a href="{{ site.baseurl_root }}/blog">{% t blog.allposts %}</a></div>
+            <div class="col {% if filename == 'urgent' %}checked{% endif %}"><a href="{{ site.baseurl_root }}/blog/tags/urgent.html">{% t blog.urgent %}</a></div>
+            <div class="col {% if filename == 'releases' %}checked{% endif %}"><a href="{{ site.baseurl_root }}/blog/tags/releases.html">{% t blog.releases %}</a></div>
+            <div class="col {% if filename == 'community' %}checked{% endif %}"><a href="{{ site.baseurl_root }}/blog/tags/community.html">{% t blog.community %}</a></div>
+            <div class="col {% if filename == 'dev diaries' %}checked{% endif %}"><a href="{{ site.baseurl_root }}/blog/tags/dev%20diaries.html">{% t blog.meetinglogs %}</a></div>
+        </div>
+    </div>
+  <!-- End category selector: desktop -->
+  <!-- Category selector: mobile -->
+  <div class="container full">
+      <div class="info-block row center-xs" id="pick-platform">
+          <div class="mob dropdowndrop">
+              <input id="filter" type="checkbox" name="category-filter"/>
+              <label for="filter">{% t blog.filter %}</label>
+              <ul id="menu">
+                  <li><a href="{{ site.baseurl_root }}/blog">{% t blog.allposts %}</a></li>
+                  <li><a href="{{ site.baseurl_root }}/blog/tags/urgent.html">{% t blog.urgent %}</a></li>
+                  <li><a href="{{ site.baseurl_root }}/blog/tags/releases.html">{% t blog.releases %}</a></li>
+                  <li><a href="{{ site.baseurl_root }}/blog/tags/community.html">{% t blog.community %}</a></li>
+                  <li><a href="{{ site.baseurl_root }}/blog/tags/dev%20diaries.html">{% t blog.meetinglogs %}</a></li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  <!-- End category selector: mobile -->
+</div>
+
 <div class="site-wrap">
     <section class="container">
             <div class="row">
                 <!-- left two-thirds block-->
                 <div class="left two-thirds col-lg-8 col-md-8 col-sm-8 col-xs-12">
-                    <div class="info-block">
+                  <div class="info-block">
                         <div class="row center-xs">
-                        <div class="page-title">
-		                  <h2 class="inline"><span class="kicks">{{ tag.name }}</span></h2>
-		                </div>
-                    </div>
-                    
+                          <div class="page-title">
+                          {% if tag.name != "Dev Diaries" %}
+                            <h2 class="inline"><span class="kicks">{{ tag.name }}</span></h2>
+                          {% else %}
+                            <h2 class="inline"><span class="kicks">{% t blog.meetinglogs %}</span></h2>
+                          {% endif %}
+		                      </div>
+                        </div>
                        {% if site.tags[tag.slug] %}
-				{% for post in site.tags[tag.slug] %}
-                  <div class="post-tag">
+			                 	 {% for post in site.tags[tag.slug] %}
+                  <div class="post-lead">
                       <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
                       <p>
                         {{ post.summary }}
@@ -33,10 +67,11 @@ layout: custom
                         </small>
                       </p>
                   </div>
-				{% endfor %}
-			{% else %}
-				<h3>{% t tags.notags %}</h3>
-			{% endif %}
+                
+                         {% endfor %}
+                       {% else %}
+                        <h3>{% t tags.notags %}</h3>
+                       {% endif %}
                     
                     </div>
                 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,36 +1,66 @@
 ---
-layout: base
-title: titles.allposts
+layout: custom
+title: titles.blogbytag
 ---
 
-<h1 class="text-center">{% t page.title %}</h1>
-
-<div class="site-wrap">
-    <!-- FULL WIDTH BLOCK -->
-        <section class="container full">
-            <div>
-                {% for post in paginator.posts %}
-                    <div class="post-lead info-block">
-                        <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
-                        <p>
-                            {{ post.summary }}
-                        </p>
-                        <p>
-                            <small>
-                            {% t blog.author %} {{ post.author }} | {{ post.date | date: "%-d %B %Y" }}<br>
-                            Category:
-                            {% for tag in post.tags %}
-                            <a href="/blog/tags/{{ tag }}.html">{{ tag }}</a>{% unless forloop.last %},{% endunless %}
-                            {% endfor %}
-                            </small>
-                        </p>
-                    </div>
-                {% endfor %}
-            </div>
-        </section>
-    <!-- END FULL WIDTH BLOCK -->
+<div class="blog">
+  <!-- Category selector: desktop -->
+  <div class="container full desktop-only">
+    <div class="info-block blog-nav row">
+      <div class="col {% if page.name == 'index.html' %}checked{% endif %}"><a href="{{ site.baseurl_root }}/blog">{% t blog.allposts %}</a></div>
+      <div class="col"><a href="{{ site.baseurl_root }}/blog/tags/urgent.html">{% t blog.urgent %}</a></div>
+      <div class="col"><a href="{{ site.baseurl_root }}/blog/tags/releases.html">{% t blog.releases %}</a></div>
+      <div class="col"><a href="{{ site.baseurl_root }}/blog/tags/community.html">{% t blog.community %}</a></div>
+      <div class="col"><a href="{{ site.baseurl_root }}/blog/tags/dev%20diaries.html">{% t blog.meetinglogs %}</a></div>
+    </div>
+  </div>
+  <!-- End category selector: desktop -->
+  <!-- Category selector: mobile -->
+  <div class="container full">
+    <div class="info-block row center-xs" id="pick-platform">
+      <div class="mob dropdowndrop">
+        <input id="filter" type="checkbox" name="category-filter"/>
+        <label for="filter">{% t blog.filter %}</label>
+        <ul id="menu">
+          <li><a href="{{ site.baseurl_root }}/blog">{% t blog.allposts %}</a></li>
+          <li><a href="{{ site.baseurl_root }}/blog/tags/urgent.html">{% t blog.urgent %}</a></li>
+          <li><a href="{{ site.baseurl_root }}/blog/tags/releases.html">{% t blog.releases %}</a></li>
+          <li><a href="{{ site.baseurl_root }}/blog/tags/community.html">{% t blog.community %}</a></li>
+          <li><a href="{{ site.baseurl_root }}/blog/tags/dev%20diaries.html">{% t blog.meetinglogs %}</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <!-- End category selector: mobile -->
 </div>
 
+<div class="site-wrap">
+  <section class="container full">
+    <div class="row">
+      <!-- Full block-->
+        <div class="info-block">
+          <h2>{% t blog.allposts %}</h2>
+          {% for post in paginator.posts %}
+          <div class="post-lead">
+            <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+              <p>
+                  {{ post.summary }}
+              </p>
+              <p>
+                <small>
+                  {% t blog.author %} {{ post.author }} | {{ post.date | date: "%-d %B %Y" }}<br>
+                  Category:
+                  {% for tag in post.tags %}
+                  <a href="/blog/tags/{{ tag }}.html">{{ tag }}</a>{% unless forloop.last %},{% endunless %}
+                  {% endfor %}
+                </small>
+              </p>
+          </div>
+          {% endfor %}
+        </div>
+      <!-- End full block-->
+  </section>
+</div>
 
 {% if paginator.total_pages > 1 %}
 <div class="text-center page-numbers"><p>

--- a/css/custom.css
+++ b/css/custom.css
@@ -1928,6 +1928,7 @@ img.monero-logo {
 .white-nav {
     margin-bottom: 1rem;
     line-height: 1;
+    text-align: center;
 }
 
 .white-nav>.nav-items>.nav-item {
@@ -3880,6 +3881,42 @@ h3#months {
 
 
 /***********************************POST STYLING********************************/
+
+.blog .blog-nav a {
+  display: -ms-flexbox;
+  display: -webkit-box;
+  display: flex;
+  justify-content: center;
+  padding: 1rem 2rem;
+  font-weight: bold;
+  font-size: 0.92rem;
+  font-family: 'Hind', sans-serif;
+  -webkit-transition: all ease-out .2s;
+  -moz-transition: all ease-out .2s;
+  -o-transition: all ease-out .2s;
+  transition: all ease-out .2s;
+  border: none;
+}
+
+.blog-nav a:hover {
+  background-color: #d26e2b;
+  color: #fff;
+  text-decoration: none;
+}
+
+.blog .full>.info-block.blog-nav {
+  padding: 0;
+}
+
+.blog .col {
+  width: 20%;
+}
+
+.checked a {
+  background-color: #d26e2b;
+  color: #fff;
+  text-decoration: none;
+}
 
 .post-tag {
     padding-top: 1.5rem;


### PR DESCRIPTION
- Added separator between posts
- remove all submenus and use only 'blog'
- Add category selector for desktop and mobile

Resolves  #1001

Preview:
![blog-preview](https://user-images.githubusercontent.com/28106476/83867042-0a81d500-a729-11ea-8799-76caf64a5a5b.gif)
