### PR TITLE
_config.yml: fix wrong baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ email: dev@getmonero.org
 name: Monero
 description: Monero is a digital currency that is secure, private, and untraceable.
 keywords: "monero, xmr, bitmonero, cryptocurrency"
-baseurl: "https://www.getmonero.org"
+baseurl: ""
 url: "https://www.getmonero.org"
 
 markdown: kramdown


### PR DESCRIPTION
Something went wrong during the rebase of e5de616c31b7aeb7d35a34b8738d205187e70835 and [the change of baseurl](https://github.com/monero-project/monero-site/pull/1164) was reverted. This should be merged ASAP.