### PR TITLE
German translation of Moneropedia entries starting with C

### DIFF
--- a/_i18n/de/resources/moneropedia/canonically-unique-host.md
+++ b/_i18n/de/resources/moneropedia/canonically-unique-host.md
@@ -1,22 +1,22 @@
 ---
 tags: ["kovri"]
-terms: ["Canonically-unique-host"]
-summary: "A host that is canonically resolved to an address or set of addresses"
+terms: ["Canonically-unique-host", "Kanonisch-einzigartiger-Host", "Kanonisch-einzigartigen-Host", "Kanonisch-einzigartige-Hosts", "Kanonisch-einzigartigen-Hosts"]
+summary: "Ein Host, der vorschriftsgemäß in eine Adresse oder eine Reihe von Adressen aufgelöst wird"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-A Canonically-unique host is a [FQDN](https://en.wikipedia.org/wiki/FQDN) that will canonically resolve to a designated address or set of addresses. Not to be confused with a @locally-unique-host.
+Ein kanonisch einzigartiger Host ist ein [FQDN](https://de.wikipedia.org/wiki/Domain_(Internet)#Fully_Qualified_Domain_Name_(FQDN)), der vorschriftsgemäß in eine vorgesehene Adresse (oder eine Reihe dieser) aufgelöst wird. Nicht zu verwechseln mit dem @Lokal-einzigartigen-Host.
 
-### In-depth information
+### Ausführliche Informationen
 
-A Canonically-unique host is defined by remote authoritative sources; usually through [DNS](https://en.wikipedia.org/wiki/DNS). When resolving a peer's hostname, you will most likely use an external source for resolution unless you have the following implemented:
+Ein kanonisch einzigartiger Host wird durch rechnerferne, maßgebende Quellen definiert, normalerweise durch das [DNS](https://de.wikipedia.org/wiki/Domain_Name_System). Zum Auflösen des Hostnamens eines Rechners nutzt du sehr wahrscheinlich eine externe Quelle, sofern du nicht Folgendes implementiert hast:
 
-- a database file similar to a [hosts file](https://en.wikipedia.org/wiki/Hosts_(file))
-- an internal-network resolver (which eventually pulls from external sources)
+- eine Datenbankdatei, die einer [Hosts-Datei](https://de.wikipedia.org/wiki/Hosts_(Datei)) ähnelt
+- einen netzwerkinternen Auflöser (der letztlich auf externe Quellen zurückgreift)
 
-### Notes
+### Anmerkungen
 
-- Monero primarily uses @canonically-unique-host resolution while @I2P only uses @locally-unique-host resolution.
-- @I2P's and @Kovri's self-assigned top-level domain is currently `.i2p` and @Kovri intends to only process/use the `.i2p` [top-level domain](https://en.wikipedia.org/wiki/Top_level_domain)
+- Monero nutzt primär die Auflösung des kanonisch einzigartigen Hosts, während I2P ausschließlich die Auflösung des @Lokal-einzigartigen-Hosts verwendet.
+- Die an I2P und @Kovri zugewiesene Top-Level-Domain ist derzeit `.i2p`; @Kovri beabsichtigt, einzig die `.i2p`-[Top-Level-Domain](https://de.wikipedia.org/wiki/Top-Level-Domain) zu nutzen und zu verarbeiten.

--- a/_i18n/de/resources/moneropedia/change.md
+++ b/_i18n/de/resources/moneropedia/change.md
@@ -1,15 +1,15 @@
 ---
-terms: ["change"]
-summary: "Monero sent as part of a transaction, that returns to your account instead of going to another recipient"
+terms: ["change", "Wechselgeld"]
+summary: "Monero, die Teil einer Transaktion waren und auf das Konto zurückgebucht werden, anstatt an einen anderen Empfänger zu gehen"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-Monero sent as part of a transaction, that returns to your account instead of going to another recipient.
+Monero, die als Teil einer Transaktion versendet wurden und auf das Konto zurückgebucht werden, anstatt an einen anderen Empfänger zu gehen.
 
-### More Information
+### Weitere Informationen
 
-The @wallet in the Monero software makes change automatically, but when you send a transaction, you are taking an input that you control and telling the Monero network what to do with it. The input is a "deposit" to your account that you are able to spend. Outputs are the part of the transaction that tells the Monero network where to send the funds.
+Das @Wallet der Monero-Software berechnet Wechselgeld automatisch. Wenn du eine Transaktion vornimmst, sagst du dem Monero-Netzwerk, was es mit einem von dir kontrollierten Input tun soll. Ein Input ist eine "Einzahlung" auf dein Konto, welche du anschließend ausgeben kannst. Outputs sind der Teil einer Transaktion, welcher dem Monero Netzwerk mitteilt, wohin Beträge gesendet werden sollen (Outputs sind also gewissermaßen die gesendeten und damit ausgegebenen Geldbeträge).
 
-You might have multiple inputs in your account, in many different denominations (For example: you deposited 0.5 XMR on Friday, and 0.75 XMR on Saturday). So, when have a transaction with an input of 0.5 XMR, but you only want to send 0.1 XMR, your transaction will include a fee to pay the @miner, an output for 0.1 XMR to send to the recipient, and the rest that you want to send back to yourself will be an output back to you (this is called "change"). Once the transaction is completed, the change becomes available to you as an input that you can again split and send with a new transaction.
+Du kannst mehrere Inputs in verschiedenen Stückelungen auf deinem Konto haben (so hast du vielleicht am Freitag 0,5 XMR und am Samstag 0,75 XMR eingezahlt). Wenn du also eine Transaktion mit einem Input von 0,5 XMR hast, jedoch nur 0,1 XMR versenden möchtest, wird deine @Transaktion neben einer Gebühr zur Bezahlung des @Miners einen Output von 0,1 XMR, die an den Empfänger gehen, enthalten. Der Restbetrag, den du zurückerhalten möchtest, geht als Output an dich selbst (dies wird "Wechselgeld" genannt). Sobald die Transaktion abgeschlossen ist, wird das Wechselgeld zu einem Input, welches du wieder aufteilen und in einer neuen Transaktion versenden kannst.

--- a/_i18n/de/resources/moneropedia/clearnet.md
+++ b/_i18n/de/resources/moneropedia/clearnet.md
@@ -1,32 +1,33 @@
 ---
 tags: ["kovri"]
 terms: ["Clearnet"]
-summary: "The Internet in which anonymous overlay networks are built upon"
+summary: "Das Internet, auf welchem anonyme, überlagernde Netzwerke aufbauen"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-When you use the Internet for things like news, email, social media, and even Monero, you are most likely using a clearnet connection. This means that *all* of your connections can be tracked, traced, and monitored by:
+Wenn du das Internet für Dinge wie das Abrufen der Nachrichten, E-Mails, soziale Medien oder auch Monero nutzt, nutzt du sehr wahrscheinlich eine Clearnet-Verbindung. Dies bedeutet, dass deine *gesamten* Verbindungen aufgespürt, verfolgt und überwacht werden können, und das von:
 
-- your [ISP](https://en.wikipedia.org/wiki/ISP)
-- the website/service/person you're communicating with
-- possibly a [Five Eyes](https://en.wikipedia.org/wiki/5_Eyes) capable entity
+- deinem [Internetprovider](https://de.wikipedia.org/wiki/Internetdienstanbieter)
+- der Webseite/der Person/dem Service, mit der/dem du in Verbindung stehst
+- eventuell einer mit den Möglichkeiten der [Five Eyes](https://en.wikipedia.org/wiki/5_Eyes) befähigten Instanz
 
-and even if you use [HTTPS](https://en.wikipedia.org/wiki/HTTPS) or similar (which *encrypts* your transmission), your route is not hidden nor is it anonymous, thus; it is in the *clear*.
+Selbst wenn du [HTTPS](https://de.wikipedia.org/wiki/Hypertext_Transfer_Protocol_Secure) oder Ähnliches nutzt, sind die übertragenen Inhalte zwar verschlüsselt (vor dem "Abhören" durch Dritte geschützt), jedoch ist die Verbindung weder verborgen, noch anonym (Dritte können feststellen, dass die Verbindung existiert und zwischen wem). Daher werden auch HTTPs und ähnliche Technologien dem Clearnet zugeordnet.
 
-### In-depth information
+### Ausführliche Informationen
 
-Since a traditional [VPN](https://en.wikipedia.org/wiki/VPN) cannot save you from clearnet (as you are still using *clearnet* (though you are more proxied than without a VPN)), you should use an *anonymous overlay network* to avoid using clearnet directly:
+Da dich ein klassisches [VPN](https://de.wikipedia.org/wiki/Virtual_Private_Network) nicht vor dem Clearnet schützen kann - du nutzt schließlich nach wie vor das *Clearnet* (wobei deine Daten zumindest besser umgeleitet werden, als ohne die Verwendung eines VPNs) - solltest du ein sogenanntes Overlay-Netzwerk, also ein anonymes, überlagerndes Netzwerk nutzen, um den direkten Gebrauch des Clearnets zu vermeiden:
 
 - @Kovri
-- @Java-I2P
-- [Tor](https://torproject.org/)
+- Java-I2P
+- [Tor](https://torproject.org/de/)
 
-These technologies protect you from clearnet by building an anonymous network **over** clearnet to keep your transmissions both encrypted **and** anonymous.
+Diese Technologien schützen dich vor dem Clearnet, indem sie ein anonymes Netz **über** ebendiesem errichten und deine Verbindungen somit verschlüsselt **und** anonym bleiben.
 
-Here is an accurate, [interactive diagram](https://www.eff.org/pages/tor-and-https) provided by the [EFF](https://www.eff.org/) which describes *clearnet* as it relates to **Tor**. The concept also (somewhat) applies to @Kovri and @I2P in terms of anonymity with the exception that:
+Ein [interaktives Diagramm](https://www.eff.org/pages/tor-and-https) des [EFF](https://www.eff.org/) zeigt den Zusammenhang des *Clearnets* und **Tor**. Dieses Konzept trifft in puncto Anonymität (in gewisser Hinsicht) auch auf @Kovri und I2P zu, mit der Ausnahme, dass:
 
-- @Kovri does not use exit nodes when connecting to an @eepsite
-- Your traffic never need to leave the @I2P network
-- You do not need HTTPS to use @Kovri (with the exception of @reseed)
+- Kovri für Verbindungen zu einer Eepsite keine Exit-Nodes verwendet
+- dein Datenverkehr niemals das I2P-Netzwerk verlassen muss
+- du HTTPS nicht benötigst, um @Kovri nutzen zu können (ausgenommen ist ein Reseed)
+

--- a/_i18n/de/resources/moneropedia/coinbase.md
+++ b/_i18n/de/resources/moneropedia/coinbase.md
@@ -1,9 +1,9 @@
 ---
-terms: ["coinbase-transaction"]
-summary: "a special type of transaction included in each block, which contains a small amount of Monero sent to the miner as a reward for their mining work"
+terms: ["coinbase-transaction", "Coinbase-Transaktion"]
+summary: "Eine in jedem Block enthaltene besondere Art der Transaktion, welche einen kleinen Monero-Betrag enthält, der als Belohnung für den Mining-Aufwand an den Miner geht"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-A special type of transaction included in each block, which contains a small amount of Monero sent to the miner as a reward for their mining work.
+Eine in jedem Block enthaltene besondere Art der Transaktion, welche einen kleinen Monero-Betrag enthält, der als Belohnung für den Mining-Aufwand an den Miner geht.

--- a/_i18n/de/resources/moneropedia/consensus.md
+++ b/_i18n/de/resources/moneropedia/consensus.md
@@ -1,9 +1,9 @@
 ---
-terms: ["consensus", "consensus-network"]
-summary: "consensus describes a property of distributed networks like Monero where most of the participants follow the rules, and thus reject bad participants"
+terms: ["consensus", "consensus-network", "Konsens", "Konsens-Netzwerk"]
+summary: "Konsens beschreibt eine Eigenschaft dezentraler Netzwerke wie Monero, in denen der Großteil der Mitwirkenden die Regeln befolgt und dementsprechend schädliche Beteiligte abgewiesen werden"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-Consensus describes a property of distributed networks like Monero where most of the participants follow the rules, and thus reject bad participants.
+Konsens beschreibt eine Eigenschaft dezentraler Netzwerke wie Monero, in denen der Großteil der Mitwirkenden die Regeln befolgt und dementsprechend schädliche Beteiligte abgewiesen werden.

--- a/_i18n/de/resources/moneropedia/cryptocurrency.md
+++ b/_i18n/de/resources/moneropedia/cryptocurrency.md
@@ -1,21 +1,21 @@
 ---
 terms: ["cryptocurrency", "cryptocurrencies", "altcoin", "altcoins", "Kryptowährungen", "Kryptowährung"]
-summary: "a digital currency in which encryption techniques are used to regulate the generation of units of currency and verify the transfer of funds, usually operating independently of a central bank"
+summary: "Eine üblicherweise von einer Zentralbank unabhängige digitale Währung, die Verschlüsselungstechnologien zur Regulierung der Erstellung von Währungseinheiten und zur Verifizierung von Geldtransfers nutzt"
 ---
 
-{% include disclaimer.html translated="no" translationOutdated="no" %}
-### The Basics
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+### Grundlagen
 
-A digital currency in which encryption techniques are used to regulate the generation of units of currency and verify the transfer of funds, usually operating independently of a central bank.
+Eine digitale Währung, die Verschlüsselungstechnologien zur Regulierung der Erstellung von Währungseinheiten und zur Verifizierung von Geldtransfers nutzt. In der Regel operieren Kryptowährungen in Unabhängigkeit von einer Zentralbank.
 
-### More Information
+### Weitere Informationen
 
-Cryptocurrency is the generic term for a large set of digital assets that use encryption techniques to generate units of currency, verify the transactions, and transfer value. Generally, cryptocurrencies are considered to be decentralized. Cryptocurrency should not be confused with virtual currency which is a type of digital money that is usually controlled by its creators or developers. Some examples of virtual currency are gametime in World of Warcraft, ROBUX in Roblox, reward points programs, or Ripple, all of which can be exchanged for currency or cash value, but are not considered cryptocurrency because they are centalized and controlled/issued by a single entity.  
+"Kryptowährung" ist der allgemeine Begriff für eine große Menge digitaler Assets, welche Verschlüsselungstechnologien zum Erstellen von Währungseinheiten und zur Verifizierung von Transaktionen und deren Wert nutzen. Im Allgemeinen werden Kryptowährungen als dezentralisiert verstanden. Sie sollten nicht mit virtueller Währung verwechselt werden; diese ist eine Art digitalen Geldes, das in der Regel von den Erzeugern oder Entwicklern kontrolliert wird. Beispiele für virtuelle Währungen sind Gametime in World of Warcraft, Robux bei Roblox, Treuepunktprogramme oder auch Ripple: Alle können gegen Währung beziehungsweise den Geldwert getauscht werden, werden jedoch nicht als Kryptowährungen betrachtet, da sie zentralisiert sind und von eine einzelnen Instanz ausgegeben und kontrolliert werden.
 
-Monero is one of many cryptocurrencies currently available. Other examples are Bitcoin, Litecoin, Dogecoin, Dash, Zcash, etc, but nearly all other cryptocurrencies lack features that make them a true money (most importantly @fungibility which is a requirement for it to be a store-of-value).
+Monero ist eine von vielen derzeit verfügbaren Kryptowährungen. Andere Beispiele sind Bitcoin, Litecoin, Dogecoin, Dash, Zcash und so weiter; allerdings fehlt es nahezu allen anderen Kryptowährungen an Funktionen, welche sie zu tatsächlichem Geld werden lassen (am wichtigsten hierbei ist die @Fungibilität als Voraussetzung, als Wertanlage zu funktionieren).
 
-Not all cryptocurrencies operate the same, but they usually share the properties of decentralization, encryption, and the ability to send and receive transactions. Most are irreversible, pseudonymous, global, and permissionless. Most aim to be a store-of-value or be digital cash that allows you to transact.
+Nicht alle Kryptowährungen funktionieren gleich, sie teilen jedoch üblicherweise Eigenschaften bezüglich Dezentralisierung, Verschlüsselung und der Möglichkeit, Transaktionen zu senden oder zu empfangen. Die meisten sind irreversibel, pseudonym, global und ohne Berechtigungen nutzbar. Ein Großteil verfolgt das Ziel, als Wertanlage zu fungieren oder als digitales Bargeld eingesetzt zu werden.
 
-Most cryptocurrencies (including Monero) use a distributed ledger (called a @blockchain) to keep track of previous transactions. The blockchain serves to tell other users on the network that transactions have happened. There are many different ways for cryptocurrencies to create their blockchain, and not all are the same. Monero uses proof-of-work to craft blocks, where other cryptocurrencies may use proof-of-stake or other consolidated methods.
+Die meisten Kryptowährungen (darunter auch Monero) nutzen ein verteiltes Kassenbuch (@Blockchain genannt), um vergangene Transaktionen zu verwalten. Die Blockchain dient dazu, anderen Nutzern auf dem Netzwerk mitzuteilen, dass Transaktionen stattgefunden haben. Es gibt viele verschiedene Wege für Kryptowährungen, eine Blockchain zu erstellen. Monero nutzt zum Erstellen von Blöcken ein Proof-of-Work-System, während andere Kryptowährungen Proof-of-Stake- oder andere, zusammengelegte Methoden nutzen.
 
-Ultimately, cryptocurrency is an attempt to create trustless value; that is free from borders, governments, and banks. Whether that be to transact or to be digital gold is up to the users of each.
+Letzten Endes verkörpern Kryptowährungen das Bestreben danach, Geldwerte zu schaffen, die nicht auf Vertrauen basieren und somit frei von Grenzen, Regierungen und Banken sind - ob diese nun als Zahlungsmittel genutzt oder als digitale Goldanlage betrachtet werden, liegt in den Händen eines jeden Nutzers.


### PR DESCRIPTION
**German translation of the following Moneropedia entries:**

- Canonically Unique Host
- Change
- Clearnet
- Coinbase
- Concensus
- Cryptocurrencies