### PR TITLE
User guides: fix link to hashesh in 'verification-allos-advanced.md'

### DIFF
--- a/_i18n/ar/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/ar/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ gpg:              unchanged: 1
 في ليُنكس يمكنك تنزيل ملف الهاشات الموقّع عن طريق إصدار الأمر التالي:
 
 ```
-wget -O hashes.txt {{ site.baseurl }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. تأكد من ملف الهاش

--- a/_i18n/de/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/de/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File

--- a/_i18n/en/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/en/resources/user-guides/verification-allos-advanced.md
@@ -101,7 +101,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File

--- a/_i18n/es/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/es/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ En Windows o Mac, ve a los [archivos hash en getmonero.org]({{ site.baseurl }}/d
 En Linux, puedes descargar los hashes firmados utilizando el siguiente comando:
 
 ```
-wget -O hashes.txt {{ site.baseurl }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verificar Archivo Hash

--- a/_i18n/fr/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/fr/resources/user-guides/verification-allos-advanced.md
@@ -105,7 +105,7 @@ Sur Windows et Mac, rendez-vous sur sur la [page de haches getmonero.org](https:
 Sur Linux, vous pouvez télécharger le fichier de hachage en tapant la commande suivante :
 
 ```
-wget -O hashes.txt {{ site.baseurl }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Vérifier le Fichier de Hachage

--- a/_i18n/it/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/it/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File

--- a/_i18n/nl/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/nl/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ Op Windows of een Mac ga je naar het [hashbestand op getmonero.org]({{ site.base
 Op Linux kun je het ondertekende hashbestand downloaden door de volgende opdracht op te geven:
 
 ```
-wget -O hashes.txt {{ site.baseurl }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Hashbestand verifiëren

--- a/_i18n/pl/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/pl/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File

--- a/_i18n/pt-br/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/pt-br/resources/user-guides/verification-allos-advanced.md
@@ -101,7 +101,7 @@ No Windows ou Mac, vá para a página com o [arquivo de hashes em getmonero.org]
 No Linux, você pode baixar o arquivo com os hashes assinados através do seguinte comando:
 
 ```
-wget -O hashes.txt {{ site.baseurl }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verificar o Arquivo de Hashes

--- a/_i18n/ru/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/ru/resources/user-guides/verification-allos-advanced.md
@@ -101,7 +101,7 @@ gpg:              unchanged: 1
 В том случае, если используется Linux, можно загрузить подписанный хеш-файл, используя следующую команду:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Верификация хеш-файла

--- a/_i18n/tr/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/tr/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File

--- a/_i18n/zh-cn/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/zh-cn/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File

--- a/_i18n/zh-tw/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/zh-tw/resources/user-guides/verification-allos-advanced.md
@@ -103,7 +103,7 @@ On Windows or Mac, go to the [hashes file on getmonero.org]({{ site.baseurl_root
 On Linux, you can download the signed hashes file by issuing the following command:
 
 ```
-wget -O hashes.txt {{ site.baseurl_root }}/downloads/hashes.txt
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
 ```
 
 ### 3.2. Verify Hash File


### PR DESCRIPTION
`{{ site.baseurl }}` doesn't seem to work inside a block of code.

Thanks charuto for spotting the issue.