### PR TITLE
Updating "Wallet/daemon isolation with Qubes + Whonix"

### DIFF
--- a/_i18n/ar/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/ar/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 # عزل واجهه سطر الأوامر/الخادم في نظام Qubes + Whonix
 

--- a/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -13,7 +13,7 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain](https://web.getmonero.org/downloads/#blockchain). Keep in mind that the blockchain will take more space with time.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain](https://web.getmonero.org/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
@@ -71,7 +71,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:

--- a/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -13,32 +13,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain](https://web.getmonero.org/downloads/#blockchain). Keep in mind that the blockchain will take more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl_root }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -55,7 +37,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -66,16 +48,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -108,16 +84,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -13,7 +13,7 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain](https://web.getmonero.org/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain](https://{{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 

--- a/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/en/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -13,7 +13,7 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain](https://{{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 

--- a/_i18n/es/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/es/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 # Aislamiento de Monedero CLI/Daemon con Qubes + Whonix
 

--- a/_i18n/fr/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/fr/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 # Isolation du Portefeuille CLI et du Démon avec Qubes et Whonix
 

--- a/_i18n/it/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/it/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -4,7 +4,7 @@
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
 
-Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the @daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
 
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
@@ -15,32 +15,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -57,7 +39,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -68,16 +50,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -97,7 +73,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:
@@ -110,16 +86,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/_i18n/nl/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/nl/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 # Portemonnee isoleren van node met Qubes en Whonix
 

--- a/_i18n/pl/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/pl/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -4,7 +4,7 @@
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
 
-Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the @daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
 
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
@@ -15,32 +15,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -57,7 +39,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -68,16 +50,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -97,7 +73,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:
@@ -110,16 +86,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/_i18n/pt-br/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/pt-br/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -4,7 +4,7 @@
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
 
-Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the @daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
 
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
@@ -15,32 +15,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -57,7 +39,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -68,16 +50,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -97,7 +73,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:
@@ -110,16 +86,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/_i18n/ru/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/ru/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,4 +1,4 @@
-{% include disclaimer.html translated="yes" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="yes" %}
 
 С помощью [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) можно создать кошелек Monero, который не будет требовать подключения к сети и работать на фактически изолированной от демона Monero системе , у которого весь сетевой трафик будет проходить через сеть [Tor](https://torproject.org).
 

--- a/_i18n/tr/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/tr/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -4,7 +4,7 @@
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
 
-Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the @daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
 
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
@@ -15,32 +15,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl_root }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -57,7 +39,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -68,16 +50,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -97,7 +73,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:
@@ -110,16 +86,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/_i18n/zh-cn/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/zh-cn/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -4,7 +4,7 @@
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
 
-Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the @daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
 
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
@@ -15,32 +15,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -57,7 +39,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -68,16 +50,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -97,7 +73,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:
@@ -110,16 +86,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/_i18n/zh-tw/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/zh-tw/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -4,7 +4,7 @@
 
 With [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) you can have a Monero wallet that is without networking and running on a virtually isolated system from the Monero daemon which has all of its traffic forced over [Tor](https://torproject.org).
 
-Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+Qubes gives the flexibility to easily create separate VMs for different purposes. First you will create a Whonix workstation for the wallet with no networking. Next, another Whonix workstation for the @daemon which will use your Whonix gateway as it's NetVM. For communication between the wallet and daemon you can make use of Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
 
 This is safer than other approaches which route the wallets rpc over a Tor hidden service, or that use physical isolation but still have networking to connect to the daemon. In this way you don't need any network connection on the wallet, you preserve resources of the Tor network, and there is less latency.
 
@@ -15,32 +15,14 @@ This is safer than other approaches which route the wallets rpc over a Tor hidde
 
   - The first workstation will be used for your wallet, it will referred to as `monero-wallet-ws`. You will have `NetVM` set to `none`.
 
-  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`.
+  - The second workstation will be for the `monerod` daemon, it will be referred to as `monerod-ws`. You will have `NetVM` set to the Whonix gateway `sys-whonix`. Before moving on, make sure this workstation has enough private storage. You can estimate how much space you need by checking the size of the [raw blockchain]({{ site.baseurl }}/downloads/#blockchain). Keep in mind that the blockchain will take up more space with time.
 
 ## 2. In the AppVM `monerod-ws`:
 
-+ Download, verify, and install Monero software.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Create a `systemd` file.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Paste the following contents:
@@ -57,7 +39,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -68,16 +50,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Copy `monero-wallet-cli` executable to the `monero-wallet-ws` VM.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Make `monerod` daemon run on startup by editing the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add these lines to the bottom:
@@ -97,7 +73,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubes-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Add this line:
@@ -110,16 +86,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. In the AppVM `monero-wallet-ws`:
 
-+ Move the `monero-wallet-cli` executable.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Edit the file `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Add the following line to the bottom:

--- a/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -2,7 +2,7 @@
 layout: user-guide
 title: CLI Wallet/Daemon Isolation with Qubes + Whonix
 permalink: /resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html
-outdated: True
+outdated: False
 ---
 
 {% t global.lang_tag %}


### PR DESCRIPTION
**What I've changed:**
+ Added notice about increasing the daemon workstation's private storage and how to estimate the space needed.
+ Changed `monerod` location in the systemd file to `/usr/bin/monerod` from `/usr/local/bin/monerod` since that is where it is located now.
- Removed the parts about installing monero since it is now preinstalled in Whonix.
+ Changed mentions of `gedit` to `nano` because `gedit` is not installed by default.
+ Set outdated to False

I think the name should be changed to exclude the CLI part since the guide works for both monero-gui and monero-cli but to avoid mismatch between title and filenames I left it out for a later PR.