### PR TITLE
Make baseurl empty and adapt README, netlify.toml and the sitemap_generator accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you need support about something related to the website, plese join `#monero-
 Once you have the above list of things, it's typically a good idea to build the website from your local computer to make sure it works before you make any changes. To do this, complete the following steps:
 
 1. Navigate to your local `monero-site` repository.
-2. Serve the website: `bundle exec jekyll serve --baseurl ''`. If you want, you can speedup thi process by loading only the last blog post instead of all of them. Simply add `--limit_posts 1` to the command above. The resulting command will be `bundle exec jekyll serve --limit_posts 1 --baseurl ''`.
+2. Serve the website: `bundle exec jekyll serve`. If you want, you can speedup this process by loading only the last blog post instead of all of them. Simply add `--limit_posts 1` to the command above. The resulting command will be `bundle exec jekyll serve --limit_posts 1`.
 3. Open a browser and go to [http://127.0.0.1:4000](http://127.0.0.1:4000).
 4. If all went well, you should see the Monero website and you're ready to make changes.
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ email: dev@getmonero.org
 name: Monero
 description: Monero is a digital currency that is secure, private, and untraceable.
 keywords: "monero, xmr, bitmonero, cryptocurrency"
-baseurl: "https://www.getmonero.org"
+baseurl: ""
 url: "https://www.getmonero.org"
 
 markdown: kramdown

--- a/_plugins/sitemap_generator.rb
+++ b/_plugins/sitemap_generator.rb
@@ -181,7 +181,7 @@ module Jekyll
     # Returns the location of the page or post
     def fill_location(site, page_or_post)
       loc = REXML::Element.new "loc"
-      url = site.config['baseurl']
+      url = site.config['url'] + site.config['baseurl']
       loc.text = page_or_post.location_on_server(url)
 
       loc

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "_site/"
-  command = "jekyll build --trace --limit-posts 10 --baseurl ''"
+  command = "jekyll build --trace --limit-posts 10"
 
 [build.environment]
   RUBY_VERSION = "2.6"


### PR DESCRIPTION
We enforce a baseurl with a wrong structure (the baseurl [shouldn't be a full URL](https://byparker.com/img/what-is-a-baseurl.jpg)) and that conflicts with jekyll's structure. As a result, most of the plugins, like jekyll-feed don't behave as they should and break. This was also the cause of several other problems we had in past, like the broken sitemap generator and autodetection of the feed.

A `baseurl` is needed for the i18n plugin to work, so we just feed it with an empty one. The result is that all internal links will be stripped of the domain `https://www.getmonero.org', but the structure of the website shouldn't be affected. I made several tests and i don't expect any disruption, unless some nginx configuration gets in the middle for some reason.

This will also make the configuration of the onion mirror easier (#904).

This PR also reverts commit c235ca1db7140e8d6a68ff73c5ebdaa70bfc2004.
Closes #1162 