### PR TITLE
German translation of Moneropedia entries A - B

### DIFF
--- a/_i18n/de/resources/moneropedia/account.md
+++ b/_i18n/de/resources/moneropedia/account.md
@@ -1,34 +1,34 @@
 ---
-terms: ["account", "accounts", "wallet", "wallets", "Account", "Accounts"]
-summary: "similar in function to a bank account, contains all of your sent and received transactions"
+terms: ["account", "accounts", "wallet", "wallets", "Konto", "Konten", "Kontos", "Wallet", "Wallets"]
+summary: "Funktionsähnlich zu einem Bankkonto, enthält all deine gesendeten und empfangenen Transaktionen"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-Those familiar with Monero's predecessors will be more familiar with the term *wallet* to describe this. In Monero we call this an account, and it is a private account owned and operated by a Monero user.
+Für jene, die mit Moneros Vorgängern vertraut sind, wird zur Beschreibung der Begriff *Wallet* geläufiger sein. Bei Monero nennen wir dies ein Konto, welches ein privates, von einem Monero-Nutzer geführtes und in dessen Besitz befindliches Konto ist.
 
-Your account contains all of the Monero @transactions you have sent and received. Your account balance is a sum of all the Monero you've received, less the Monero you've sent. When using Monero you may notice that your account has two balances, a locked and an unlocked balance. The unlocked balance contains funds that can be spent immediately, and the locked balance contains funds that you can't spend right now. You may receive a transaction that has an @unlock-time set, or you may have sent some Monero and are waiting for the @change to come back to your wallet, both situations that could lead to those funds being locked for a time.
+Dein Konto enthält die @Transaktionen aller Monero, welche du gesendet und empfangen hast. Dein Kontoguthaben ist die Summe aller Monero, die du empfangen hast, abzüglich derer, die du gesendet hast. Bei der Nutzung von Monero kannst du feststellen, dass dein Konto zwei Guthaben hat: ein gesperrtes und ein offenes. Das offene Guthaben enthält Geldmittel, die unmittelbar ausgegeben werden können, das gesperrte Guthaben enthält jene, die nicht direkt ausgabebereit sind. Letzteres könnte beispielsweise daran liegen, dass eine von dir empfangene Transaktion eine gesetzte @Freigabedauer hat, oder dass du noch auf @Wechselgeld der von dir gesendeten Monero wartest - beide Situationen könnten dazu führen, dass dieses Guthaben für eine Weile gesperrt ist.
 
-A key difference between traditional electronic currency and Monero is that your account resides only under your control, normally on your computer, and cannot be accessed by anyone else if you [practice good security](#practicing-good-security).
+Ein entscheidender Unterschied zwischen traditioneller elektronischer Währung und Monero ist, dass dein Konto, das im Normalfall auf deinem Computer liegt, einzig und allein unter deiner Kontrolle ist und nicht von anderen abgerufen werden kann, sofern du gut auf deine [Sicherheit](#Auf-Sicherheit-achten) achtest.
 
-### Multiple Accounts
+### Multiple Konten
 
-There are no costs attached to creating a Monero account, and there are no fees charged except for individual @transaction fees that go to @miners.
+Mit dem Erstellen von Monero-Konten sind keine Kosten verbunden und es werden keinerlei Gebühren erhoben (ausgenommen davon sind einzelne Gebühren für @Transaktionen, welche an @Miner gehen).
 
-This means that individuals can easily create a Monero account for themselves as well as a joint account to share with their partner, and individual accounts for their children. Similarly, a business could create separate accounts for each division or group. Since Monero's @transaction fees are quite low, moving funds between accounts is not an expensive exercise.
+Dies bedeutet, dass Einzelpersonen ohne Umstände ein privates Monero-Konto für sich selbst, wie auch ein Gemeinschaftskonto mit dem Partner, und zusätzlich individuelle Konten für ihre Kinder erstellen können. Auf die gleiche Weise könnte ein Unternehmen für jede Abteilung oder jeden Bereich separate Konten einrichten. Da Moneros Gebühren für @Transaktionen ziemlich niedrig sind, ist es nicht sonderlich kostenintensiv, Gelder zwischen Konten hin- und herzubewegen.
 
-### Cryptographic Keys
+### Kryptografische Schlüssel
 
-Monero relies heavily on a cryptography principle known as *public/private key cryptography* or *asymmetric cryptography*, which is thoroughly detailed in [this Wikipedia article](https://en.wikipedia.org/wiki/Public-key_cryptography).
+Monero vertraut stark auf ein kryptografisches Prinzip, welches als *Public/Private-Key-Verschlüsselungssystem* oder *asymmetrisches Kryptosystem* bekannt ist. Dies wird ausführlich in [diesem Wikipedia-Artikel](https://de.wikipedia.org/wiki/Asymmetrisches_Kryptosystem) erläutert.
 
-Your account is based on two keys, a @spend-key and a @view-key. The @spend-key is special in that it is the single key required to spend your Monero funds, whereas the @view-key allows you to reveal your @transactions to a third party, for example for auditing or accounting purposes. These keys in your account also play an important role in Monero's @transaction's privacy.
+Dein Konto basiert auf zwei Schlüsseln: einem @Spend-Key und einem @View-Key. Das Besondere am @Spend-Key ist, dass es der einzige Schlüssel ist, welcher zum Ausgeben deines Monero-Guthabens benötigt wird. Der @View-Key hingegen erlaubt es dir, deine @Transaktionen Dritten offenzulegen, beispielsweise zur Rechnungsprüfung oder zu Buchhaltungszwecken. Diese Schlüssel spielen zudem eine wichtige Rolle bezüglich der Privatsphäre von Moneros @Transaktionen.
 
-The private keys for both of these must be protected by you in order to retain your account privacy. On the other hand, the public keys are obviously public (they are part of your Monero account address). For normal public/private key cryptography someone could send you a private message by encrypting it with either of your public keys, and you would then be the only one able to decrypt it with your private keys.
+Diese privaten Schlüssel müssen durch dich geschützt werden, um die Privatsphäre deines Kontos zu erhalten. Die öffentlichen Schlüssel hingegen sind - offensichtlich - öffentlich (sie sind Teil deiner Monero-Kontoadresse). Mit regulären Public-/Private-Key-Verschlüsselungssystemen könnte dir jemand eine mit einem deiner öffentlichen Schlüssel verschlüsselte Nachricht schicken und nur du wärst in der Lage, diese mit deinen privaten Schlüsseln zu entschlüsseln.
 
-### Backing Up Your Account
+### Dein Konto sichern
 
-When you manage your own Monero Account with the private @spend-key, you are solely responsible for the security of your funds. Thankfully, Monero makes it very easy to backup your account. When creating a Monero account for the first time you will be given a unique @mnemonic-seed for your account that consists of 13 or 25 words in the language of your choosing. **This seed is the only thing you need to backup for your account**, and so it is imperative that it is written down and stored securely.  Never store this seed in a form or location that would allow someone else to see it!
+Wenn du dein eigenes Monero-Konto mit dem privaten @Spend-Key verwaltest, bist allein du für die Sicherheit deiner Gelder verantwortlich. Glücklicherweise gestaltet es Monero sehr einfach, dein Konto zu sichern. Wenn du zum ersten Mal ein Monero-Konto erstellst, wird dir ein einzigartiger @mnemonischer-Seed mitgeteilt, welcher aus 13 oder 25 Wörtern in der von dir gewählten Sprache besteht. **Dieser Seed ist das Einzige, das du für dein Konto sichern musst**, es ist also unbedingt erforderlich, dass er niedergeschrieben und sicher verstaut wird. Speichere oder lagere ihn niemals in einer Ausführung oder an einem Ort, welche(r) es jemand anderem erlauben könnte, ihn einzusehen!
 
 ```
 List of available languages for your wallet's seed:
@@ -68,14 +68,14 @@ Background refresh thread started
 
 ```
 
-As the example above indicates, it is incredibly important to store these words in safe locations. If you are concerned about the risk of critical loss at your home, for instance, you may want to store a second copy of your seed with your attorney or in a safety deposit box. It is also recommended that it is stored in a way that does not make it obvious that it is your seed, so writing it into a letter or as part of other notes is advisable.
+Wie das obige Beispiel zeigt, ist es unglaublich wichtig, diese Wörter an sicheren Orten aufzubewahren. Solltest du etwa über deren Verlust bei dir Zuhause besorgt sein, könntest du eine Kopie deines Seeds bei einem Bevollmächtigten oder in einem Tresor- oder Bankschließfach lagern. Es wird außerdem empfohlen, ihn so aufzubewahren, dass es nicht direkt ersichtlich ist, dass es sich um deinen Seed handelt; das Einbinden der Wörter in einen Brief oder Notizen ist empfehlenswert.
 
-### Practicing Good Security
+### Auf Sicherheit achten
 
-Over and above backing up your @mnemonic-seed so that you have access to your account in the event of critical data loss, it is also important to practice good security. Use a secure password when creating a local Monero account (not used on [MyMonero](https://mymonero.com) or other web-based account systems).
+Über das Sichern deines @mnemonischen-Seeds (wodurch dein Zugriff auf dein Konto im Falle eines totalen Datenverlusts gewährleistet ist) hinaus ist es ebenso wichtig, auf Sicherheit zu achten. Nutze ein sicheres Passwort, wenn du ein lokales Monero-Konto erstellst (eines, das du nicht auf [MyMonero](https://mymonero.com) oder anderen webbasierten Kontosystemen verwendest). 
 
-Don't ever give your Monero account password to anyone, as this can be used to access the Monero on your computer without knowing your @mnemonic-seed. Similarly, make sure you have running and up-to-date antivirus, especially on Windows computers. Finally, be careful when clicking links in emails or on unknown and untrusted websites, as malware installed on your computer can sit and wait for you to access your Monero account before taking the funds from it.
+Gib niemals das Passwort deines Monero-Kontos an jemanden weiter: Dies kann dazu verwendet werden, auf die Monero auf deinem Computer zuzugreifen, ohne deinen @mnemonischen-Seed kennen zu müssen. Stelle gleichermaßen sicher, dass du ein aktives und aktualisiertes Antivirenprogramm hast, insbesondere auf Windows-Computern. Sei schlussendlich vorsichtig, wenn du auf Links in E-Mails oder auf unbekannten und nicht vertraulichen Webseiten klickst; auf deinem Computer installierte Malware kann auf dem Rechner verweilen und auf deinen Zugriff auf dein Monero-Konto warten, bevor es Gelder davon entwendet.
 
-### Leaving Your Account to Next of Kin
+### Dein Konto einem nächsten Angehörigen überlassen
 
-Providing access to your Monero account to your next of kin is just as easy as it is to backup your Monero account. Simply leave your @mnemonic-seed to them in your will, or store it somewhere safe where it will be given to them upon the execution of your will. A key advantage to this is that your next of kin won't have to wait for months for a third party to release the funds to them.
+Nächsten Angehörigen den Zugriff auf dein Monero-Konto zu ermöglichen ist genauso leicht, wie ebendieses zu sichern. Überlasse ihnen in deinem Testament einfach deinen @mnemonischen-Seed oder lagere diesen an einem sicheren Ort, von welchem aus er bei der Vollziehung deines Testaments übergeben wird. Ein entscheidender Vorteil hierbei ist, dass deine Angehörigen nicht monatelang darauf warten müssen, dass ihnen Dritte Gelder ausgeben.

--- a/_i18n/de/resources/moneropedia/address.md
+++ b/_i18n/de/resources/moneropedia/address.md
@@ -1,21 +1,21 @@
 ---
 terms: ["address", "addresses", "Adresse" , "Adressen"]
-summary: "either an alias, such as donate.getmonero.org, or a set of 95 characters starting with a 4"
+summary: "Entweder ein Alias wie donate.getmonero.org, oder eine Reihe von 95 Schriftzeichen, beginnend mit einer 4"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
+Wenn du Monero an jemanden versenden möchtest, benötigst du nur eine einzige Information, und das ist die Monero-Adresse des jeweiligen Empfängers. Eine Monero-Adresse ist eine Reihe von 95 Schriftzeichen, beginnend mit einer "4". Die Spendenadresse von Monero ist beispielsweise <span class="long-term">888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H</span>.
 
-Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to <span class="long-term">donate@getmonero.org</span> or <span class="long-term">donate.getmonero.org</span>.
+Da diese Adressen lang und komplex sind, wird dir stattdessen häufig eine @OpenAlias-Adresse begegnen. So können Spenden an Monero zum Beispiel an <span class="long-term">donate@getmonero.org</span> oder <span class="long-term">donate.getmonero.org</span> gesendet werden.
 
-If you would like to get an @OpenAlias address of your own then there is some information on the [OpenAlias page](/de/the-monero-project/).
+Solltest du eine eigene @OpenAlias-Adresse haben wollen, findest du einige Informationen auf der [OpenAlias-Seite](https://openalias.org/).
 
-### Integrated address
+### Integrierte Adresse
 
-An integrated address is an address combined with an encrypted 64-bit @payment-ID. A raw integrated address is 106 characters long.
+Eine integrierte Adresse ist eine Adresse, die mit einer verschlüsselten 64-Bit-@Zahlungs-ID kombiniert ist. Eine integrierte Adresse hat eine Länge von 106 Zeichen.
 
-### In-depth Information
+### Detaillierte Informationen
 
-The address is actually the concatenation, in Base58 format, of the *public* @spend-key and the *public* @view-key, prefixed with the network byte (the number 18 for Monero) and suffixed with the first four bytes of the Keccac-256 hash of the whole string (used as a checksum).
+Die Adresse ist genau genommen eine Verkettung (im Base58-Format) des *öffentlichen* @Spend-Keys und des *öffentlichen* @View-Keys, mit vorangestelltem Netzwerk-Byte (für Monero die Zahl 18) und den angehängten ersten vier Bytes des Keccac-256-Hashs des gesamten Strings (genutzt als Prüfsumme).

--- a/_i18n/de/resources/moneropedia/airgap.md
+++ b/_i18n/de/resources/moneropedia/airgap.md
@@ -1,11 +1,9 @@
 ---
-terms: ["airgap"]
-summary: "An airgap is a security measure to physically separate a computer or device from all other networks, such as the Internet."
+terms: ["airgap", "Airgap"]
+summary: "Ein Airgap ist eine Sicherheitsmaßnahme, mit welcher ein Computer oder Gerät physisch von allen anderen Netzwerken (wie etwa dem Internet) getrennt wird"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-"An air gap, air wall or air gapping is a network security measure employed on one or more computers to ensure that a secure computer network is physically isolated from unsecured networks, such as the public Internet or an unsecured local area network.[2] The name arises from the technique of creating a network that is physically separated (with a conceptual air gap) from all other networks. The air gap may not be completely literal, as networks employing the use of dedicated cryptographic devices that can tunnel packets over untrusted networks while avoiding packet rate or size variation can be considered air gapped, as there is no ability for computers on opposite sides of the gap to communicate."
-
-Taken from https://en.wikipedia.org/wiki/Air_gap_(networking)
+Ein Airgap (engl.: Luftspalt) oder eine Airwall (engl.: Luftmauer) ist eine auf einem oder mehreren Computern eingerichtete Sicherheitsmaßnahme, welche sicherstellt, dass ein sicheres, vertrauenswürdiges Computernetzwerk von unsicheren Netzwerken, so etwa das öffentliche Internet oder ein unsicheres lokales Netzwerk, physisch isoliert ist. Der Name kommt von der Methode des Erstellens eines Netzwerks, das (durch einen gedanklichen Luftspalt) physisch von allen anderen Netzwerken separiert ist. Der Airgap mag kein wortwörtlicher Luftspalt sein; so können Netzwerke, die spezielle kryptografische Geräte zur Umschiffung der Daten um nicht vertrauliche Netzwerke herum verwenden, dennoch als "air gapped" betrachtet werden, da es keine Möglichkeit für außerhalb des Gaps befindliche Computer gibt, mit jenen Netzwerken zu kommunizieren. Der quasi einzige Weg, Daten zwischen dem isolierten System und der Außenwelt auszutauschen, besteht darin, ebenjene über einen Wechseldatenträger vom einen auf das andere System zu transferieren.

--- a/_i18n/de/resources/moneropedia/atomic-units.md
+++ b/_i18n/de/resources/moneropedia/atomic-units.md
@@ -1,11 +1,11 @@
 ---
-terms: ["atomic-units", "atomic-unit"]
-summary: "Atomic Units refer to the smallest fraction of 1 XMR."
+terms: ["atomic-units", "atomic-unit", "Kleinste-Einheit"]
+summary: "Kleinste Einheiten beziehen sich auf den kleinsten Bruchteil eines XMRs"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-Atomic Units refer to the smallest fraction of 1 XMR.
-One atomic unit is currently 1e-12 XMR (0.000000000001 XMR, or one @piconero).
-It may be changed in the future.
+Kleinste Einheiten beziehen sich auf den kleinsten Bruchteil eines XMRs.
+Eine kleinste Einheit ist derzeit 1e-12 XMR (0.000000000001 XMR, oder ein @Piconero).
+In Zukunft könnte dies geändert werden.

--- a/_i18n/de/resources/moneropedia/block.md
+++ b/_i18n/de/resources/moneropedia/block.md
@@ -1,15 +1,15 @@
 ---
-terms: ["block", "blocks"]
-summary: "a container of transactions, a sequence of which forms a blockchain"
+terms: ["block", "blocks", "Block", "Blöcke"]
+summary: "Eine Zusammenfassung von Transaktionen; eine Reihung dieser formt eine Blockchain"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-A block is a container of @transactions, with a new block being added to the @blockchain once every 2 minutes (see constant `DIFFICULTY_TARGET_V2` defined as 120 seconds), on average.
+Ein Block enthält @Transaktionen (ein Block ist sozusagen eine Zusammenfassung ebendieser). Durchschnittlich wird alle zwei Minuten ein neuer Block zur @Blockchain hinzugefügt (siehe das konstant als 120 Sekunden definierte `DIFFICULTY_TARGET_V2`).
 
-Blocks also contain a special type of transaction, the @coinbase-transaction, which add newly created Monero to the network.
+Blöcke enthalten zudem eine besondere Art von Transaktion: die @Coinbase-Transaktion, welche neu erschaffene Monero zum Netzwerk hinzufügt.
 
-Blocks are created through the process of @mining, and the @node that successfully mines the block then broadcasts it to each of the @nodes connected to it, who subsequently re-broadcast the block until the entire Monero network has received it.
+Blöcke werden durch den Prozess des @Minings erschaffen. Der @Node, der einen Block erfolgreich geminet ("geschürft") hat, sendet diesen dann zu allen verbundenen @Nodes, welche den Block wiederum weitersenden, bis ihn das ganze Monero-Netzwerk empfangen hat.
 
-Fake or bad blocks generally cannot be created, as @nodes that receive blocks always verify the @transactions they contain against a set of consensus rules that all nodes adhere to, including validating the cryptographic @signatures on each transaction.
+Falsche oder fehlerhafte, schlechte Blöcke können grundsätzlich nicht erstellt werden. @Nodes, welche Blöcke empfangen, verifizieren die in diesen enthaltenen @Transaktionen durch eine Reihe allgemeingültiger Regeln, die von allen Nodes eingehalten werden. Dazu gehört auch die Validierung der kryptografischen @Signaturen jeder einzelnen Transaktion.

--- a/_i18n/de/resources/moneropedia/blockchain.md
+++ b/_i18n/de/resources/moneropedia/blockchain.md
@@ -1,12 +1,13 @@
 ---
-terms: ["blockchain", "blockchains"]
-summary: "a distributed ledger of all transactions both past and present, without revealing who the funds came from or went to"
-
+terms: ["blockchain", "blockchains", "Blockchain", "Blockchains"]
+summary: "Ein verteiltes Kassenbuch aller vergangenen und gegenwärtigen Transaktionen, ohne Sender oder Empfänger der Gelder aufzudecken"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
-A @blockchain is a distributed database that continuously grows with a record of all of the transactions that have occurred with a given cryptocurrency.  This database is often referred to as a ledger because the data contains a large list of transactions that have taken place.  In Monero, these transactions are packaged together into 'blocks' every 2 minutes (on average), and all miners and nodes on the network have copies of these blocks.  
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-### Monero's @Blockchain
-Unlike Bitcoin and other cryptocurrencies, transactions in the Monero @blockchain do not reveal where funds came from or went to, providing anonymity and making the currency completely @fungible. Additionally, the amounts of all transactions are hidden by @RingCT, a feature of Monero. For auditing or other transparency purposes a user can share a @view-key to prove they control certain amounts of Moneroj.
+Eine Blockchain ist eine verteilte Datenbank, welche durch die Aufzeichnung aller Transaktionen einer bestimmten Kryptowährung kontinuierlich wächst. Diese Datenbank wird häufig als Kassenbuch (engl.: Ledger) bezeichnet, da das Datenmaterial eine lange Liste bereits geschehener Transaktionen enthält. Bei Monero werden diese Transaktionen im Durchschnitt alle zwei Minuten zu sogenannten "Blöcken" zusammengepackt, von welchen alle Miner und Nodes auf dem Netzwerk Kopien besitzen.
+
+### Moneros Blockchain
+
+Im Gegensatz zu Bitcoin und anderen Kryptowährungen offenbaren Transaktionen innerhalb der Monero-Blockchain nicht, woher Gelder kommen oder wohin diese gehen. Dies bietet Anonymität und macht die Währung zudem gänzlich @fungibel. Zusätzlich werden die Beträge aller Transaktionen durch @Ring-CTs, einer Besonderheit von Monero, verdeckt. Für eine etwaige Betriebsprüfung oder zu anderen Zwecken der Nachvollziehbarkeit/Transparenz kann ein Nutzer durch das Teilen eines @View-Keys belegen, dass er einen bestimmten Betrag von Monero bewirtschaftet.

--- a/_i18n/de/resources/moneropedia/bootstrap-node.md
+++ b/_i18n/de/resources/moneropedia/bootstrap-node.md
@@ -1,13 +1,13 @@
 ---
-terms: ["bootstrap-node", "bootstrap-nodes"]
-summary: "A node to which a daemon connects to give immediate usability to wallets while syncing"
+terms: ["bootstrap-node", "bootstrap-nodes", "Bootstrap-Node", "Bootstrap-Nodes"]
+summary: "Ein Node, zu dem ein Hintergrunddienst verbindet, um schon während des Synchronisierens eine sofortige Verwendbarkeit von Wallets zu ermöglichen"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-The daemon running on a local @node has to sync with other (remote) @nodes. While it is not fully synced, @wallet may still be connected to the local node. Therefore, the @wallet cannot access the @blocks that are bot yet synced on the local @node.
+Ein auf einem lokalen @Node laufender Hintergrunddienst muss mit anderen (Remote-)@Nodes synchronisieren. Während er noch nicht gänzlich synchronisiert ist, könnte das @Wallet noch mit dem lokalen Node verbunden sein, was zur Folge hat, dass es keinen Zugriff auf die noch nicht synchronisierten @Blöcke hat.
 
-To allow the @wallet to be immediately usable, the daemon on the local @node uses a bootstrap node to which the RPC request are proxying to, giving access to the missing @blocks.
+Um das @Wallet unmittelbar nutzbar zu machen, nutzt der (auf einem lokalen @Node laufende) Hintergrunddienst einen Bootstrap-Node, an welchen RPC-Anfragen umgeleitet werden. Dadurch wird der Zugriff auf die noch fehlenden @Blöcke ermöglicht.
 
-Note: the replies from the bootstrap node may be untrustworthy.
+Anmerkung: Die Antworten des Bootstrap-Nodes könnten nicht vertrauenswürdig sein.

--- a/_i18n/de/resources/moneropedia/bulletproofs.md
+++ b/_i18n/de/resources/moneropedia/bulletproofs.md
@@ -1,31 +1,31 @@
 ---
-terms: ["bulletproofs", "bulletproof"]
-summary: "a new kind of range proofs replacing RingCT in transactions to obfuscate the amounts sent"
+terms: ["bulletproofs", "bulletproof", "Bulletproof", "Bulletproofs"]
+summary: "Eine neue Art von 'Range-Proofs', welche Ring-CT in Transaktionen ersetzen, um die gesendeten Beträge zu verschleiern"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
-@RingCT was introduced to obfuscate transaction amounts. One goal of @RingCT was to prove the sum of inputs - outputs in the @transaction was equal to 0, and all outputs were positive numbers.  
-To accomplish this, two kind of ring signatures were constructed: One ring signature for the whole transaction (to prove the sum is 0), and a set of ring signatures for the subsets of transaction bits (to prove the outputs are positive numbers), then combined together using originally Schnorr signatures (and later replaced by Borromean ring signature).  
-While it was doing the job, a big drawback was the huge size of such a ringCT transaction.
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
+@Ring-CT wurde und wird eingesetzt, um Transaktionsbeträge zu verschleiern. Ein Ziel von @Ring-CT ist es, nachzuweisen, dass der Endbetrag von Inputs zu Outputs gleich null ist, und alle Outputs positive Zahlen sind.
+Um dies zu erreichen, werden zwei Arten von Ringsignaturen konstruiert: eine Ringsignatur für die gesamte Transaktion (um nachzuweisen, dass die Endsumme null ergibt) und eine Reihe von Ringsignaturen für die Teilmengen von Transaktionsstücken (um nachzuweisen, dass die Outputs positive Zahlen sind). Diese werden anschließend kombiniert (zu Beginn passierte das durch Schnorr-Signaturen, welche später von Borromäischen Ringsignaturen abgelöst wurden). Während dies grundsätzlich funktioniert, gibt es einen großen Haken an der Sache: die immense Größe einer solchen Ring-CT-Transaktion.
 
-### Where it comes to bulletproofs
-Back in 2017, a [Standford applied crypto group](https://crypto.stanford.edu/bulletproofs/) wrote a [paper](https://eprint.iacr.org/2017/1066.pdf) presenting a new kind of range proofs, called bulletproofs.  
+### Wo Bulletproofs ins Spiel kommen
+Im Jahr 2017 veröffentlichte die [Applied Crypto Group der Stanford University](https://crypto.stanford.edu/bulletproofs/) ein [Paper](https://eprint.iacr.org/2017/1066.pdf), in welchem sie eine neue Art von "Range-Proofs" vorstellte: sogenannte Bulletproofs. 
+
 
 > Bulletproofs are short non-interactive zero-knowledge proofs that require no trusted setup.
 
-Bulletproofs, unlike Borromean or Schnorr signatures, are very efficient as range proofs. Proving a big set of data only generates a small proof, and the size of this proofs grows logarithmically with the size of the data being proved.  
-It means that increasing the number of outputs in a transaction will, with bulletproofs only slightly increase the size of the proof.  
-Bulletproofs also have the advantage to allow to prove that multiple committed amounts are in the desired range at once. No need to prove each output to each destination in separate proofs; the whole transaction amounts could be proven in one bigger (but still very small) bulletproof.
+Bulletproofs sind, im Gegensatz zu Borromäischen oder Schnorr-Signaturen, eine sehr effiziente Art von "Range-Proofs". Die Bereitstellung eines großen Datensatzes generiert lediglich einen kleinen Proof (Nachweis), und die Größe dessen wächst logarithmisch mit der Größe der überprüften/nachgewiesenen Daten.
+Die Nutzung von Bulletproofs bedeutet also, dass eine zunehmende Anzahl von Outputs die Größe des Proofs selbst nur leicht erhöht.
+Bulletproofs haben außerdem den Vorteil, dass sie es erlauben, nachzuweisen, dass sich mehrere überwiesene Beträge gleichzeitig im gewünschten Bereich befinden. Es gibt keinen Grund dazu, jeden einzelnen Output zu jedem Ziel in separaten Proofs zu überprüfen - die kompletten Transaktionsbeträge können in einem umfassenderen (und dennoch sehr kleinen) Bulletproof überprüft/nachgewiesen werden.
 
-### Thorough audit process and implementation
-As bulletproofs were really new, and the initial implementation made by the group, while thoroughly done, needed a rewrite focused on our specific use-case, implementing bulletproof in Monero was not a simple thing.  
-The code has been written and rewritten to follow the new version of bulletproofs which was still being developed, but once this Monero implementation was finalized, the resulting deployment should be taken with extreme care.  
-Therefore, the community started an auditing process. Researchers reached out to Benedikt Bünz, lead author of the Bulletproofs paper, and to [OSTIF](https://ostif.org/) an organization which helps open source technologies to improve and secure themselves.  
-OSTIF directed the group to several organizations with the skills required to perform the audit. While one of them asked to be kept unnamed and was therefore put away from the process that needed to be public, two others (QuarksLab & Kudelski Security) were choosen to conduct the audit.  
-Our 3 auditors were funded by the community to check out the if the implementation did not did not contain critical bugs, and if it did not have any exploits.  
-The final reports were released during the summer of 2018, with several useful corrections and fixes suggested, and the final bulletproof implementation has been added first to Monero Stagenet, and then to the main Monero network during the October 2018 network upgrade.
+### Ein umfassender Prüfungsablauf und Implementierung
 
-Since the bulletproofs deployment, the size of an average transaction has dropped by at least 80%, as well as the transaction fees.
+Bulletproofs waren ziemlich neu, und obwohl die ursprüngliche Implementierung durch die Gruppe sehr ausführlich und umfassend war, benötigte es eine Neufassung, die sich auf unseren speziellen Anwendungsfall bezog. Dies machte es nicht gerade einfach, Bulletproofs innerhalb Moneros zu implementieren.
+Der Code wurde mehrfach umgeschrieben, um der (noch immer in Entwicklung befindlichen) neuen Version der Bulletproofs zu entsprechen. Nachdem die finale Umsetzung zum Abschluss gebracht wurde, durfte sie nur unter hoher Sorgfalt zum Einsatz kommen.
+Aus diesem Grund initiierte die Community einen Prüfungssprozess: Forscher traten in Kontakt mit Benedikt Bünz, dem leitenden Autor des Bulletproofs-Papers, und darüber hinaus mit [OSTIF](https://ostif.org/), einer Organisation, die Open-Source-Technologien dabei hilft, sich zu verbessern und abzusichern. OSTIF verwies die Gruppe an etliche Organisationen, welche über die für die Überprüfung benötigten Kompetenzen verfügten. Während eine davon darum bat, nicht namentlich erwähnt zu werden und damit vom öffentlich stattfindenden Prozess ausgeschlossen werden musste, wurden zwei andere (QuarksLab und Kudelski Security) ausgewählt, um die Prüfung durchzuführen.
+Unsere (schlussendlich drei) Prüfer wurden durch die Community finanziert und sollten testen, ob die Implementation der Bulletproofs kritische Bugs oder andere Probleme (wie Malware) enthielt.
+Die abschließenden Berichte wurden im Sommer 2018 veröffentlicht und enthielten einige nützliche Anregungen zu Fehlerbehebungen und anderen Nachbesserungen. Die finale Bulletproof-Implementation ist zunächst zum Monero-Stagenet und während des Netzwerkupgrades im Oktober 2018 schließlich auch zum Hauptnetzwerk hinzugefügt worden.
 
-More explanations on Monero's implementation of bulletproofs could be found on youtube fondajo channel in a [conversation with Sarang Noether](https://www.youtube.com/watch?v=6lEWqIMLzUU).
+Seit der Bereitstellung von Bulletproofs ist die Größe einer durchschnittlichen Transaktion um mindestens 80 Prozent gesunken; das Gleiche gilt für die Transaktionsgebühren.
+
+Weitere Erläuterungen zu Moneros Implementierung von Bulletproofs finden sich auf dem Youtube-Kanal der Monero Community Workgroup in einem [Gespräch mit Sarang Noether](https://www.youtube.com/watch?v=6lEWqIMLzUU).


### PR DESCRIPTION
The following entries were translated:
- Account
- Address
- Airgap
- Atomic Units
- Block
- Blockchain
- Bootstrap Node
- Bulletproofs

Note: The links to other Moneropedia entries (marked with an @) may not work in the preview since the terminology has to be updated with the German terms.