### PR TITLE
Replace 'Library and Helpers' with 'Web Hosting' in the 'New Merchant' GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-merchant.md
+++ b/.github/ISSUE_TEMPLATE/new-merchant.md
@@ -37,7 +37,7 @@ https://
 - [ ] Exchange
 - [ ] Block Explorer
 - [ ] Payment Gateway
-- [ ] Library and Helper
+- [ ] Web Hosting
 - [ ] Tool
 - [ ] Service
 - [ ] Goods


### PR DESCRIPTION
To be merged after #1131, which removes the 'Library and helpers' section in the Merchants page