### PR TITLE
Reorganize Monero videos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ email: dev@getmonero.org
 name: Monero
 description: Monero is a digital currency that is secure, private, and untraceable.
 keywords: "monero, xmr, bitmonero, cryptocurrency"
-baseurl: ""
+baseurl: "https://www.getmonero.org"
 url: "https://www.getmonero.org"
 
 markdown: kramdown

--- a/css/custom.css
+++ b/css/custom.css
@@ -975,6 +975,19 @@ a {
     text-decoration: none;
 }
 
+/* Videos */
+
+.box-video {
+  padding: 0.5rem 0;
+}
+
+.box-video video {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
 /* External link icon */
 
 a[href^="https:"]:not([href*="getmonero.org"]):not([class*="btn-link"]):not([class="chats-img"]):not([class*="ext-noicon"]):not([class*="white"]) {
@@ -2662,10 +2675,6 @@ p.main-downloads {
     padding: 4rem 2rem 4rem 0;
 }
 
-.monero-video {
-    padding: 4rem 2rem;
-}
-
 .main-info p {
     padding-top: 0.5rem;
 }
@@ -4339,133 +4348,7 @@ p.hangouts-social {
     padding: 1rem 1.5rem;
 }
 
-/*CAROUSEL*/
-
-
-.carousel {
-  height: 38rem;
-  overflow: hidden;
-  text-align: center;
-  position: relative;
-  padding: 0;
-  list-style: none;
-  margin: 0;
-}
-
-.carousel-controls,
-.carousel-activator {
-  display: none;
-}
-
-.carousel-slide {
-  opacity: 0;
-  z-index: -1;
-  height: 100%;
-  position: absolute;
-  padding: 0 3rem;
-  overflow: hidden;
-  -webkit-transition: opacity ease-out .3s;
-    -moz-transition: opacity ease-out .3s;
-    -o-transition: opacity ease-out .3s;
-    transition: opacity ease-out .3s;
-}
-
-.carousel-activator:nth-of-type(1):checked ~ .carousel-controls:nth-of-type(1), .carousel-activator:nth-of-type(2):checked ~ .carousel-controls:nth-of-type(2), .carousel-activator:nth-of-type(3):checked ~ .carousel-controls:nth-of-type(3), .carousel-activator:nth-of-type(4):checked ~ .carousel-controls:nth-of-type(4) {
-  display: block;
-}
-
-
-.carousel-activator:nth-of-type(1):checked ~ .carousel-slide:nth-of-type(1), .carousel-activator:nth-of-type(2):checked ~ .carousel-slide:nth-of-type(2), .carousel-activator:nth-of-type(3):checked ~ .carousel-slide:nth-of-type(3), .carousel-activator:nth-of-type(4):checked ~ .carousel-slide:nth-of-type(4) {
-    z-index: 2;
-    opacity: 1;
-}
-
-.carousel-control {
-  height: 2rem;
-  width: 2rem;
-  margin-top: -1rem;
-  top: 50%;
-  position: absolute;
-  display: block;
-  cursor: pointer;
-  border-width: 5px 5px 0 0;
-  border-style: solid;
-  border-color: #4c4c4c;
-  opacity: 0.35;
-  outline: 0;
-  z-index: 3;
-}
-.carousel-control:hover {
-  opacity: 1;
-}
-.carousel-control-backward {
-  left: 0.8rem;
-  -webkit-transform: rotate(-135deg);
-          transform: rotate(-135deg);
-}
-.carousel-control-forward {
-  right: 0.8rem;
-  -webkit-transform: rotate(45deg);
-          transform: rotate(45deg);
-}
-
-
-@-webkit-keyframes carousel-show-slide {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@keyframes carousel-show-slide {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.carousel video {
-    margin-top: 1rem;
-}
-
-.carousel h3 {
-    text-align: left;
-}
-
-@supports (-ms-ime-align:auto) {
-
-.carousel-slide.ms {
-    width: 91%;
-}
-
-@media only screen and (max-width: 75rem) {
-
-.carousel-slide.ms {
-    width: auto;
-}
-
-
-}
-
-}
-
-
-@media only screen and (max-width: 75rem) {
-
-.carousel {
-    height: 33rem;
-}
-
-}
-
 @media only screen and (max-width: 62rem) {
-
-.carousel {
-    height: 24rem;
-}
 
 .about-monero .info-block-row img.main-icon {
     width: 100%;
@@ -4478,78 +4361,12 @@ p.hangouts-social {
     padding: 1rem;
 }
 
-.carousel-control {
-  height: 1.5rem;
-  width: 1.5rem;
-}
-
 .about-monero .info-block-row img.main-icon {
     width: 40%;
 }
 
 .about-monero .info-block-row .col-sm-4 {
     display: none;
-}
-
-}
-
-@media only screen and (max-width: 42rem) {
-
-.carousel { height: 22rem;}
-
-.carousel-control {
-  margin-top: 0;
-}
-
-}
-
-@media only screen and (max-width: 37rem) {
-
-.carousel { height: 18rem;}
-
-.carousel-control {
-  height: 1rem;
-  width: 1rem;
-}
-
-}
-
-@media only screen and (max-width: 34rem) {
-
-.carousel { height: 16rem; }
-
-.carousel-slide {
-    padding: 0 2.5rem;
-}
-
-}
-
-@media only screen and (max-width: 30rem) {
-.monero-vid .col-md-6 {
-    padding: 1rem 0;
-}
-
-}
-
-@media only screen and (max-width: 26rem) {
-
-.carousel {
-    height: auto;
-    position: static;
-}
-
-.carousel-activator:nth-of-type(1):checked ~ .carousel-controls:nth-of-type(1), .carousel-activator:nth-of-type(2):checked ~ .carousel-controls:nth-of-type(2), .carousel-activator:nth-of-type(3):checked ~ .carousel-controls:nth-of-type(3), .carousel-activator:nth-of-type(4):checked ~ .carousel-controls:nth-of-type(4) {
-  display: none;
-}
-
-.carousel-slide {
-    position: static;
-    opacity: 1;
-    padding: 0;
-}
-
-.carousel video {
-    margin-top: 0.5rem;
 }
 
 }

--- a/get-started/what-is-monero/index.md
+++ b/get-started/what-is-monero/index.md
@@ -56,62 +56,13 @@ permalink: /get-started/what-is-monero/index.html
             <section class="full col-xs-12 monero-vid">
                 <div class="info-block">
                     <div class="row center-xs">
-                        <div class="col"><h2>{% t what-is-monero.videos %}</h2></div>
-                    </div>
-                    <div class="row center-xs">
-                        <div class="col-xs-12 carousel-container">
-                            <ul class="carousel my-carousel">
-                                <input class="carousel-activator" type="radio" id="A" name="activator" checked="checked"/>
-                                <input class="carousel-activator" type="radio" id="B" name="activator"/>
-                                <input class="carousel-activator" type="radio" id="C" name="activator"/>
-                                <input class="carousel-activator" type="radio" id="D" name="activator"/>
-                                <div class="carousel-controls">
-                                    <label class="carousel-control carousel-control-backward" for="D"></label>
-                                    <label class="carousel-control carousel-control-forward" for="B"></label>
-                                </div>
-                                <div class="carousel-controls">
-                                    <label class="carousel-control carousel-control-backward" for="A"></label>
-                                    <label class="carousel-control carousel-control-forward" for="C"></label>
-                                </div>
-                                <div class="carousel-controls">
-                                    <label class="carousel-control carousel-control-backward" for="B"></label>
-                                    <label class="carousel-control carousel-control-forward" for="D"></label>
-                                </div>
-                                <div class="carousel-controls">
-                                    <label class="carousel-control carousel-control-backward" for="C"></label>
-                                    <label class="carousel-control carousel-control-forward" for="A"></label>
-                                </div>
-                                <li class="carousel-slide ms">
-                                    <h3>Monero Promo</h3>
-                                    <video controls poster="/img/monero-community.png" preload="metadata">
-                                        <source src="/media/Monero_Promo.m4v">
-                                    </video>
-                                </li>
-                                <li class="carousel-slide">
-                                    <h3>Monero: The Essentials</h3>
-                                    <video controls poster="/img/monero-cash-video-poster.png" preload="metadata">
-                                        <source src="/media/Monero%20-%20The%20Essentials.m4v">
-                                    </video>
-                                </li>
-                                <li class="carousel-slide">
-                                    <h3>Stealth Addresses</h3>
-                                    <video controls poster="/img/stealth-address-poster.png" preload="metadata">
-                                        <source src="/media/Monero%20-%20Stealth%20Addresses.m4v">
-                                    </video>
-                                </li>
-                                <li class="carousel-slide">
-                                    <h3>Ring Signatures</h3>
-                                    <video controls poster="/img/ring-signatures-poster.png" preload="metadata">
-                                        <source src="/media/Monero%20-%20Ring%20Signatures.m4v">
-                                    </video>
-                                </li>
-                                <li class="carousel-slide">
-                                    <h3>RingCT</h3>
-                                    <video controls poster="/img/ringct-poster.png" preload="metadata">
-                                        <source src="/media/Monero%20-%20RingCT.m4v">
-                                    </video>
-                                </li>
-                            </ul>
+                        <div class="col">
+                            <h2>Monero: The Essentials (English)</h2>
+                        </div>
+                        <div class="box-video">
+                            <video controls poster="/img/monero-cash-video-poster.png" preload="metadata" aria-label="Video Monero: The essentials">
+                                <source src="/media/Monero%20-%20The%20Essentials.m4v">
+                            </video>
                         </div>
                     </div>
                 </div>

--- a/resources/moneropedia/ringCT.md
+++ b/resources/moneropedia/ringCT.md
@@ -5,6 +5,10 @@ entry: moneropedia.entries.ringCT
 ---
 
 @moneropedia_article
-
 {% t global.lang_tag %}
+<div class="box-video">
+  <video controls poster="/img/ringct-poster.png" preload="metadata" aria-label="RingCT video">
+    <source src="/media/Monero%20-%20RingCT.m4v">
+  </video>
+</div>
 {% tf resources/moneropedia/ringCT.md %}

--- a/resources/moneropedia/ringsignatures.md
+++ b/resources/moneropedia/ringsignatures.md
@@ -7,4 +7,9 @@ entry: moneropedia.entries.ringsignatures
 @moneropedia_article
 
 {% t global.lang_tag %}
+<div class="box-video">
+  <video controls poster="/img/ring-signatures-poster.png" preload="metadata" aria-label="Introduction to Ring Signatures">
+    <source src="/media/Monero%20-%20Ring%20Signatures.m4v">
+  </video>
+</div>
 {% tf resources/moneropedia/ringsignatures.md %}

--- a/resources/moneropedia/stealthaddress.md
+++ b/resources/moneropedia/stealthaddress.md
@@ -7,4 +7,9 @@ entry: moneropedia.entries.stealthaddress
 @moneropedia_article
 
 {% t global.lang_tag %}
+<div class="box-video">
+  <video controls poster="/img/stealth-address-poster.png" preload="metadata" aria-label="Stealth addresses video">
+    <source src="/media/Monero%20-%20Stealth%20Addresses.m4v">
+  </video>
+</div>
 {% tf resources/moneropedia/stealthaddress.md %}


### PR DESCRIPTION
Closes #1187

- Remove carousel structure in the 'What is Monero' page and leave only one video: 'Monero: the essentials'
- Move technology specific videos to their moneropedia entry: Ring Signatures, RingCT, Stealth Addresses
- Add aria-label to imrpove accessibility of the videos

If we like this change, i suggest to also create a FAQ entry saying something like "Are there some videos about how Monero works?" and then link to the videos. They are meant to be watched one after another and this new system kinda break that. I'm proposing it because i don't think people actually notice and watch those videos at the moment. Adding a faq with the list of videos in the right order will fix that and will allow us to link to all the videos at the same time.

We have one video missing here: #1188. We can decide where to put it once we have it.