### PR TITLE
User Guides: Mark guide 'CLI Wallet/Daemon Isolation with Qubes + Whonix' as outdated

### DIFF
--- a/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -2,7 +2,7 @@
 layout: user-guide
 title: CLI Wallet/Daemon Isolation with Qubes + Whonix
 permalink: /resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html
-outdated: False
+outdated: True
 ---
 
 {% t global.lang_tag %}


### PR DESCRIPTION
I've seen some reports by users not being able to set up a working daemon after using this guide, so it's probably outdated. If somebody using this system could confirm the issue and/or update the guide, would be very appreciated.