### PR TITLE
Fixes to feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ plugins:
   - jekyll-feed
 
 feed:
-  path: feed.atom
   posts_limit: 20
 
 # jekyll-multiple-languages-plugin settings:

--- a/_data/lang/ar/footer-1.yml
+++ b/_data/lang/ar/footer-1.yml
@@ -9,7 +9,7 @@
   - name: دليل المستخدم
     url: resources/user-guides/
   - name: RSS Feed
-    url: feed.atom
+    url: feed.xml
 - title: IRC قنوات الدردشة
   subfolderitems:
   - name: مونيرو

--- a/_data/lang/de/footer-1.yml
+++ b/_data/lang/de/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Bibliothek
     url: library
   - name: RSS-Feed
-    url: feed.atom
+    url: feed.xml
 - title: IRC-Channels
   subfolderitems:
   - name: monero

--- a/_data/lang/en/footer-1.yml
+++ b/_data/lang/en/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Library
     url: library
   - name: RSS Feed
-    url: feed.atom
+    url: feed.xml
 - title: IRC Channels
   subfolderitems:
   - name: monero

--- a/_data/lang/es/footer-1.yml
+++ b/_data/lang/es/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Librería
     url: library
   - name: RSS Feed
-    url: feed.atom
+    url: feed.xml
 - title: Canales IRC
   subfolderitems:
   - name: monero

--- a/_data/lang/fr/footer-1.yml
+++ b/_data/lang/fr/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Librairie
     url: library
   - name: Flux RSS
-    url: feed.atom
+    url: feed.xml
 - title: Canaux IRC
   subfolderitems:
   - name: monero

--- a/_data/lang/it/footer-1.yml
+++ b/_data/lang/it/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Libreria
     url: library
   - name: Feed RSS
-    url: feed.atom
+    url: feed.xml
 - title: Chat IRC
   subfolderitems:
   - name: monero

--- a/_data/lang/nl/footer-1.yml
+++ b/_data/lang/nl/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Bibliotheek
     url: library
   - name: RSS-kanaal
-    url: feed.atom
+    url: feed.xml
 - title: IRC-kanalen
   subfolderitems:
   - name: monero

--- a/_data/lang/pl/footer-1.yml
+++ b/_data/lang/pl/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Księgarnia
     url: library
   - name: Kanał RSS
-    url: feed.atom
+    url: feed.xml
 - title: Kanały IRC
   subfolderitems:
   - name: monero

--- a/_data/lang/pt-br/footer-1.yml
+++ b/_data/lang/pt-br/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Biblioteca
     url: library
   - name: RSS Feed
-    url: feed.atom
+    url: feed.xml
 - title: Canais no IRC
   subfolderitems:
   - name: monero

--- a/_data/lang/ru/footer-1.yml
+++ b/_data/lang/ru/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Библиотека
     url: library
   - name: Канал RSS
-    url: feed.atom
+    url: feed.xml
 - title: Каналы IRC
   subfolderitems:
   - name: monero

--- a/_data/lang/tr/footer-1.yml
+++ b/_data/lang/tr/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Kütüphane
     url: library
   - name: RSS Besleme
-    url: feed.atom
+    url: feed.xml
 - title: IRC Kanalları
   subfolderitems:
   - name: monero

--- a/_data/lang/zh-cn/footer-1.yml
+++ b/_data/lang/zh-cn/footer-1.yml
@@ -11,7 +11,7 @@
   - name: Library
     url: library
   - name: RSS Feed
-    url: feed.atom
+    url: feed.xml
 - title: IRC Channels
   subfolderitems:
   - name: monero

--- a/_data/lang/zh-tw/footer-1.yml
+++ b/_data/lang/zh-tw/footer-1.yml
@@ -11,7 +11,7 @@
   - name: 圖書出版品
     url: library
   - name: RSS 摘要
-    url: feed.atom
+    url: feed.xml
 - title: IRC 頻道
   subfolderitems:
   - name: monero

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,7 +48,7 @@
     
     <meta name="msapplication-config" content="/ietemplates/ieconfig.xml">
 
-  <!-- Expose helper tag to support automated discovery of blog feed -->
-  {% feed_meta %}
+  <!-- Feed autodetection -->
+  <link type="application/atom+xml" rel="alternate" href="{{ site.baseurl_root }}/feed.xml" title="Monero">
 
   </head>

--- a/blog/index.html
+++ b/blog/index.html
@@ -40,7 +40,7 @@ title: titles.blogbytag
       <!-- Full block-->
         <div class="info-block">
           <div class="feed">
-            <a href="/feed.atom"><span class="feed-pic"></span></a>
+            <a href="/feed.xml"><span class="feed-pic"></span></a>
             <h2>{% t blog.allposts %}</h2>
           </div>
           {% for post in paginator.posts %}


### PR DESCRIPTION
The autodetection wasn't working as expected. The helper tag is using both url + baseurl, this broke things but not locally (since we build with an empty baseurl), that's why we didn't see it in https://github.com/monero-project/monero-site/pull/1051#issuecomment-648252942.

Also changed the feed from feed.atom to feed.xml. The new structure of the feed broke things for people who are using the old version.