### PR TITLE
Downloads: add warning about binaries being potentially flagged as malware by AVs

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -197,6 +197,8 @@ downloads:
   mobilelight2: Hangouts
   mobilelight3:  page to see where we are.
   installer: Installer
+  avwarning: Be aware that some antiviruses and firewalls may flag the Monero executables and archives as malware.
+  moreinfofaq: More info in the FAQ
 
 monero-project:
   kovri: The Kovri project uses end-to-end encryption so that neither the sender nor receiver of a Monero transaction need to reveal their IP address to the other side or to third-party observers (the blockchain). This is done using the same technology that powers the dark net, i2p (Invisible Internet Protocol). The project is currently in heavy, active development and is not yet integrated with Monero.

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -91,6 +91,7 @@ permalink: /downloads/index.html
                     {% endfor %}
                     </ul>
                   </div>
+                  <p>{% t downloads.avwarning %} <a href="{{ site.baseurl }}/get-started/faq/#antivirus">{% t downloads.moreinfofaq %}</a>.</p>
                   <div class="col-md-12 col-sm-12 col-xs-12">
                   <p><details>
                        <summary>{% t downloads.showissues %}</summary>
@@ -184,6 +185,7 @@ permalink: /downloads/index.html
                       {% endfor %}
                     </ul>
                 </div>
+                <p>{% t downloads.avwarning %} <a href="{{ site.baseurl }}/get-started/faq/#antivirus">{% t downloads.moreinfofaq %}</a>.</p>
                 <div class="col-md-12 col-sm-12 col-xs-12">
                 <p><details>
                      <summary>{% t downloads.showissues %}</summary>


### PR DESCRIPTION
Added for both GUI and CLI.

Requires #1030, Closes #1028

Preview (GUI):

![warning](https://user-images.githubusercontent.com/28106476/83941984-0a98d800-a7f0-11ea-8602-d492a571ef27.png)
