### PR TITLE
Remove 'Libraries and helpers' from the merchants page and replace it with 'Web Hosting' + Add ''Libraries and helpers" to the dev guides

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -137,35 +137,49 @@
       url: https://swirlpay.io/
     - name: Vigla
       url: https://vigla.biz/
-- category: Libraries and Helpers
-  id: libraries
+- category: Web hosting
+  id: hosting
   merchants:
-    - name: Monero Integrations (eCommerce plugins)
-      url: http://monerointegrations.com/
-    - name: monero-nodejs (Node.js)
-      url: https://github.com/PsychicCat/monero-nodejs
-    - name: MoneroApi.Net (.NET)
-      url: https://github.com/Jojatekok/MoneroApi.Net
-    - name: moneronjs (NodeJS)
-      url: https://github.com/netmonk/moneronjs
-    - name: Monero Payments Library (PHP)
-      url: https://github.com/monero-integrations/monerophp
-    - name: Monero-PHP (PHP)
-      url: https://github.com/PsychicCat/monero-php
-    - name: MoneroPy (Python)
-      url: https://github.com/bigreddmachine/MoneroPy
-    - name: monero-python (Python)
-      url: https://github.com/monero-ecosystem/monero-python
-    - name: PHP-Monero (PHP)
-      url: https://github.com/MalMen/PHP-Monero
-    - name: python-monero (Python)
-      url: https://github.com/tippero/python-monero
-    - name: xmr-integration (PHP)
-      url: https://github.com/TheKoziTwo/xmr-integration
-    - name: Monero Utilities (golang)
-      url: https://github.com/paxos-bankchain/moneroutil
-    - name: monerorpc (Java)
-      url: https://github.com/00-matt/monerorpc
+    - name: 1Gbits
+      url: https://1gbits.com/
+    - name: 1oasis.net
+      url: https://web.senang.online/
+    - name: 99Stack Hosting
+      url: https://www.99stack.com
+    - name: Abaco Hosting
+      url: https://abacohosting.com/
+    - name: Ablative Hosting
+      url: https://ablative.hosting
+    - name: Capsul - Simple, Fast, Private Virtual Machines
+      url: https://capsul.org
+    - name: Cryptoho.st - VPS hosting
+      url: https://cryptoho.st/
+    - name: Evolution Host - Hosting services
+      url: https://evolution-host.com/
+    - name: HostingCanada - Web hosting 
+      url: https://hostingcanada.org/
+    - name: Monovm
+      url: https://monovm.com/
+    - name: NiceVPS - VPS and web hosting
+      url: https://nicevps.net/
+    - name: Njalla - privacy-aware domain registration
+      url: https://njal.la/
+    - name: RouterHosting - Hosting (VPS)
+      url: https://www.routerhosting.com/
+    - name: Snel - dedicated and VPS hosting
+      url: https://www.snel.com/
+    - name: SporeStack - Accountless, API-driven VPS hosting
+      url: https://sporestack.com
+    - name: SuperBitHost - Dedicated server, VPS, shared hosting, domains and SSL certificates
+      url: https://www.superbithost.com
+    - name: Tuxcon Hosting - Mail and Web Hosting
+      url: https://tuxcon.com
+    - name: VPNtesting
+      url: https://www.vpntesting.com/
+    - name: Webbdo Hosting (se)
+      url: https://www.webbdo.se/webbhotell/
+    - name: Whattheserver - Web hosting
+      url: https://Whattheserver.me
 - category: Tools
   id: tools
   merchants:
@@ -186,16 +200,6 @@
 - category: Services
   id: services
   merchants:
-    - name: 1Gbits
-      url: https://1gbits.com/
-    - name: 1oasis.net
-      url: https://web.senang.online/
-    - name: 99Stack Hosting
-      url: https://www.99stack.com
-    - name: Abaco Hosting
-      url: https://abacohosting.com/
-    - name: Ablative Hosting
-      url: https://ablative.hosting
     - name: AGRsicurezza - Business Consultant (IT)
       url: https://www.agrsicurezza.it/
     - name: AirVPN
@@ -212,12 +216,8 @@
       url: https://bunkervpn.com
     - name: Caliston Design - Design and web development agency
       url: https://calistondesign.com/
-    - name: Capsul - Simple, Fast, Private Virtual Machines
-      url: https://capsul.org
     - name: cloakVPN.com
       url: https://cloakVPN.com
-    - name: Cryptoho.st - VPS hosting
-      url: https://cryptoho.st/
     - name: Cryptostorm VPN
       url: https://cryptostorm.is/
     - name: cryptwerk - online directory with companies, websites, shops, services accepting cryptocurrencies
@@ -228,8 +228,6 @@
       url: https://galanglaw.com/
     - name: Esperanto lessons from Kaja
       url: mailto:kiah.morante@gmail.com
-    - name: Evolution Host - Hosting services
-      url: https://evolution-host.com/
     - name: ExchangeRates - compares the prices of Monero and other cryptocurrencies across exchanges
       url: https://exchangerates.pro/
     - name: Farmer ALP, LLC, Arizona
@@ -244,8 +242,6 @@
       url: https://healthiermatters.com/advertise-with-us
     - name: Hiri - Email client
       url: https://www.hiri.com/crypto/currency/XMR/
-    - name: HostingCanada - Web hosting 
-      url: https://hostingcanada.org/
     - name: Information Technology Works
       url: https://itwrx.org/
     - name: Ink Rebels
@@ -260,42 +256,18 @@
       url: https://marcosaguayo.com/
     - name: MSvB Hardware Design (using a secure element)
       url: mailto:monerodev+sitesvcs@encambio.com?subject=Monero%20Services%20Hardware%20Design%20Request
-    - name: MoneroJobs - Find and list jobs that pay Monero (XMR)
-      url: https://www.monerojobs.com/
-    - name: Monovm
-      url: https://monovm.com/
     - name: MyMonero Web-based Wallet
       url: https://mymonero.com
-    - name: NiceVPS - VPS and web hosting
-      url: https://nicevps.net/
-    - name: Njalla - privacy-aware domain registration
-      url: https://njal.la/
-    - name: RouterHosting - Hosting (VPS)
-      url: https://www.routerhosting.com/
     - name: Seymour Locksmiths
       url: https://seymour-locksmiths.co.uk/
-    - name: Snel - dedicated and VPS hosting
-      url: https://www.snel.com/
     - name: Social Media LTD - Digital marketing agency
       url: https://social-media.co.uk/
-    - name: SporeStack - Accountless, API-driven VPS hosting
-      url: https://sporestack.com
-    - name: SuperBitHost - Dedicated server, VPS, shared hosting, domains and SSL certificates
-      url: https://www.superbithost.com
     - name: TorGuard - VPN, proxy and email service
       url: https://torguard.net
     - name: Travala - Cryptocurrency Friendly Travel Booking
       url: https://www.travala.com/
-    - name: Tuxcon Hosting - Mail and Web Hosting
-      url: https://tuxcon.com
     - name: Vpn.surf
       url: https://vpn.surf/blog/buy-vpn-with-monero/
-    - name: VPNtesting
-      url: https://www.vpntesting.com/
-    - name: Webbdo Hosting (se)
-      url: https://www.webbdo.se/webbhotell/
-    - name: Whattheserver - Web hosting
-      url: https://Whattheserver.me
     - name: XMR.to Monero to Bitcoin Payment Service
       url: https://xmr.to/
 - category: Goods

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -443,6 +443,19 @@ developer-guides:
   moneroexamples: Rich list of examples and docs related to Monero development.
   moneroecosystem: Community of Monero developers. Contains libraries and resources and guides of some Monero Workgroups, like the Localization Workgroup and the Outreach Workgroup.
   monerose: One of the most complete resources for both users and developers.
+  libraries: Libraries and helpers
+  libraries_para: Monero libraries created and maintained by the community. They are not vetted by the core team and are listed here only for convenience. Make your own researches before using them. If you want to add a library to this list, please open an issue on
+  monero-javascript: A Node.js library for using Monero.
+  monero-nodejs: Wallet manager for interacting with monero-wallet-rpc.
+  monerophp: A Monero library written in PHP by the Monero Integrations team.
+  monerowp: Monero WooCommerce Plugin for Wordpress.
+  monero-python: A comprehensive Python module for handling Monero cryptocurrency.
+  moneriote-python: Python scripts to maintain Monero opennodes DNS records.
+  monerorpc: A Java interface for Monero wallet and daemon RPC.
+  monero-java: A Java library for using Monero.
+  monero-cpp: A C++ library for using Monero.
+  vanity-monero: Generate vanity address for CryptoNote currency (Monero etc.).
+  go-monero-rpc-client: A go client for the Monero wallet and daemon RPC.
 
 user-guides:
   general: General

--- a/resources/developer-guides/index.md
+++ b/resources/developer-guides/index.md
@@ -43,6 +43,33 @@ permalink: /resources/developer-guides/index.html
                         <p>{% t developer-guides.monerose %}</p>
                 </div>
             </div>
+            <div class="full container">
+                <div class="info-block">
+                    <div class="row center-xs">
+                        <h2>{% t developer-guides.libraries %}</h2>
+                    </div>
+                    <p>{% t developer-guides.libraries_para %} <a href="https://github.com/monero-project/monero-site/issues">GitHub</a>.</p>
+                <ul class="logo">
+                    <h3>Node.js</h3>
+                        <li><a href="https://github.com/monero-ecosystem/monero-javascript">monero-javascript (Monero Ecosystem)</a> - {% t developer-guides.monero-javascript %}</li>
+                        <li><a href="https://github.com/PsychicCat/monero-nodejs">monero-nodejs</a> - {% t developer-guides.monero-nodejs %}</li>
+                    <h3>PHP</h3>
+                        <li><a href="https://github.com/monero-integrations/monerophp">monerophp (Monero Integrations)</a> - {% t developer-guides.monerophp %}</li>
+                        <li><a href="https://github.com/monero-integrations/monerowp">monerowp (Monero Integrations)</a> - {% t developer-guides.monerowp %}</li>
+                    <h3>Python</h3>
+                        <li><a href="https://github.com/monero-ecosystem/monero-python">monero-python (Monero Ecosystem)</a> - {% t developer-guides.monero-python %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/moneriote-python">moneriote-python (Monero Ecosystem)</a> - {% t developer-guides.moneriote-python %}</li>
+                    <h3>Java</h3>
+                        <li><a href="https://github.com/00-matt/monerorpc">monerorpc</a> - {% t developer-guides.monerorpc %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/monero-java">monero-java (Monero Ecosystem)</a> - {% t developer-guides.monero-java %}</li>
+                    <h3>C++</h3>
+                        <li><a href="https://github.com/monero-ecosystem/monero-cpp">monero-cpp (Monero Ecosystem)</a> - {% t developer-guides.monero-cpp %}</li>
+                    <h3>Golang</h3>
+                        <li><a href="https://github.com/monero-ecosystem/vanity-monero">vanity-monero (Monero Ecosystem)</a> - {% t developer-guides.vanity-monero %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/go-monero-rpc-client">go-monero-rpc-client (Monero Ecosystem)</a> - {% t developer-guides.go-monero-rpc-client %}</li>
+                </ul>
+                </div>
+            </div>
         </div>
     </section>
 </div>


### PR DESCRIPTION
These two changes have to be made together because, with the current structure, if we remove a section from the merchants page we have to replace it with something else.

- **Moved 'Libraries and helpers' from the merchants page to the developer guides**. Most of the listed repositories were obsolete. I removed almost all of them and replaced with maintained repos (if anybody have more repos to suggest, please let me know).
- **Added section 'Web Hosting' to the merchants page**. We had a big amount of merchants offering web hosting in the 'services' section. Since to not mess up the selector at the top we need to keep the same amount of categories in the merchants page, i thought was a good idea to create a section dedicated to web hosting.

Closes #974