### PR TITLE
Fix confusion and add warning in blockchain import guide

### DIFF
--- a/_i18n/ar/resources/user-guides/importing_blockchain.md
+++ b/_i18n/ar/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### الخطوه 1
 

--- a/_i18n/de/resources/user-guides/importing_blockchain.md
+++ b/_i18n/de/resources/user-guides/importing_blockchain.md
@@ -1,40 +1,48 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
+### Purpose and Warning
+
+Most people don't need this. To use Monero, just start the software and it will synchronize itself with the peer-to-peer network. Normally, this is much faster than downloading and importing the blockchain as detailed in this guide. This is because you'll be downloading from many peers instead of just a single server, and the Monero daemon will verify each block as it's received, instead of verifying separately after downloading.
+
+This option is mostly useful for development, or possibly if some unusual problem is preventing you from syncing the normal way.
+
+**Never** use the dangerous unverified import option, it is strictly for experts only. Especially, don't use it with any blockchain you download from the Internet, including the official site. It is only safe to use if a) you are importing a file that you exported locally, yourself *and* b) you are absolutely sure it was already fully and properly verified before exporting.
+
 ### Step 1
 
-Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the Blockchain from another source.
+Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the blockchain from another source.
 
 ### Step 2
 
-Find the path of your Monero wallet (the folder where you extracted your wallet). For example mine is:
+Find the path where the Monero software is installed. For example mine is:
 
 `D:\monero-gui-0.10.3.1`
 
-Your path may be different depending on where you decided to download your wallet and what version of the Monero wallet you have.
+Your path may be different depending on where you decided to install the Monero software, and what version of the software you have.
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was:
+Find the path of your downloaded blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Yours might be different depending on where you downloaded the Blockchain to.
+Yours might be different depending on where you chose to save the downloaded blockchain.
 
 ### Step 4
 
-Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD`
+Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD` and pressing Enter.
 
 ### Step 5
 
-Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
+Now you need to navigate using the CMD window to the path of your Monero software. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
+`cd C:\YOUR\MONERO\PATH\HERE`
 
 It should look something like:
 
 `cd D:\monero-gui-0.10.3.1`
 
-If your Monero wallet is on another drive you can use `DriveLetter:` for example if your Monero wallet was on your D drive then before using the cd command you would do `D:`
+If your Monero software is on another drive you can use `DriveLetter:` for example if your Monero software was on your D drive then before using the cd command you would do `D:`
 
 ### Step 6
 
@@ -46,11 +54,9 @@ For example I would type :
 
 `monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
-
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
+After the the blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/en/resources/user-guides/importing_blockchain.md
+++ b/_i18n/en/resources/user-guides/importing_blockchain.md
@@ -1,40 +1,48 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
+### Purpose and Warning
+
+Most people don't need this. To use Monero, just start the software and it will synchronize itself with the peer-to-peer network. Normally, this is much faster than downloading and importing the blockchain as detailed in this guide. This is because you'll be downloading from many peers instead of just a single server, and the Monero daemon will verify each block as it's received, instead of verifying separately after downloading.
+
+This option is mostly useful for development, or possibly if some unusual problem is preventing you from syncing the normal way.
+
+**Never** use the dangerous unverified import option, it is strictly for experts only. Especially, don't use it with any blockchain you download from the Internet, including the official site. It is only safe to use if a) you are importing a file that you exported locally, yourself *and* b) you are absolutely sure it was already fully and properly verified before exporting.
+
 ### Step 1
 
-Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the Blockchain from another source.
+Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the blockchain from another source.
 
 ### Step 2
 
-Find the path of your Monero wallet (the folder where you extracted your wallet). For example mine is:
+Find the path where the Monero software is installed. For example mine is:
 
 `D:\monero-gui-0.10.3.1`
 
-Your path may be different depending on where you decided to download your wallet and what version of the Monero wallet you have.
+Your path may be different depending on where you decided to install the Monero software, and what version of the software you have.
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was:
+Find the path of your downloaded blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Yours might be different depending on where you downloaded the Blockchain to.
+Yours might be different depending on where you chose to save the downloaded blockchain.
 
 ### Step 4
 
-Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD`
+Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD` and pressing Enter.
 
 ### Step 5
 
-Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
+Now you need to navigate using the CMD window to the path of your Monero software. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
+`cd C:\YOUR\MONERO\PATH\HERE`
 
 It should look something like:
 
 `cd D:\monero-gui-0.10.3.1`
 
-If your Monero wallet is on another drive you can use `DriveLetter:` for example if your Monero wallet was on your D drive then before using the cd command you would do `D:`
+If your Monero software is on another drive you can use `DriveLetter:` for example if your Monero software was on your D drive then before using the cd command you would do `D:`
 
 ### Step 6
 
@@ -46,11 +54,9 @@ For example I would type :
 
 `monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
-
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
+After the the blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/es/resources/user-guides/importing_blockchain.md
+++ b/_i18n/es/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### Paso 1
 

--- a/_i18n/fr/resources/user-guides/importing_blockchain.md
+++ b/_i18n/fr/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### Étape 1
 

--- a/_i18n/it/resources/user-guides/importing_blockchain.md
+++ b/_i18n/it/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### Passo 1
 

--- a/_i18n/nl/resources/user-guides/importing_blockchain.md
+++ b/_i18n/nl/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### Stap 1
 

--- a/_i18n/pl/resources/user-guides/importing_blockchain.md
+++ b/_i18n/pl/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### Krok 1
 

--- a/_i18n/pt-br/resources/user-guides/importing_blockchain.md
+++ b/_i18n/pt-br/resources/user-guides/importing_blockchain.md
@@ -1,40 +1,48 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
+### Purpose and Warning
+
+Most people don't need this. To use Monero, just start the software and it will synchronize itself with the peer-to-peer network. Normally, this is much faster than downloading and importing the blockchain as detailed in this guide. This is because you'll be downloading from many peers instead of just a single server, and the Monero daemon will verify each block as it's received, instead of verifying separately after downloading.
+
+This option is mostly useful for development, or possibly if some unusual problem is preventing you from syncing the normal way.
+
+**Never** use the dangerous unverified import option, it is strictly for experts only. Especially, don't use it with any blockchain you download from the Internet, including the official site. It is only safe to use if a) you are importing a file that you exported locally, yourself *and* b) you are absolutely sure it was already fully and properly verified before exporting.
+
 ### Step 1
 
-Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the Blockchain from another source.
+Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the blockchain from another source.
 
 ### Step 2
 
-Find the path of your Monero wallet (the folder where you extracted your wallet). For example mine is:
+Find the path where the Monero software is installed. For example mine is:
 
 `D:\monero-gui-0.10.3.1`
 
-Your path may be different depending on where you decided to download your wallet and what version of the Monero wallet you have.
+Your path may be different depending on where you decided to install the Monero software, and what version of the software you have.
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was:
+Find the path of your downloaded blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Yours might be different depending on where you downloaded the Blockchain to.
+Yours might be different depending on where you chose to save the downloaded blockchain.
 
 ### Step 4
 
-Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD`
+Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD` and pressing Enter.
 
 ### Step 5
 
-Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
+Now you need to navigate using the CMD window to the path of your Monero software. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
+`cd C:\YOUR\MONERO\PATH\HERE`
 
 It should look something like:
 
 `cd D:\monero-gui-0.10.3.1`
 
-If your Monero wallet is on another drive you can use `DriveLetter:` for example if your Monero wallet was on your D drive then before using the cd command you would do `D:`
+If your Monero software is on another drive you can use `DriveLetter:` for example if your Monero software was on your D drive then before using the cd command you would do `D:`
 
 ### Step 6
 
@@ -46,11 +54,9 @@ For example I would type :
 
 `monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
-
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
+After the the blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/ru/resources/user-guides/importing_blockchain.md
+++ b/_i18n/ru/resources/user-guides/importing_blockchain.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 ### Шаг 1
 

--- a/_i18n/tr/resources/user-guides/importing_blockchain.md
+++ b/_i18n/tr/resources/user-guides/importing_blockchain.md
@@ -1,40 +1,48 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
+### Purpose and Warning
+
+Most people don't need this. To use Monero, just start the software and it will synchronize itself with the peer-to-peer network. Normally, this is much faster than downloading and importing the blockchain as detailed in this guide. This is because you'll be downloading from many peers instead of just a single server, and the Monero daemon will verify each block as it's received, instead of verifying separately after downloading.
+
+This option is mostly useful for development, or possibly if some unusual problem is preventing you from syncing the normal way.
+
+**Never** use the dangerous unverified import option, it is strictly for experts only. Especially, don't use it with any blockchain you download from the Internet, including the official site. It is only safe to use if a) you are importing a file that you exported locally, yourself *and* b) you are absolutely sure it was already fully and properly verified before exporting.
+
 ### Step 1
 
-Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the Blockchain from another source.
+Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the blockchain from another source.
 
 ### Step 2
 
-Find the path of your Monero wallet (the folder where you extracted your wallet). For example mine is:
+Find the path where the Monero software is installed. For example mine is:
 
 `D:\monero-gui-0.10.3.1`
 
-Your path may be different depending on where you decided to download your wallet and what version of the Monero wallet you have.
+Your path may be different depending on where you decided to install the Monero software, and what version of the software you have.
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was:
+Find the path of your downloaded blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Yours might be different depending on where you downloaded the Blockchain to.
+Yours might be different depending on where you chose to save the downloaded blockchain.
 
 ### Step 4
 
-Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD`
+Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD` and pressing Enter.
 
 ### Step 5
 
-Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
+Now you need to navigate using the CMD window to the path of your Monero software. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
+`cd C:\YOUR\MONERO\PATH\HERE`
 
 It should look something like:
 
 `cd D:\monero-gui-0.10.3.1`
 
-If your Monero wallet is on another drive you can use `DriveLetter:` for example if your Monero wallet was on your D drive then before using the cd command you would do `D:`
+If your Monero software is on another drive you can use `DriveLetter:` for example if your Monero software was on your D drive then before using the cd command you would do `D:`
 
 ### Step 6
 
@@ -46,11 +54,9 @@ For example I would type :
 
 `monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
-
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
+After the the blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/zh-cn/resources/user-guides/importing_blockchain.md
+++ b/_i18n/zh-cn/resources/user-guides/importing_blockchain.md
@@ -1,40 +1,48 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
+### Purpose and Warning
+
+Most people don't need this. To use Monero, just start the software and it will synchronize itself with the peer-to-peer network. Normally, this is much faster than downloading and importing the blockchain as detailed in this guide. This is because you'll be downloading from many peers instead of just a single server, and the Monero daemon will verify each block as it's received, instead of verifying separately after downloading.
+
+This option is mostly useful for development, or possibly if some unusual problem is preventing you from syncing the normal way.
+
+**Never** use the dangerous unverified import option, it is strictly for experts only. Especially, don't use it with any blockchain you download from the Internet, including the official site. It is only safe to use if a) you are importing a file that you exported locally, yourself *and* b) you are absolutely sure it was already fully and properly verified before exporting.
+
 ### Step 1
 
-Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the Blockchain from another source.
+Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the blockchain from another source.
 
 ### Step 2
 
-Find the path of your Monero wallet (the folder where you extracted your wallet). For example mine is:
+Find the path where the Monero software is installed. For example mine is:
 
 `D:\monero-gui-0.10.3.1`
 
-Your path may be different depending on where you decided to download your wallet and what version of the Monero wallet you have.
+Your path may be different depending on where you decided to install the Monero software, and what version of the software you have.
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was:
+Find the path of your downloaded blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Yours might be different depending on where you downloaded the Blockchain to.
+Yours might be different depending on where you chose to save the downloaded blockchain.
 
 ### Step 4
 
-Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD`
+Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD` and pressing Enter.
 
 ### Step 5
 
-Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
+Now you need to navigate using the CMD window to the path of your Monero software. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
+`cd C:\YOUR\MONERO\PATH\HERE`
 
 It should look something like:
 
 `cd D:\monero-gui-0.10.3.1`
 
-If your Monero wallet is on another drive you can use `DriveLetter:` for example if your Monero wallet was on your D drive then before using the cd command you would do `D:`
+If your Monero software is on another drive you can use `DriveLetter:` for example if your Monero software was on your D drive then before using the cd command you would do `D:`
 
 ### Step 6
 
@@ -46,11 +54,9 @@ For example I would type :
 
 `monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
-
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
+After the the blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys

--- a/_i18n/zh-tw/resources/user-guides/importing_blockchain.md
+++ b/_i18n/zh-tw/resources/user-guides/importing_blockchain.md
@@ -1,40 +1,48 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
+### Purpose and Warning
+
+Most people don't need this. To use Monero, just start the software and it will synchronize itself with the peer-to-peer network. Normally, this is much faster than downloading and importing the blockchain as detailed in this guide. This is because you'll be downloading from many peers instead of just a single server, and the Monero daemon will verify each block as it's received, instead of verifying separately after downloading.
+
+This option is mostly useful for development, or possibly if some unusual problem is preventing you from syncing the normal way.
+
+**Never** use the dangerous unverified import option, it is strictly for experts only. Especially, don't use it with any blockchain you download from the Internet, including the official site. It is only safe to use if a) you are importing a file that you exported locally, yourself *and* b) you are absolutely sure it was already fully and properly verified before exporting.
+
 ### Step 1
 
-Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the Blockchain from another source.
+Download the Current bootstrap from https://downloads.getmonero.org/blockchain.raw; you can skip this step if you are importing the blockchain from another source.
 
 ### Step 2
 
-Find the path of your Monero wallet (the folder where you extracted your wallet). For example mine is:
+Find the path where the Monero software is installed. For example mine is:
 
 `D:\monero-gui-0.10.3.1`
 
-Your path may be different depending on where you decided to download your wallet and what version of the Monero wallet you have.
+Your path may be different depending on where you decided to install the Monero software, and what version of the software you have.
 
 ### Step 3
 
-Find the path of your downloaded Blockchain for example mine was:
+Find the path of your downloaded blockchain for example mine was:
 
 `C:\Users\KeeJef\Downloads\blockchain.raw`
 
-Yours might be different depending on where you downloaded the Blockchain to.
+Yours might be different depending on where you chose to save the downloaded blockchain.
 
 ### Step 4
 
-Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD`
+Open a Command Prompt window. You can do this by pressing the Windows key + R, and then typing in the popup box `CMD` and pressing Enter.
 
 ### Step 5
 
-Now you need to navigate using the CMD window to the path of your Monero wallet. You can do this by typing:
+Now you need to navigate using the CMD window to the path of your Monero software. You can do this by typing:
 
-`cd C:\YOUR\MONERO\WALLET\FILE\PATH\HERE`
+`cd C:\YOUR\MONERO\PATH\HERE`
 
 It should look something like:
 
 `cd D:\monero-gui-0.10.3.1`
 
-If your Monero wallet is on another drive you can use `DriveLetter:` for example if your Monero wallet was on your D drive then before using the cd command you would do `D:`
+If your Monero software is on another drive you can use `DriveLetter:` for example if your Monero software was on your D drive then before using the cd command you would do `D:`
 
 ### Step 6
 
@@ -46,11 +54,9 @@ For example I would type :
 
 `monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
 
-If you downloaded the Blockchain from a trusted, reputable source you may set `verify 0` this will reduce the amount of time to sync the Blockchain.  
-
 ### Step 7
 
-After the the Blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
+After the the blockchain has finished syncing up you can open your Monero wallet normally. Your downloaded blockchain.raw can be deleted.
 
 
 Author: Kee Jefferys


### PR DESCRIPTION
I recently encountered a new user that was led astray by this document.

First, it implied that it was okay to use unverified import with "trusted and reputable sources," which is just wrong. Replaced that with a warning and moved to the top.

Second, it referred to the Monero software as "the wallet" or even "your wallet," which led the user to the location of, well, their wallet file, instead of the binaries. 

Lastly, it seems that people are doing this because they somehow just assume it will be faster. I'm pretty sure the reverse is true, which means that no one should need this tool except for testing and development. This seems worth clarifying at the top.

Also fixed some capitalization.

