### PR TITLE
Add Nano S/X; capitalize Trezor Model T; remove wallet versions; add supported wallets

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -186,9 +186,9 @@ downloads:
   showhash4: "Two guides are available to guide you through the verification process:"
   hardware1: The Monero community has funded a
   hardware2: Dedicated Hardware Wallet (Kastelo)
-  hardware3: which is now in progress. Moreover, since CLI 0.12.1 and GUI 0.12.3 Ledger has
-  hardware4: integrated Monero into their hardware wallets.
-  hardware5: Trezor model T supports Monero since version 0.14.1.
+  hardware3: which is now in progress.
+  hardware4: Ledger Nano S and Nano X are supported in Monero CLI, Monero GUI, and Monerujo wallets.
+  hardware5: Trezor Model T is supported in Monero CLI and Monero GUI wallets.
   mobilelight1: The following are mobile or light wallets that are deemed safe by respected members of the community. If there is a wallet that is not on here, you can request the community check it out. Go to our
   mobilelight2: Hangouts
   mobilelight3:  page to see where we are.

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -292,12 +292,13 @@ permalink: /downloads/index.html
                   <h2 id="hardware">{% t downloads.hardware %}</h2>
                         <div class="row">
                             <div class="col-md-12 col-sm-12 col-xs-12">
-                                <p>{% t downloads.hardware1 %} <a href="https://forum.getmonero.org/9/work-in-progress/88149/dedicated-monero-hardware-wallet" target="_blank" rel="noreferrer, noopener">{% t downloads.hardware2 %}</a> {% t downloads.hardware3 %} <a href="https://github.com/LedgerHQ/blue-app-monero" target="_blank" rel="noreferrer, noopener">{% t downloads.hardware4 %}</a></p>
-                                <p>{% t downloads.hardware5 %}</p>
+                                <p>{% t downloads.hardware1 %} <a href="https://forum.getmonero.org/9/work-in-progress/88149/dedicated-monero-hardware-wallet" target="_blank" rel="noreferrer, noopener">{% t downloads.hardware2 %}</a> {% t downloads.hardware3 %}</p>
+                                <p><a href="https://support.ledger.com/hc/en-us/articles/360006352934-Monero-XMR-" target="_blank" rel="noreferrer, noopener">{% t downloads.hardware4 %}</a></p>
+                                <p><a href="https://wiki.trezor.io/Monero_(XMR)" target="_blank" rel="noreferrer, noopener">{% t downloads.hardware5 %}</a></p>
                             </div>
                         </div>
                         <div class="row mob-wallets center-xs">
-                            <a class="ext-noicon" href="https://www.ledger.com/monero-wallet/"><img src="/img/ledger.png" alt="ledger logo"></a>
+                            <a class="ext-noicon" href="https://support.ledger.com/hc/en-us/articles/360006352934-Monero-XMR-"><img src="/img/ledger.png" alt="ledger logo"></a>
                             <a class="ext-noicon" href="https://wiki.trezor.io/Monero_(XMR)"><img src="/img/trezor.png" alt="Trezor logo"></a>
                         </div>
                         <div class="row mob-wallets center-xs">


### PR DESCRIPTION
Changes:
- Add Nano S and Nano X models
- Capitalize Trezor **M**odel T
- Remove "supported since" wallet versions: it's useless information for most users (old versions don't work anyway because of hard forks)
- Add wallets that support each hardware wallet type
- Add/update links to support pages in Ledger and Trezor websites