### PR TITLE
Fix tooltip messing up the width of a page on mobile in some edge cases

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -4659,8 +4659,11 @@ input.accordion[type=radio]:checked + label::after {
   margin: 1rem 0;
 }
 
+[data-tooltip]:before {
+  width: 0;
 }
 
+}
 
 
 


### PR DESCRIPTION
Closes #1099 

The problem seems to happen only with one tooltip in the Downloads page (CLI wallet -> 'Bootstrap Node' entry -> "Remote Node" tooltip). Seems to be triggered if a tooltip happens to be at the end of a line on mobile. I solved removing the width of the balloon when on mobile, since it's not shown anyway in that case.