### PR TITLE
roadmap: change 'months' id to css class

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -3555,7 +3555,7 @@ span.icon-browser {
 
 /***************************ROADMAP STYLING*********************************/
 
-h3#months {
+h3.months {
   font-style: italic;
   margin-bottom: 0.5rem
 }

--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -28,19 +28,19 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>2014</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.apr %}</h3>
+                                <h3 class="months">{% t roadmap.apr %}</h3>
                                    <li class="completed">{% t roadmap.launched %}</li>
                                    <li class="completed">{% t roadmap.renamed %}</li>
-                                <h3 id="months">{% t roadmap.sep %}</h3>
+                                <h3 class="months">{% t roadmap.sep %}</h3>
                                     <li class="completed">{% t roadmap.recovered %}</li>
                                     <li class="completed">{% t roadmap.paper1-2 %}</li>
                                     <li class="completed">{% t roadmap.paper3 %}</li>
-                                <h3 id="months">{% t roadmap.dec %}</h3>
+                                <h3 class="months">{% t roadmap.dec %}</h3>
                                     <li class="completed">{% t roadmap.released-0-8-8-6 %}</li>
                             </ul>
                         <h2>2015</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.jan %}</h3>
+                                <h3 class="months">{% t roadmap.jan %}</h3>
                                     <li class="completed">{% t roadmap.paper4 %}</li>
                             </ul>
                     </div>
@@ -50,16 +50,16 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>2016</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.jan %}</h3>
+                                <h3 class="months">{% t roadmap.jan %}</h3>
                                     <li class="completed">{% t roadmap.released-0-9-0 %}</li>
-                                <h3 id="months">{% t roadmap.feb %}</h3>
+                                <h3 class="months">{% t roadmap.feb %}</h3>
                                     <li class="completed">{% t roadmap.paper5 %}</li>
-                                <h3 id="months">{% t roadmap.mar %}</h3>
+                                <h3 class="months">{% t roadmap.mar %}</h3>
                                     <li class="completed">{% t roadmap.ringsize-3 %}</li>
-                                <h3 id="months">{% t roadmap.sep %}</h3>
+                                <h3 class="months">{% t roadmap.sep %}</h3>
                                     <li class="completed">{% t roadmap.released-0-10-0 %}</li>
                                     <li class="completed">{% t roadmap.splitcoinbase %}</li>
-                                <h3 id="months">{% t roadmap.dec %}</h3>
+                                <h3 class="months">{% t roadmap.dec %}</h3>
                                     <li class="completed">{% t roadmap.released-0-10-1 %}</li>
                                     <li class="completed">{% t roadmap.guibeta1 %}</li>
                             </ul>
@@ -70,29 +70,29 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>2017</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.jan %}</h3>
+                                <h3 class="months">{% t roadmap.jan %}</h3>
                                     <li class="completed">{% t roadmap.enableringct %}</li>
-                                <h3 id="months">{% t roadmap.feb %}</h3>
+                                <h3 class="months">{% t roadmap.feb %}</h3>
                                     <li class="completed">{% t roadmap.released-0-10-2 %}</li>
-                                <h3 id="months">{% t roadmap.mar %}</h3>
+                                <h3 class="months">{% t roadmap.mar %}</h3>
                                     <li class="completed">{% t roadmap.released-0-10-3-1 %}</li>
-                                <h3 id="months">{% t roadmap.apr %}</h3>
+                                <h3 class="months">{% t roadmap.apr %}</h3>
                                     <li class="completed">{% t roadmap.hfminblock %}</li>
-                                <h3 id="months">{% t roadmap.jul %}</h3>
+                                <h3 class="months">{% t roadmap.jul %}</h3>
                                     <li class="completed">{% t roadmap.webredesign %}</li>
-                                <h3 id="months">{% t roadmap.sept %}</h3>
+                                <h3 class="months">{% t roadmap.sept %}</h3>
                                     <li class="completed">{% t roadmap.released-0-11-0 %}</li>
                                     <li class="completed">{% t roadmap.fluffyblocks %}</li>
                                     <li class="completed">{% t roadmap.guioutbeta %}</li>
                                     <li class="completed">{% t roadmap.minringsize5 %}</li>
                                     <li class="completed">{% t roadmap.releasedgui-0-11-0 %}</li>
                                     <li class="completed">{% t roadmap.zeromq %}</li>
-                                <h3 id="months">{% t roadmap.oct %}</h3>
+                                <h3 class="months">{% t roadmap.oct %}</h3>
                                     <li class="completed">{% t roadmap.subaddress %}</li>
                                     <li class="completed">{% t roadmap.paper6 %}</li>
                                     <li class="completed">{% t roadmap.release-0-11-1 %}</li>
                                     <li class="completed">{% t roadmap.releasedgui-0-11-1 %}</li>
-                                <h3 id="months">{% t roadmap.dec %}</h3>
+                                <h3 class="months">{% t roadmap.dec %}</h3>
                                     <li class="completed">{% t roadmap.multisig %}</li>
                             </ul>
                     </div>
@@ -102,37 +102,37 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>2018</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.mar %}</h3>
+                                <h3 class="months">{% t roadmap.mar %}</h3>
                                     <li class="completed">{% t roadmap.released-0-12-0 %}</li>
-                                <h3 id="months">{% t roadmap.apr %}</h3>
+                                <h3 class="months">{% t roadmap.apr %}</h3>
                                     <li class="completed">{% t roadmap.releasedgui-0-12-0 %}</li>
                                     <li class="completed">{% t roadmap.cryptonightv2 %}</li>
                                     <li class="completed">{% t roadmap.hfring7 %}</li>
                                     <li class="completed">{% t roadmap.getmonero-fr-pl %}</li>
-                                <h3 id="months">{% t roadmap.may %}</h3>
+                                <h3 class="months">{% t roadmap.may %}</h3>
                                     <li class="completed">{% t roadmap.released-0-12-1 %}</li>
-                                <h3 id="months">{% t roadmap.jun %}</h3>
+                                <h3 class="months">{% t roadmap.jun %}</h3>
                                     <li class="completed">{% t roadmap.ledger %}</li>
                                     <li class="completed">{% t roadmap.released-0-12-2 %}</li>
-                                <h3 id="months">{% t roadmap.jul %}</h3>
+                                <h3 class="months">{% t roadmap.jul %}</h3>
                                     <li class="completed">{% t roadmap.released-0-12-3 %}</li>
                                     <li class="completed">{% t roadmap.releasedgui-0-12-3 %}</li>
-                                <h3 id="months">{% t roadmap.aug %}</h3>
+                                <h3 class="months">{% t roadmap.aug %}</h3>
                                     <li class="completed">{% t roadmap.kovrialpha %}</li>
                                     <li class="completed">{% t roadmap.moneropedialoc %}</li>
                                     <li class="completed">{% t roadmap.getmonero-ar %}</li>
-                                <h3 id="months">{% t roadmap.oct %}</h3>
+                                <h3 class="months">{% t roadmap.oct %}</h3>
                                     <li class="completed">{% t roadmap.released-0-13-0-2 %}</li>
                                     <li class="completed">{% t roadmap.releasedgui-0-13-3 %}</li>
                                     <li class="completed">{% t roadmap.cryptonightv3 %}</li>
                                     <li class="completed">{% t roadmap.bulletproofs %}</li>
                                     <li class="completed">{% t roadmap.ringsize11 %}</li>
                                     <li class="completed">{% t roadmap.released-0-13-0-4 %}</li>
-                                <h3 id="months">{% t roadmap.nov %}</h3>
+                                <h3 class="months">{% t roadmap.nov %}</h3>
                                     <li class="completed">{% t roadmap.paper8-9 %}</li>
                                     <li class="completed">{% t roadmap.releasedgui-0-13-0-4 %}</li>
                                     <li class="completed">{% t roadmap.paper7 %}</li>
-                                <h3 id="months">{% t roadmap.dec %}</h3>
+                                <h3 class="months">{% t roadmap.dec %}</h3>
                                     <li class="completed">{% t roadmap.paper10 %}</li>
                                     <li class="completed">{% t roadmap.mms %}</li>
                             </ul>
@@ -143,26 +143,26 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>2019</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.feb %}</h3>
+                                <h3 class="months">{% t roadmap.feb %}</h3>
                                     <li class="completed">{% t roadmap.getmonero-de %}</li>
                                     <li class="completed">{% t roadmap.released-0-14-0 %}</li>
-                                <h3 id="months">{% t roadmap.mar %}</h3>
+                                <h3 class="months">{% t roadmap.mar %}</h3>
                                     <li class="completed">{% t roadmap.releasedgui-0-14-0 %}</li>
                                     <li class="completed">{% t roadmap.ccs %}</li>
                                     <li class="completed">{% t roadmap.released-0-14-0-2 %}</li>
                                     <li class="completed">{% t roadmap.cryptonightr %}</li>
                                     <li class="completed">{% t roadmap.getmonero-pt_br %}</li>
-                                <h3 id="months">{% t roadmap.may %}</h3>
+                                <h3 class="months">{% t roadmap.may %}</h3>
                                     <li class="completed">{% t roadmap.dlsag %}</li>
-                                <h3 id="months">{% t roadmap.jul %}</h3>
+                                <h3 class="months">{% t roadmap.jul %}</h3>
                                     <li class="completed">{% t roadmap.pruning %}</li>
                                     <li class="completed">{% t roadmap.trezort %}</li>
                                     <li class="completed">{% t roadmap.nanox %}</li>
                                     <li class="completed">{% t roadmap.tori2p %}</li>
                                     <li class="completed">{% t roadmap.multisigms %}</li>
-                                <h3 id="months">{% t roadmap.oct %}</h3>
+                                <h3 class="months">{% t roadmap.oct %}</h3>
                                     <li class="completed">{% t roadmap.weblate %}</li>
-                                <h3 id="months">{% t roadmap.nov %}</h3>
+                                <h3 class="months">{% t roadmap.nov %}</h3>
                                     <li class="completed">{% t roadmap.rpcpay %}</li>
                                     <li class="completed">{% t roadmap.ipv6 %}</li>
                                     <li class="completed">{% t roadmap.removedpid %}</li>
@@ -176,21 +176,21 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>2020</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.feb %}</h3>
+                                <h3 class="months">{% t roadmap.feb %}</h3>
                                     <li class="completed">{% t roadmap.getmoneroweblate %}</li>
-                                <h3 id="months">{% t roadmap.mar %}</h3>
+                                <h3 class="months">{% t roadmap.mar %}</h3>
                                     <li class="completed">{% t roadmap.releasedgui-0-15-0-4 %}</li>
                                     <li class="completed">{% t roadmap.released-0-15-0-5 %}</li>
-                                <h3 id="months">{% t roadmap.apr %}</h3>
+                                <h3 class="months">{% t roadmap.apr %}</h3>
                                     <li class="completed">{% t roadmap.dandelion %}</li>
-                                <h3 id="months">{% t roadmap.may %}</h3>
+                                <h3 class="months">{% t roadmap.may %}</h3>
                                     <li class="completed">{% t roadmap.released-0-16-0-0 %}</li>
-                                <h3 id="months">{% t roadmap.aug %}</h3>
+                                <h3 class="months">{% t roadmap.aug %}</h3>
                                     <li class="completed">{% t roadmap.supercop %}</li>
-                                <h3 id="months">{% t roadmap.oct %}</h3>
+                                <h3 class="months">{% t roadmap.oct %}</h3>
                                     <li class="completed">{% t roadmap.clsag %}</li>
                                     <li class="completed">{% t roadmap.released-0-17 %}</li>
-                                <h3 id="months">{% t roadmap.comingsoon %}</h3>
+                                <h3 class="months">{% t roadmap.comingsoon %}</h3>
                                     <li class="ongoing">{% t roadmap.onionaddress %}</li>
                                     <li class="ongoing">{% t roadmap.tryptych %}</li>
                                     <li class="ongoing">{% t roadmap.kastelo %}</li>
@@ -203,7 +203,7 @@ permalink: /resources/roadmap/index.html
                     <div class="tabPanel-content">
                         <h2>{% t roadmap.future %}</h2>
                             <ul>
-                                <h3 id="months">{% t roadmap.comingsoon %}</h3>
+                                <h3 class="months">{% t roadmap.comingsoon %}</h3>
                                     <li class="upcoming">{% t roadmap.returnaddr %}</li>
                             </ul>
                     </div>


### PR DESCRIPTION
The ID was duplicated (as reported by the W3C validator in #1289). Transformed into a class