### PR TITLE
Roadmap: add CLI and GUI 0.16.0.0

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -581,6 +581,7 @@ roadmap:
   tryptych: "Triptych: logarithmic-sized linkable ring signatures with applications"
   kastelo: "Kastelo: open source hardware wallet"
   layer2: Second-layer solutions for speed and scalability
+  released-0-16-0-0: CLI and GUI 0.16.0.0 released
   
   returnaddr: Return addresses
 

--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -183,6 +183,8 @@ permalink: /resources/roadmap/index.html
                                     <li class="completed">{% t roadmap.released-0-15-0-5 %}</li>
                                 <h3 id="months">{% t roadmap.apr %}</h3>
                                     <li class="completed">{% t roadmap.dandelion %}</li>
+                                <h3 id="months">{% t roadmap.may %}</h3>
+                                    <li class="completed">{% t roadmap.released-0-16-0-0 %}</li>
                                 <h3 id="months">{% t roadmap.comingsoon %}</h3>
                                     <li class="ongoing">{% t roadmap.onionaddress %}</li>
                                     <li class="ongoing">{% t roadmap.supercop %}</li>


### PR DESCRIPTION
We had other minor point release after 0.16.0.0, but i don't think make sense to clog the roadmap with release dates, which are also easily browsable on the blog. I think would be better to only list major releases in the roadmap.