### PR TITLE
Fix swapped hashes of 0.16.0.2 for win64 and linux64 in downloads.yml

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -7,7 +7,7 @@ gui:
      icon: icon-windows
      vers: 
    - platform: Windows 64-bit (Zip)
-     hash: 9ff8c91268f8eb027bd26dcf53fda5e16cb482815a6d5b87921d96631a79f33f
+     hash: 6e0efb25d1f5c45a4527c66ad6f6c623c08590d7c21de5a611d8c2ff0e3fbb55
      link: https://downloads.getmonero.org/gui/win64
      icon: icon-windows
      vers: 
@@ -17,7 +17,7 @@ gui:
      icon: icon-apple
      vers: 
    - platform: Linux 64-bit
-     hash: 6e0efb25d1f5c45a4527c66ad6f6c623c08590d7c21de5a611d8c2ff0e3fbb55
+     hash: 9ff8c91268f8eb027bd26dcf53fda5e16cb482815a6d5b87921d96631a79f33f
      link: https://downloads.getmonero.org/gui/linux64
      icon: icon-linux
      vers: 


### PR DESCRIPTION
See https://old.reddit.com/r/Monero/comments/hpn8i0/hashes_dont_match/

The hashes on the blog post (#1066, not deployed yet) and [the signed hashes.txt](https://web.getmonero.org/downloads/hashes.txt) file are correct. The hashes in the downloads page of [Linux 64-bit](https://github.com/monero-project/monero-site/pull/1071/files#diff-69cb2c60ade563f7533c5f5bac421be4R20) and [Windows 64-bit (Zip)](https://github.com/monero-project/monero-site/pull/1071/files#diff-69cb2c60ade563f7533c5f5bac421be4R10) were swapped.

Please double check this PR by verifying the hashes of both archives before merging.