### PR TITLE
Add arrow-up button to the blog and move the related CCS to the general section

### DIFF
--- a/_layouts/blog_by_tag.html
+++ b/_layouts/blog_by_tag.html
@@ -124,5 +124,5 @@ layout: custom
                 <!-- end right one-third block-->
             </div>
         </section>
-    
+    <a href="#" class="arrow-up" aria-label="{% t accessibility.arrowup %}"><i></i></a>
 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -63,6 +63,7 @@ title: titles.blogbytag
         </div>
       <!-- End full block-->
   </section>
+  <a href="#" class="arrow-up" aria-label="{% t accessibility.arrowup %}"><i></i></a>
 </div>
 
 {% if paginator.total_pages > 1 %}

--- a/css/custom.css
+++ b/css/custom.css
@@ -1223,6 +1223,42 @@ ul.logo {
   list-style-image: url('/img/logo-list.svg');
 }
 
+a.arrow-up {
+  border: 1px solid #d26e2b;
+  border-radius: 50%;
+  height: 3rem;
+  width: 3rem;
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background-color: #ffffff;
+  z-index: 5;
+}
+
+a.arrow-up:hover, a.arrow-up:focus {
+  border: none;
+  background-color: #d26e2b;
+}
+
+a.arrow-up i {
+  border: solid #d26e2b;
+  border-width: 0 3px 3px 0;
+  padding: 0.5rem;
+  position: absolute;
+  top: 1.02rem;
+  left: 0.88rem;
+  transform: rotate(-135deg);
+  -webkit-transform: rotate(-135deg);
+  -webkit-transition: all ease-out .2s;
+  -moz-transition: all ease-out .2s;
+  -o-transition: all ease-out .2s;
+  transition: all ease-out .2s;
+}
+
+a.arrow-up:hover i, a.arrow-up:focus i {
+  border-color: #ffffff;
+}
+
 @media only screen and (max-width: 75rem) {
 
 .upgrade-content p {
@@ -3241,42 +3277,6 @@ span.icon-browser {
   margin-top: 0;
 }
 
-.downloads a.arrow-up {
-    border: 1px solid #d26e2b;
-    border-radius: 50%;
-    height: 3rem;
-    width: 3rem;
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    background-color: #ffffff;
-    z-index: 5;
-}
-
-.downloads a.arrow-up:hover, .downloads a.arrow-up:focus {
-    border: none;
-    background-color: #d26e2b;
-}
-
-.downloads a.arrow-up i {
-    border: solid #d26e2b;
-    border-width: 0 3px 3px 0;
-    padding: 0.5rem;
-    position: absolute;
-    top: 1.02rem;
-    left: 0.88rem;
-    transform: rotate(-135deg);
-    -webkit-transform: rotate(-135deg);
-    -webkit-transition: all ease-out .2s;
-    -moz-transition: all ease-out .2s;
-    -o-transition: all ease-out .2s;
-    transition: all ease-out .2s;
-}
-
-.downloads a.arrow-up:hover i, .downloads a.arrow-up:focus i {
-    border-color: #ffffff;
-}
-
 .mobile-only {
   display:none;
 }
@@ -4584,42 +4584,6 @@ p.hangouts-social {
 
 .faq .tab h3 {
   font-weight: bold;
-}
-
-.faq a.arrow-up {
-  border: 1px solid #d26e2b;
-  border-radius: 50%;
-  height: 3rem;
-  width: 3rem;
-  position: fixed;
-  bottom: 2rem;
-  right: 2rem;
-  background-color: #ffffff;
-  z-index: 5;
-}
-
-.faq a.arrow-up:hover, .downloads a.arrow-up:focus {
-  border: none;
-  background-color: #d26e2b;
-}
-
-.faq a.arrow-up i {
-  border: solid #d26e2b;
-  border-width: 0 3px 3px 0;
-  padding: 0.5rem;
-  position: absolute;
-  top: 1.02rem;
-  left: 0.88rem;
-  transform: rotate(-135deg);
-  -webkit-transform: rotate(-135deg);
-  -webkit-transition: all ease-out .2s;
-  -moz-transition: all ease-out .2s;
-  -o-transition: all ease-out .2s;
-  transition: all ease-out .2s;
-}
-
-.faq a.arrow-up:hover i, .faq a.arrow-up:focus i {
-  border-color: #ffffff;
 }
 
 .tab .anchor {


### PR DESCRIPTION
The blog pages tend to be long. Adding the arrow-up button here as well to allow people to go back to the top with one click/tap.

I also moved the css related to the button to the general section and deleted the duplicated page-specific classes, so that the button can be used everywhere withou duplicating CSS.