### PR TITLE
workflows: improve performance of github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [ '2.4', '2.5', '2.6', '2.7' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -20,4 +20,4 @@ jobs:
       - name: bundle install
         run: bundle install --jobs 4 --retry 3
       - name: build site
-        run: bundle exec jekyll build
+        run: bundle exec jekyll build --limit-posts 10


### PR DESCRIPTION
- Bump actions/checkout to v2
- Limit number of posts to be built to 10

Build time reduced from about 6 minutes to 2.20 minutes (rough average)