### PR TITLE
Remove xmr-stak from 'Mining' page

### DIFF
--- a/get-started/mining/index.md
+++ b/get-started/mining/index.md
@@ -68,9 +68,6 @@ permalink: /get-started/mining/index.html
                        <p>{% t mining.software_para %}</p>
                     </div>
                     <div class="row center-xs">
-                        <p><a href="https://github.com/fireice-uk/xmr-stak" target="_blank" rel="noreferrer noopener">XMR Stak</a></p>
-                    </div>
-                    <div class="row center-xs">
                         <p><a href="https://github.com/xmrig/xmrig" target="_blank" rel="noreferrer noopener">XMRig</a></p>
                     </div>
                     <div class="row center-xs">


### PR DESCRIPTION
The creator is a malicious actor who, beside constantly running disinformation campaigns against Monero, is currently actively attacking the network and its users. I don't see a reason for suggesting his mining software on Getmonero.