### PR TITLE
Partially fill up title for the 'New Merchant' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-merchant.md
+++ b/.github/ISSUE_TEMPLATE/new-merchant.md
@@ -1,7 +1,7 @@
 ---
 name: New Merchant
 about: Propose a new merchant to add to the 'Merchants' page
-title: ''
+title: 'Add <NAME OF YOUR BUSINESS> to the list of merchants'
 labels: "\U0001F3EA merchant, \U0001F50D Needs investigation"
 assignees: ''
 


### PR DESCRIPTION
To make sure merchants add the name of their business to the title of the issue.