### PR TITLE
Navigation: add language img for language selector (desktop)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -71,7 +71,7 @@
                           <a href="https://translate.getmonero.org" class="top-link">Translate</a>
                           <div href="#" class="dropdown top-link language-change">
                             <input class="burger-checkdropdown" id="langdrop" type="checkbox" tabindex="0">
-                            <label for="langdrop">{{ site.data.languages.langs.[site.lang] }}
+                            <label for="langdrop"><img src="/img/language.png" alt="Language selector icon" class="icon-language"/>{{ site.data.languages.langs.[site.lang] }}
                            <div class="arrow-down"></div></label>
                             <div class="dropdown-content text-center">
                               {% for lang in site.languages %}

--- a/css/custom.css
+++ b/css/custom.css
@@ -1849,6 +1849,12 @@ img.monero-logo {
     padding: 0.8rem 0.8rem 0.8rem 3.4rem;
 }
 
+img.icon-language {
+  width: 1rem;
+  padding-right: 0.2rem;
+  vertical-align: middle;
+}
+
 .topnav .topnav-list a, .topnav .topnav-list label {
     color: #6B6B6B;
     text-decoration: none;


### PR DESCRIPTION
Makes the language selector more visible. We already use the image for the mobile version, so we don't even make a new request.

Preview:
![img](https://user-images.githubusercontent.com/28106476/94831955-a1c41400-040d-11eb-8935-c0de35dbeed2.png)
