### PR TITLE
Added documentation for `get_outs` input parameter `get_txid`

### DIFF
--- a/resources/developer-guides/daemon-rpc.md
+++ b/resources/developer-guides/daemon-rpc.md
@@ -2329,6 +2329,7 @@ Inputs:
 * *outputs* array of *get_outputs_out* structure as follows:
   * *amount* - unsigned int;
   * *index* - unsigned int;
+* *get_txid* - boolean; If `true`, a *txid* will included for each output in the response.
 
 Outputs:
 


### PR DESCRIPTION
See monero-project/monero#6721