### PR TITLE
Upgrade banner: Link to Downloads page and make text more generic

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -19,7 +19,7 @@ global:
   upgradoct: Make sure your software is up-to-date with the
   upgradeoctlink: "October 17th network upgrade."
   upgrdecont: To continue using Monero after that date,
-  dwlsoftware: Download Monero 0.17 "Oxygen Orion".
+  dwlsoftware: Download Monero "Oxygen Orion" (0.17).
   lang_tag: "@lang_tag_en"
 
 titles:

--- a/_includes/upgrade.html
+++ b/_includes/upgrade.html
@@ -1,6 +1,6 @@
 <div class="upgrade-container">
    <input id="upgrade-toggle" type="checkbox">
    <div class="upgrade-content">
-        <p>{% t global.upgradoct %} <a href="{{ site.baseurl}}/2020/08/18/network-upgrade-october-2020.html">{% t global.upgradeoctlink %}</a> {% t global.upgrdecont %} <a href="{{ site.baseurl}}/2020/09/17/monero-0.17-released.html">{% t global.dwlsoftware %}</a> <label class="upgrade-x" for="upgrade-toggle"></label></p>
+        <p>{% t global.upgradoct %} <a href="{{ site.baseurl}}/2020/08/18/network-upgrade-october-2020.html">{% t global.upgradeoctlink %}</a> {% t global.upgrdecont %} <a href="{{ site.baseurl}}/downloads/">{% t global.dwlsoftware %}</a> <label class="upgrade-x" for="upgrade-toggle"></label></p>
     </div>
 </div>


### PR DESCRIPTION
The banner specifically mention the 0.17.0.0 release, but we will have at least one point release before the hard fork and there could be more. Better be more generic and link to the Downloads page instead of the blog post announcing 0.17.0.0.

Would be good to merge this along with #1214 