### PR TITLE
Downloads: remove 'known issues' dropdown

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -156,11 +156,6 @@ downloads:
   cli_intro: The CLI wallet gives you the total control over your Monero node and funds. Highly customizable and includes various analysis tools, as well as an HTTP RPC and 0MQ interface.
   currentversion: Current Version
   sourcecode: Source Code
-  showissues: Show known issues for this release
-  noissues: This release has no known major issues
-  yesissuesgui: Release 0.15.0.4 (Linux) was accidentally compiled without Trezor support. Thus, Trezor Monero users on Linux are recommend to wait until next release (0.15.0.5) or compile the GUI by themselves
-  yesissuescli: >
-    Because of glibc compatibility problems, this version won't run on Ubuntu 16.04 (glibc < 2.25)
   helpsupport: Help and Support
   helpsupport1: "A guide with an explanation of every section of the wallet is available:"
   helpsupport2: "See latest release"

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -94,10 +94,6 @@ permalink: /downloads/index.html
                   <p>{% t downloads.packages %} <a href="https://github.com/monero-project/monero-gui#installing-the-monero-gui-from-a-package">{% t downloads.packages_link %}</a>.</p>
                   <p>{% t downloads.avwarning %} <a href="{{ site.baseurl }}/get-started/faq/#antivirus">{% t downloads.moreinfofaq %}</a>.</p>
                   <div class="col-md-12 col-sm-12 col-xs-12">
-                  <p><details>
-                       <summary>{% t downloads.showissues %}</summary>
-                       <p><i>{% t downloads.noissues %}.</i></p><!-- Change here if there are known GUI issues (`downloads.yesissuesgui` if issues, `downloads.noissues` if no issues) -->
-                     </details></p>
                   {% for entry in item.downloads %}
                     {% if entry.vers != nil %}
                     <div class="col-md-12 col-sm-12 col-xs-12">
@@ -188,12 +184,6 @@ permalink: /downloads/index.html
                 </div>
                 <p>{% t downloads.packages %} <a href="https://github.com/monero-project/monero#installing-monero-from-a-package">{% t downloads.packages_link %}</a>.</p>
                 <p>{% t downloads.avwarning %} <a href="{{ site.baseurl }}/get-started/faq/#antivirus">{% t downloads.moreinfofaq %}</a>.</p>
-                <div class="col-md-12 col-sm-12 col-xs-12">
-                <p><details>
-                     <summary>{% t downloads.showissues %}</summary>
-                       <p><i>{% t downloads.noissues %}.</i></p><!-- Change here if there are known CLI issues (`downloads.yesissuescli` if issues, `downloads.noissues` if no issues) -->
-                     </details></p>
-                </div>
                 </div>
                 {% for entry in item.downloads %}
                     {% if entry.vers != nil %}


### PR DESCRIPTION
It's hard and annoying to maintain (and translate in a timely way) and now we have more point releases, which would fix major issues in the precedent versions.