### PR TITLE
Fix tooltip + minor improvements

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -3210,6 +3210,10 @@ footer {
   display:none;
 }
 
+.mobile-only .nopadding {
+    padding: 0;
+}
+
 @media only screen and (max-width: 75rem) {
 
 .desktop-only {
@@ -4716,9 +4720,18 @@ input.accordion[type=radio]:checked + label::after {
 .tab-content p {
   margin: 1rem 0;
 }
+}
+
+@media only screen and (max-width: 62rem) {
+
 
 [data-tooltip]:before {
-  width: 0;
+  width: auto;
+  bottom: 100%;
+}
+    
+.downloads ul.logo {
+  padding-inline-start: 20px;
 }
 
 }


### PR DESCRIPTION
- Fix tooltip on mobile (extra fix #1102)
- Change list-logo-icons padding (40px -> 20px)
- Remove downloads-icons padding

## Before:
![image](https://user-images.githubusercontent.com/8020386/89135631-78981c00-d561-11ea-81e3-6bc3a8cc65e1.png)

## After:
![image](https://user-images.githubusercontent.com/8020386/89135637-8352b100-d561-11ea-899a-fbbdce398dde.png)
