### PR TITLE
Add 'Circled Information Source' symbol to Moneropedia links

### DIFF
--- a/_plugins/moneropedia.rb
+++ b/_plugins/moneropedia.rb
@@ -120,14 +120,14 @@ module Jekyll
           if lang != "en"
             @@moneropedia[lang].each do |entry|
               entry[:terms].each do |term|
-                content = content.gsub(/(\@#{term})((?=-#{lookahead})|(?![\w-]))/i, '<a data-tooltip="' + entry[:summary] + '" href="/' + lang + '/resources/moneropedia/' + entry[:file] + '.html" >' + term.gsub('-',' ') + '</a>')
+                content = content.gsub(/(\@#{term})((?=-#{lookahead})|(?![\w-]))/i, '<a class="info-tooltip" data-tooltip="' + entry[:summary] + '" href="/' + lang + '/resources/moneropedia/' + entry[:file] + '.html" >' + term.gsub('-',' ') + '</a>')
               end
             end
           end
           # For English and as a default (in case an entry has been forgotten in a non-English moneropedia folder)
           @@moneropedia["en"].each do |entry|
             entry[:terms].each do |term|
-              content = content.gsub(/(\@#{term})((?=-#{lookahead})|(?![\w-]))/i, '<a data-tooltip="' + entry[:summary] + '" href="/resources/moneropedia/' + entry[:file] + '.html" >' + term.gsub('-',' ') + '</a>')
+              content = content.gsub(/(\@#{term})((?=-#{lookahead})|(?![\w-]))/i, '<a class="info-tooltip" data-tooltip="' + entry[:summary] + '" href="/resources/moneropedia/' + entry[:file] + '.html" >' + term.gsub('-',' ') + '</a>')
             end
           end
         end

--- a/css/custom.css
+++ b/css/custom.css
@@ -4759,6 +4759,20 @@ input.accordion[type=radio]:checked + label::after {
 
 /*********************TOOLTIPS********************/
 
+.info-block a.info-tooltip {
+  border-bottom: none;
+}
+
+.info-block a.info-tooltip:hover {
+  border-bottom: 2px solid #a1aabb;
+}
+
+.info-tooltip {
+  background: url("/img/circled-i.svg") no-repeat right top;
+  padding-right: 0.7rem;
+  background-size: 0.7rem;
+}
+
 [data-tooltip] {
   position: relative;
   z-index: 2;

--- a/img/circled-i.svg
+++ b/img/circled-i.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">
+<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<g><g><path d="M560.1,767.2l55.3,2.9v77.5H384.7v-73.7l32-2.9c17.4-1.9,28.1-7.8,28.1-31V470.5c0-21.4-5.8-28.2-24.2-28.2l-33.9-1.9V360h173.5L560.1,767.2L560.1,767.2z M492.3,152.3c42.7,0,73.7,32.1,73.7,72.7c0,40.8-31,70.8-74.7,70.8c-44.5,0-73.6-30.1-73.6-70.8C417.6,184.4,446.7,152.3,492.3,152.3z M500,990C229.8,990,10,770.2,10,500S229.8,10,500,10c270.1,0,490,219.8,490,490S770.1,990,500,990z M500,101.9c-219.5,0-398.1,178.6-398.1,398.1S280.5,898.1,500,898.1c219.5,0,398.1-178.6,398.1-398.1S719.5,101.9,500,101.9z"/></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g></g>
+</svg>


### PR DESCRIPTION

![Screenshot from 2020-11-04 14-59-45](https://user-images.githubusercontent.com/28106476/98127277-6904d800-1eae-11eb-911b-6a8bb098567a.png)


Tested on Firefox and Chromium. Please test it on more browsers.

I was thinking of removing the dotted bottom to the internal Moneropedia links. Mostly because i don't like that in general and i thought the link to the Moneropedia entry would look nicer only in bold + the circled 'i' logo. I decided to keep the dotted bottom here only for consistency with the other internal links, but if people agree it would look nicer without, i'll take it out with pleasure :)