### PR TITLE
moneropedia.rb: If an entry is not present in LANG.yml, use English one

### DIFF
--- a/_plugins/moneropedia.rb
+++ b/_plugins/moneropedia.rb
@@ -65,6 +65,9 @@ module Jekyll
               if !entry.empty?
                 baseName = File.basename(entry_file, ".*")
                 displayName = @@localConfig[lang]["moneropedia"]["entries"][baseName]
+                if displayName == nil
+                  displayName = @@localConfig["en"]["moneropedia"]["entries"][baseName]
+                end
                 @@moneropedia[lang].push({ :terms => entry['terms'], :summary => entry['summary'], :file => baseName })
                 @@moneropedia_ordered[lang] = @@moneropedia_ordered[lang].merge({ displayName => baseName })
               end


### PR DESCRIPTION
If an entry is not found in the given language (LANG.yml), we use the English version. This will allow us to only add a new Moneropedia entry title to `en.yml` and not to all language files, reducing the amount of files to edit when adding a new Moneropedia entry from 28 to 15. This is also helpful for Weblate, since the language files should be edited only there or we risk conflicts.