### PR TITLE
German Translation of User Guides (Wallet 2/2)

### DIFF
--- a/_i18n/de/resources/user-guides/multisig-messaging-system.md
+++ b/_i18n/de/resources/user-guides/multisig-messaging-system.md
@@ -1,30 +1,30 @@
-{% include disclaimer.html translated="no" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-## Table Of Contents
-- [Table Of Contents](#table-of-contents)
-- [Introduction](#introduction)
-- [Monero Multisig in a Nutshell](#monero-multisig-in-a-nutshell)
-- [The Architecture of the MMS](#the-architecture-of-the-mms)
-- [The MMS User Experience](#the-mms-user-experience)
-  - [A Messaging System](#a-messaging-system)
-  - [Signers and Messages](#signers-and-messages)
-- [Getting the MMS](#getting-the-mms)
-- [Installing and Configuring PyBitmessage](#installing-and-configuring-pybitmessage)
-- [Further PyBitmessage Tweaks](#further-pybitmessage-tweaks)
-- [MMS Command Overview](#mms-command-overview)
-- [Configuring a Wallet for Use with the MMS](#configuring-a-wallet-for-use-with-the-mms)
-  - [Addresses and Labels](#addresses-and-labels)
-  - [Running CLI Wallet](#running-cli-wallet)
-  - [Initializing the MMS](#initializing-the-mms)
-  - [Configuring Signers](#configuring-signers)
-  - [Manually Configuring Signers](#manually-configuring-signers)
+## Inhaltsverzeichnis
+- [Inhaltsverzeichnis](#inhaltsverzeichnis)
+- [Einleitung](#einleitung)
+- [Monero-Multisig zusammengefasst](#monero-multisig-zusammengefasst)
+- [Die Architektur des MMS](#die-architektur-des-mms)
+- [Das Benutzererlebnis des MMS](#das-benutzererlebnis-des-mms)
+  - [Ein Nachrichtensystem](#ein-nachrichtensystem)
+  - [Unterzeichner und Nachrichten](#unterzeichner-und-nachrichten)
+- [Das MMS erhalten](#das-mms-erhalten)
+- [PyBitmessage installieren und einrichten](#pybitmessage-installieren-und-einrichten)
+- [Weitere PyBitmessage-Optimierungen](#weitere-pybitmessage-optimierungen)
+- [Befehlsübersicht des MMS](#befehlsübersicht-des-mms)
+- [Ein Wallet zur Nutzung mit MMS einrichten](#ein-wallet-zur-nutzung-mit-mms-einrichten)
+  - [Adressen und Labels](#adressen-und-labels)
+  - [CLI-Wallet starten](#cli-wallet-starten)
+  - [MMS initialisieren](#mms-initialisieren)
+  - [Unterzeichner einrichten](#unterzeichner-einrichten)
+  - [Unterzeichner manuell einrichten](#unterzeichner-manuell-einrichten)
   - [Auto-Config](#auto-config)
-  - [Sending Signer Configuration](#sending-signer-configuration)
-- [Establishing the Multisig Address](#establishing-the-multisig-address)
-- [Funding the Multisig Wallet](#funding-the-multisig-wallet)
-- [Syncing Wallets](#syncing-wallets)
-- [Making Multisig Transactions](#making-multisig-transactions)
-- [The Commands in Detail](#the-commands-in-detail)
+  - [Unterzeichnerkonfiguration senden](#unterzeichnerkonfiguration-senden)
+- [Multisig-Adresse herleiten](#multisig-adresse-herleiten)
+- [Finanzausstattung des Multisig-Wallets](#finanzausstattung-des-multisig-wallets)
+- [Wallets synchronisieren](#wallets-synchronisieren)
+- [Multisig-Transaktionen erstellen](#multisig-transaktionen-erstellen)
+- [Die Befehle im Detail](#die-befehle-im-detail)
   - [mms init](#mms-init)
   - [mms info](#mms-info)
   - [mms signer](#mms-signer)
@@ -43,235 +43,234 @@
   - [mms auto\_config](#mms-auto_config)
   - [mms stop\_auto\_config](#mms-stop_auto_config)
   - [mms send\_signer\_config](#mms-send_signer_config)
-- [Security](#security)
-  - [Use of Encryption and Signatures](#use-of-encryption-and-signatures)
-  - [Communication MMS to PyBitmessage](#communication-mms-to-pybitmessage)
-  - [Impersonation](#impersonation)
-  - [Attacker-Controlled Data](#attacker-controlled-data)
-- [Troubleshooting](#troubleshooting)
-  - [Solving Syncing Troubles](#solving-syncing-troubles)
-  - [Redirecting a Transaction to Another Signer](#redirecting-a-transaction-to-another-signer)
-  - [Ignoring Uncooperative Signers when Syncing](#ignoring-uncooperative-signers-when-syncing)
-  - [Recovering from Lost or Duplicate Messages](#recovering-from-lost-or-duplicate-messages)
-  - [Correcting / Updating Signer Information](#correcting--updating-signer-information)
-  - [Starting from Scratch](#starting-from-scratch)
-  - [MMS / PyBitmessage Interactions](#mms--pybitmessage-interactions)
+- [Sicherheit](#sicherheit)
+  - [Nutzen von Verschlüsselung und Signaturen](#nutzen-von-verschlüsselung-und-signaturen)
+  - [Kommunikation von MMS zu PyBitmessage](#kommunikation-von-mms-zu-pybitmessage)
+  - [Identitätsbetrug](#identitätsbetrug)
+  - [Von Angreifern kontrollierte Daten](#von-angreifern-kontrollierte-daten)
+- [Fehlerbehebung](#fehlerbehebung)
+  - [Synchronisierungsprobleme lösen](#synchronisierungsprobleme-lösen)
+  - [Eine Transaktion an einen anderen Unterzeichner umleiten/weiterleiten](#eine-transaktion-an-einen-anderen-unterzeichner-umleiten/weiterleiten)
+  - [Unkooperative Unterzeichner beim Synchronisieren ignorieren](#unkooperative-unterzeichner-beim-synchronisieren-ignorieren)
+  - [Von abhandengekommenen oder doppelten Nachrichten wiederherstellen](#von-abhandengekommenen-oder-doppelten-nachrichten-wiederherstellen)
+  - [Informationen von Unterzeichnern korrigieren/aktualisieren](#informationen-von-unterzeichnern-korrigieren/aktualisieren)
+  - [Von Grund auf beginnen](#von-grund-auf-beginnen)
+  - [Interaktionen von MMS/PyBitmessage](#interaktionen-von-mms/pybitmessage)
 
-## Introduction
+## Einleitung
 
-This manual describes the *Multisig Messaging System*, abbreviated as *MMS*. It's a system that aims to **simplify multisig transactions** for Monero and similar CrypoNote-based cryptocurrencies by making it easy to exchange info like key sets and sync data between wallets and by offering some "workflow support" guiding you through the various steps.
+Diese Anleitung behandelt das *Multisig Messaging System* (Multisig-Nachrichtensystem), kurz *MMS*. Dieses System strebt an, **Multisig-Transaktionen** für Monero und ähnliche, CryptoNote-basierte Kryptowährungen zu **vereinfachen**, indem der Austausch von Infos (etwa von Schlüsselsätzen) und die Synchronisation von Daten zwischen Wallets erleichtert werden. Zudem bietet es Unterstützung bezüglich des Arbeitsablaufs, indem Nutzer durch die verschiedenen Schritte geführt werden.
 
-The MMS so far presents itself to the user as a set of new commands in the CLI wallet. This is not surprising, as currently the CLI wallet is the only way to do multisig transactions interactively anyway. Hopefully this will be extended in the future; the MMS was designed with other wallets like e.g. the Monero GUI wallet in mind.
+Bislang erscheint das MMS für Nutzer wie eine Reihe neuer Befehle im CLI-Wallet, was im Grunde keine Überraschung ist: Das CLI-Wallet ist derzeit die einzige Möglichkeit zur interaktiven Erstellung von Multisig-Transaktionen. Dies wird aber in Zukunft hoffentlich erweitert; das MMS wurde auch mit anderen Wallets (etwa dem Monero-GUI) im Hinterkopf entworfen.
 
-This manual has some tutorial-like aspects and is intended to be read in sequential fashion, best without skipping any chapter before chapter *The Commands in Detail*.
+Diese Anleitung umfasst einige übungsähnliche Punkte und sollte der Reihe nach durchgegangen werden, möglichst ohne die Kapitel vor dem *Die Befehle im Detail*-Teil zu überspringen.
 
-If you have high requirements regarding security and are not sure whether using the MMS is acceptable for you in the first place, you may read the chapter *Security* first.
+Wenn du hohe Sicherheitsanforderungen hast und dir nicht sicher bist, ob ein Gebrauch des MMS für dich überhaupt infrage kommt, solltest du als Erstes das Kapitel *Sicherheit* lesen.
 
-This first version of the manual was written around year-end 2018 by René Brunner (*rbrunner7*), the original author of the MMS.
+Die erste Version dieser Anleitung wurde um das Jahresende 2018 herum von René Brunner (*rbrunner7*), dem ursprünglichen Schöpfer des MMS, verfasst.
 
-## Monero Multisig in a Nutshell
+## Monero-Multisig zusammengefasst
 
-Probably it will be pretty hard to understand the MMS without at least a basic grasp of how Monero multisig transactions work in principle. Here a short overview together with info about the *terminology* that this manual uses; for more details and more *technical* explanations you will have to look elsewhere.
+Es wird vermutlich ziemlich schwer sein, das MMS zu verstehen, ohne wenigstens ein Grundverständnis davon zu haben, wie Multisig-Transaktionen bei Monero prinzipiell funktionieren. Daher hier nun eine kurze Übersicht, gemeinsam mit Infos bezüglich der in dieser Anleitung verwendeten *Terminologie*. Für noch mehr Details und weitere *fachspezifische* Erklärungen müsstest du dich woanders umsehen.
 
-*Multisig* means that a transaction needs multiple signatures before it can be submitted to the Monero network and executed. Instead of one Monero wallet creating, signing, and submitting transactions all on its own, you will have a whole group of wallets and collaboration between them to transact.
+*Multisig* bedeutet, dass eine Transaktion mehrere Signaturen benötigt, bevor sie im Monero-Netzwerk eingereicht und ausgeführt werden kann. Anstelle eines einzigen Monero-Wallets, welches Transaktionen erstellt, signiert und absendet, hast du nun eine ganze Gruppe von Wallets, die zwecks Transaktion kollaborieren.
 
-In this manual those wallets, or if you prefer, the people controlling them, are called *authorized signers*. Depending on the type of multisig used, not **all** authorized signers need to sign before a transaction becomes valid, but only a subset of them. The corresponding number (which is equal to or smaller than the number of authorized signers) is called *required signers*.
+In dieser Anleitung werden diese Wallets - oder die sie kontrollierenden Personen, wenn du es so präferierst - *autorisierte Unterzeichner* genannt. Je nach Form des genutzten Multisigs müssen zur Validierung einer Transaktion nicht **alle** der autorisierten Unterzeichner, sondern nur eine Teilmenge dieser signieren. Die entsprechende Anzahl (die kleiner oder gleich der Anzahl autorisierter Unterzeichner ist) wird als *erforderliche Unterzeichner* bezeichnet.
 
-The usual notation in use here is *M/N*, with *M* standing for the number of required signers, and *N* standing for the total number of authorized signers. For example, probably the most useful and most popular type of multisig is written as *2/3*: Out of a total of **three** authorized signers, any **two** are needed to make a transaction valid.
+Die üblicherweise genutzte Schreibweise ist *M/N*, wobei *M* für die Anzahl erforderlicher Unterzeichner und *N* für die Gesamtzahl autorisierter Unterzeichner steht. So wird bspw. die vermutlich nützlichste und beliebteste Multisig-Form als *2/3* geschrieben: Aus einer Gesamtsumme von **drei** autorisierten Unterzeichnern werden **zwei** beliebige Unterzeichner zur Validation einer Transaktion benötigt.
 
-For technically "simple" coins like Bitcoin and its forks doing multisig transactions consists of the following steps:
+Bei technisch "einfacheren" Coins wie Bitcoin und dessen Abspaltungen ist der Ablauf von Multisig-Transaktionen wie folgt:
 
-* Configure the multisig wallets and establish the multisig address
-* Fund the multisig wallets / the multisig address so there is something to spend in the first place
-* Do as many multisig transactions as you like
+* Multisig-Wallets einrichten und die Multisig-Adresse herleiten
+* Multisig-Wallets/die Multisig-Adresse mit Guthaben ausstatten, sodass überhaupt etwas ausgegeben werden kann
+* So viele Multisig-Transaktionen durchführen, wie gewünscht
 
-Monero adds one more type of step, necessary for internal bookkeeping so to speak. Simply told all the mechanisms that make Monero transactions truly private complicate things and lead to a necessity to exchange information between wallets to enable them to correctly process transactions, both incoming and outgoing.
+Monero fügt dem eine Art weiteren Schritt hinzu, der gleichsam wichtig für die interne Buchhaltung ist. Einfach gesagt komplizieren all die Mechanismen, die Monero-Transaktionen wahrlich privat machen, doch so einiges und führen zu der Notwendigkeit des Austauschs von Informationen zwischen Wallets, um diese dazu zu befähigen, ein- wie ausgehende Transaktionen richtig zu verarbeiten.
 
-The MMS uses the term *syncing* for the process to making wallets ready to transact again after sending or receiving transactions, and *multisig sync data* or simply *sync data* for the information that has to be exchanged to achieve that.
+Das MMS nutzt den Begriff *syncing* ("Synchronisieren") für den Vorgang der Wiederherstellung der Betriebsbereitschaft, durch welchen Wallets nach dem Senden/Empfangen einer Transaktion auf neue Transaktionen vorbereitet werden. *multisig sync data* oder auch einfach *sync data* bezeichnet die Informationen, die dazu notwendigerweise ausgetauscht werden müssen. 
 
-So the steps for Monero multisig look like that:
+Die Schritte des Monero-Multisigs sehen also so aus:
 
-* Configure the multisig wallets and establish the multisig address
-* Fund the multisig wallets / the multisig address so there is something to spend in the first place
-* Sync the wallets for a first time
-* Do 1 multisig transaction
-* Sync the wallets again
-* Do another multisig transaction and/or receive more funds
-* Sync the wallets yet again
-* ...
+* Multisig-Wallets einrichten und die Multisig-Adresse herleiten
+* Multisig-Wallets/die Multisig-Adresse mit Guthaben ausstatten, sodass überhaupt etwas ausgegeben werden kann
+* Wallets erstmalig synchronisieren
+* Eine Multisig-Transaktion tätigen
+* Wallets erneut synchronisieren
+* Eine weitere Multisig-Transaktion tätigen und/oder Geld empfangen
+* Wallets ein weiteres Mal synchronisieren
+* ... 
 
-The "value" of the MMS is making it easy and painless to exchange all those data packets between the wallets, and telling the signers at which point of the "workflow" they currently are and what has to be the next action in order to proceed.
+Der Nutzen des MMS ist die Vereinfachung des Austauschs all dieser Datenpakete zwischen den Wallets. Außerdem wird Unterzeichnern mitgeteilt, in welchem Schritt des Arbeitsablaufs sie sich gerade befinden und was der nächste Schritt zum Fortfahren ist.
 
-## The Architecture of the MMS
+## Die Architektur des MMS
 
-The MMS basically has 3 parts:
+Das MMS besteht im Grunde aus drei Teilen:
 
-* A set of new commands in the CLI wallet
-* A running instance of PyBitmessage reachable from the computer running the CLI wallet, doing message transport on behalf of the wallet
-* Internal code extensions to wallet code managing a new `.mms` file per wallet with the messages in it and interfacing with PyBitmessage
+* Einem Satz neuer Befehle im CLI-Wallet
+* Einer laufenden Instanz von PyBitmessage, die für den Computer, auf welchem das CLI-Wallet läuft, erreichbar ist und im Namen des Wallets Nachrichten transportiert
+* Internen Erweiterungen des Wallet-Codes, die pro Wallet eine neue `.mms`-Datei, die Nachrichten enthält, verwalten und mit PyBitmessage koppeln
 
-[PyBitmessage](https://bitmessage.org/wiki/Main_Page) is currently the only supported program for message transport, the MMS won't "speak" to any other system. You can't use e-mail nor any other of the myriad of communication programs out there. If you don't like PyBitmessage or can't run it for any reason you won't be able to use the current version of the MMS.
+[PyBitmessage](https://bitmessage.org/wiki/Main_Page) ist das derzeit einzige unterstützte Nachrichtentransportprogramm; das MMS "interagiert" nicht mit anderen Systemen. Du kannst weder E-Mails noch irgendein anderes der unzähligen Kommunikationsprogramme da draußen verwenden. Wenn dir PyBitmessage nicht gefällt oder du es aus etwaigen Gründen nicht betreiben kannst, wird es dir nicht möglich sein, die aktuelle Version des MMS zu nutzen.
 
-The author of the MMS hopes that you will give it a try: PyBitmessage is fully open source, is under continued development, has enough users to almost assure message transport at any time, and takes privacy very seriously - just like Monero.
+Der Schöpfer des MMS hofft, dass du es zumindest ausprobierst: PyBitmessage ist komplett quelloffen, befindet sich in kontinuierlicher Entwicklung, hat genügend Nutzer, um den Nachrichtentransport beinahe jederzeit sicherzustellen und nimmt Privatsphäre sehr ernst - genau wie Monero.
 
-Hopefully a future MMS will build on Monero's "native" private communication system, [Kovri](https://kovri.io/), but we are probably still quite some time away from a Kovri release ready for broad use.
+Ein zukünftiges MMS wird hoffentlich auf Moneros "eigenem", privaten Kommunikationssystem ([Kovri](https://kovri.io/)) aufgebaut; wir sind aber wahrscheinlich immer noch eine ganze Weile von der Veröffentlichung einer breit verwendbaren Kovri-Version entfernt.
 
-MMS communications should be **safe**: The Bitmessage system is considered safe as it's completely invisible who sends messages to whom, and all traffic is encrypted. For additional safety the MMS encrypts any message contents itself as well: Nobody except the receiver of an MMS message can decrypt and use its content, and the messages are signed, meaning the receiver can be sure they come from the right sender.
+Kommunikationen des MMS sollten **sicher** sein: Das Bitmessage-System wird als sicher erachtet, da Informationen darüber, wer an wen Nachrichten sendet, komplett unsichtbar sind. Jeder Datenverkehr ist verschlüsselt. Für zusätzliche Sicherheit verschlüsselt das MMS auch alle Inhalte jeder Nachricht: Abgesehen vom Empfänger einer MMS-Nachricht kann niemand ihre Inhalte entschlüsseln und verwenden. Außerdem sind die Nachrichten signiert, wodurch der Empfänger sicher sein kann, dass sie von den richtigen Sendern stammen.
 
-## The MMS User Experience
+## Das Benutzererlebnis des MMS
 
-To see the "user experience" of multisig in the CLI wallet **without** MMS you can e.g. check [here](https://taiga.getmonero.org/project/rbrunner7-really-simple-multisig-transactions/wiki/22-multisig-in-cli-wallet) and [here](https://taiga.getmonero.org/project/rbrunner7-really-simple-multisig-transactions/wiki/23-multisig-in-cli-wallet).
+Um **ohne** MMS das "Benutzererlebnis" des Multisigs im CLI-Wallet zu erfahren, kannst du bspw. [hier](https://taiga.getmonero.org/project/rbrunner7-really-simple-multisig-transactions/wiki/22-multisig-in-cli-wallet) und [hier](https://taiga.getmonero.org/project/rbrunner7-really-simple-multisig-transactions/wiki/23-multisig-in-cli-wallet) nachsehen.
 
-Those pages are also useful to familiarize yourself with the steps for multisig transactions in general, as the MMS will not change the order of the steps or make any of them superfluous, but will just make execution considerably easier, and the MMS will be able to tell you the next step in order automatically in most cases.
+Diese Seiten sind auch nützlich, um sich mit den Schritten von Multisig-Transaktionen im Allgemeinen vertraut zu machen. Das MMS wird weder die Schrittfolge ändern oder irgendeinen dieser Schritte überflüssig machen, aber es wird die Ausführung deutlich vereinfachen. Dabei wird das MMS dazu in der Lage sein, dir in den meisten Fällen automatisch und der Reihe nach die nächsten Schritte mitzuteilen.
 
-### A Messaging System
+### Ein Nachrichtensystem
 
-The general approach of the MMS is very **similar to e-mail**: You send messages around, with the MMS command set in the CLI wallet playing the part of your e-mail client, allowing you to send messages, receive messages and manage a list of stored messages, something like a combined inbox and outbox.
+Der allgemeine Ansatz der MMS ist ziemlich **ähnlich zur E-Mail**: Wenn du Nachrichten umhersendest, agieren die MMS-Befehle im CLI-Wallet als dein E-Mail-Client und erlauben es dir damit, Nachrichten zu senden, zu empfangen und außerdem ein Verzeichnis abgespeicherter Nachrichten zu unterhalten - in etwa wie ein kombinierter Postein- und ausgang.
 
-The contents of those messages are of course all those things that must be transported between the wallets of the signers: key sets, wallet sync data, transactions to sign and/or submit to the network.
+Der Inhalt dieser Nachrichten umfasst natürlich all die Dinge, die zwischen den Wallets der Unterzeichner umhertransportiert werden müssen: Sätze von Schlüsseln, Synchronisationsdaten von Wallets und eben die zu signierenden und/oder im Netzwerk einzureichenden Transaktionen.
 
-PyBitmessage is used for the actual message transport and thus plays the part of your e-mail server. Once configuration is done sending and receiving messages is fully automatic i.e. needs no manual intervention.
+PyBitmessage wird hierbei für den tatsächlichen Nachrichtentransport genutzt und übernimmt damit die Aufgabe deines E-Mail-Servers. Sobald die Einrichtung abgeschlossen ist, läuft das Senden und Empfangen von Nachrichten komplett automatisch ab und benötigt damit keinen manuellen Eingriff.
 
-You don't use e-mail addresses, but Monero addresses to tell where messages should go, and you only ever send messages to other authorized signers: E.g. with 2/3 multisig you only have 2 partners to send something to.
+Statt E-Mail-Adressen werden Monero-Adressen genutzt, welche die Ziele der Nachrichten kennen. Du schickst Nachrichten immer nur an autorisierte Unterzeichner: Mit einem 2/3-Multisig hast du bspw. lediglich zwei Partner, an die du etwas sendest.
 
-Like with e-mail people don't have to be online at the same time for message transport to work: PyBitmessage will keep messages for up to 2 days, giving you time to fetch them.
+Wie bei E-Mails müssen Personen nicht gleichzeitig online sein, damit der Nachrichtentransport funktioniert: PyBitmessage speichert Nachrichten für bis zu zwei Tage und gibt dir damit Zeit, sie abzurufen.
 
-The approach is in general quite flexbile and robust: If you need messages from several signers to proceed the MMS will wait until it finds all of them in the list of received messages, and the order of reception does not matter either, which results in a quite unstressed experience.
+Im Allgemeinen ist dieser Ansatz ziemlich flexibel und robust: Solltest du zum Fortfahren Nachrichten mehrerer Unterzeichner benötigen, wartet das MMS, bis es all diese in seiner Liste empfangener Nachrichten findet. Hierbei ist die Empfangsreihenfolge unwichtig, wodurch ein ziemlich entspanntes Nutzererlebnis generiert wird.
 
-If another signer tells you that a particular message did not arrive or was lost somehow you can send it again anytime, picking it from the message list, like you would re-send an e-mail in a similar situation.
+Wenn dir ein Unterzeichner mitteilt, dass eine bestimmte Nachricht nicht angekommen oder gar verschwunden ist, kannst du sie jederzeit erneut senden, indem du sie in der Nachrichtenliste auswählst - genauso, als würdest du in einer ähnlichen Situation eine E-Mail erneut absenden.
 
-### Signers and Messages
+### Unterzeichner und Nachrichten
 
-So, where a "normal" Monero wallet without MMS simply told manages three types of data (addresses, accounts and transactions), the MMS adds two more: Signers and messages.
+Während also ein "normales" Monero-Wallet ohne MMS - einfach gesagt - drei Arten von Daten (Adressen, Konten und Transaktionen) managt, fügt das MMS zwei weitere hinzu: Unterzeichner und Nachrichten.
 
-The MMS manages, for each multisig wallet separately, a list of *authorized signers*. With 2/3 multisig that list has **three** entries. On a technical level, each entry represents a Monero wallet containing keys that can be used to sign multisig transactions. On a conceptual level it's easier to imagine a group of 3 people, i.e. yourself and 2 partners, as those "authorized signers". (Often there will be indeed 3 distinct people controlling the 3 wallets, but not always of course.)
+Für jedes einzelne Multisig-Wallet managt das MMS eine separate Liste *autorisierter Unterzeichner*. Mit einem 2/3-Multisig umfasst eine solche Liste **drei** Einträge. Technisch gesehen repräsentiert jeder Eintrag ein Monero-Wallet, das zum Signieren von Multisig-Transaktionen verwendbare Schlüssel enthält. Konzeptuell gesehen ist es wohl einfacher, sich eine Gruppe von drei Leuten (etwa dich und zwei Partner) als ebendiese "autorisierten Unterzeichner" vorzustellen. (Häufig werden diese drei Wallets tatsächlich von drei verschiedene Menschen kontrolliert; dies ist aber natürlich nicht immer der Fall.)
 
-The MMS also manages a single list of *messages* per wallet: All messages you send, plus all messages you receive. While the list of authorized signers is the same in all involved wallets, those messages of course differ. The more authorized signers there are to send you messages, and the longer you transact, the more messages will accumulate.
+Das MMS unterhält außerdem eine einzelne Liste von *Nachrichten* pro Wallet, welche alle gesendeten und alle empfangenen Nachrichten enthält. Zwar ist die Liste autorisierter Unterzeichner in allen involvierten Wallets dieselbe, die Nachrichten unterscheiden sich jedoch. Je mehr autorisierte Unterzeichner vorhanden sind (die dir Nachrichten senden) und je länger du Transaktionen durchführst, desto mehr Nachrichten sammeln sich an.
 
-## Getting the MMS
+## Das MMS erhalten
 
-Right now, at the time of writing this manual (year-end 2018), the MMS is only available as part of the latest Monero code (`master` branch on Monero's [GitHub repository](https://github.com/monero-project/monero)). To use it, you have to check out that source code and compile it yourself. Doing so is easiest on a Linux system.
+Jetzt gerade, während des Verfassens dieser Anleitung (Jahresende 2018), ist das MMS nur als Teil des aktuellsten Monero-Codes (der `master`-Zweig in Moneros [GitHub-Repository](https://github.com/monero-project/monero)) verfügbar. Um es zu nutzen, musst du diesen Quellcode prüfen und eigenständig kompilieren. Das geht am einfachsten auf einem Linuxsystem.
 
-With the next hardfork in Spring 2019 the MMS will become an integral standard part of the Monero software: You install Monero, you have it.
+Mit dem nächsten Hardfork im Frühling 2019 wird das MMS zu einem integralen Bestandteil der Monero-Software: Du installierst Monero, du hast das MMS.
 
-A word of caution: At the time of writing using the latest development Monero version does not lead to conflicts and complications with any regular Monero release software and downloaded blockchain on the same system, but that may change between now and the hardfork, especially near the hardfork.
+Ein Wort der Warnung: Zur Zeit des Verfassens führt die Nutzung der aktuellsten Entwicklungsversion Moneros zu keinerlei Konflikten und Problemen mit jeglicher regulärer Versionssoftware und heruntergeladener Blockchain auf demselben System. Dies könnte sich aber in der Zwischenzeit von jetzt bis zum Hardfork - besonders um die Zeit des Hardforks herum - ändern.
 
-## Installing and Configuring PyBitmessage
+## PyBitmessage installieren und einrichten
 
-Installing PyBitmessage is easy enough: You find links to downloads and install instructions from the [Bitmessage Wiki homepage](https://bitmessage.org/wiki/Main_Page). There are versions for all the major OS that Monero also supports: Linux, Windows, and macOS.
+Die Installation von PyBitmessage ist einfach: Du findest Links zu Downloads und Installationsanleitungen auf der [Seite des Bitmessage-Wiki](https://bitmessage.org/wiki/Main_Page). Dort sind Versionen für alle geläufigen, durch Monero unterstützten Betriebssysteme verfügbar: Linux, Windows und macOS.
 
-After installing run it, configure a Bitmessage address for you and note it, as you will later need it to configure your multisig wallet.
+Führe das Programm nach dem Installieren aus, richte eine Bitmessage-Adresse für dich ein und notiere diese, da du sie später zum Einrichten deines Multisig-Wallets benötigen wirst.
 
-Don't worry right away if PyBitmessage does not seem to connect to the Bitmessage network when you run it the first time: Due to the decentral nature of that network it can take quite some time for your initial connect. It seems this often takes **half an hour**.
+Mache dir keine Sorgen, wenn sich PyBitmessage nach dem ersten Start nicht gleich zum Bitmessage-Netzwerk zu verbinden scheint: Aufgrund des dezentralen Charakters dieses Netzwerks kann es bis zur ersten Verbindung eine ganze Weile dauern. Es scheint, als dauere dies häufig eine **halbe Stunde**.
 
-Likewise sending the very first message to a brand-new Bitmessage address can take time because there is a key exchange involved, sometimes another half of an hour. Once the key exchange is done messages are typically delivered within a few minutes however, sometimes within seconds.
+Ebenso kann das Senden der allerersten Nachricht an eine brandneue Bitmessage-Adresse einige Zeit - manchmal eine weitere halbe Stunde - dauern, weil hier ein Schlüsselaustausch involviert ist. Sobald dieser abgeschlossen ist, werden Nachrichten üblicherweise innerhalb weniger Minuten und manchmal schon nach Sekunden zugestellt.
 
-You don't need to configure more than one Bitmessage address for you. You can run several multisig wallets over a **single** address without any problems because the MMS will be able to pick the right messages for the right wallets. You can even continue to use the same address for "normal" messages; those won't disturb the MMS, it will simply ignore any messages not intended for it.
+Du musst nicht mehr als eine Bitmessage-Adresse für dich einrichten. Du kannst problemlos mehrere Multisig-Wallets über eine **einzige** Adresse betreiben, weil das MMS die richtigen Nachrichten für die jeweils korrekten Wallets herausfiltert. Du kannst sogar dieselbe Adresse für "normale" Nachrichten verwenden; da das MMS schlicht jegliche Nachrichten, die nicht für ebenjenes gedacht sind, ignoriert, werden diese es nicht stören.
 
-Out of the box your PyBitmessage installation is not yet ready for use with the MMS because it does not allow other programs to use its API per default, you have to enable this explicitely (which makes sense, of course, for security reasons).
+Die vorkonfigurierte PyBitmessage-Installation ist in Verbindung mit dem MMS zunächst nicht einsatzbereit. Da es anderen Programmen standardmäßig die Verwendung seines APIs verwehrt, muss die entsprechende Berechtigung erst explizit erteilt werden (aus Sicherheitsgründen ergibt dies natürlich Sinn).
 
-You find instructions how to **enable the API** on the [Bitmessage wiki API reference page](https://bitmessage.org/wiki/API_Reference). You will use the user name and the password you choose here later as command-line parameters for the CLI wallet so that the MMS will be able to log in to PyBitmessage.
+Anleitungen bezüglich der **Freigabe des APIs** finden sich auf der [Bitmessage-Wiki-Seite zur "API reference"](https://bitmessage.org/wiki/API_Reference). Der hier gewählte Nutzername und das Passwort werden später als Befehlszeilenparameter für das CLI genutzt, damit der Log-in des MMS in PyBitmessage ermöglicht wird.
 
-## Further PyBitmessage Tweaks
+## Weitere PyBitmessage-Optimierungen
 
-The current official release version 0.6.3.2 has a [Dandelion++ protocol extension](https://arxiv.org/abs/1805.11060) built-in that hardens the network further against attacks that try to track message flow to find out who sends messages to whom. Unfortunately it seems that it has still a bug somewhere that can lead to wildly differing and very long message transmission times which is quite unfortunate when using the MMS.
+Die aktuelle, offizielle Freigabeversion 0.6.3.2 verfügt über eine eingebaute [Dandelion++-Protokollerweiterung](https://arxiv.org/abs/1805.11060), die das Netzwerk gegenüber Angriffen, in welchen versucht wird, durch Verfolgen des Nachrichtenflusses Sender und Empfänger von Nachrichten auszumachen, verstärkt. Unglücklicherweise scheint irgendwo ein Bug zu existieren, der zu sehr unterschiedlichen und extrem langen Nachrichtenübertragungszeiten führen kann - beim Verwenden des MMS ist das ziemlich unerfreulich.
 
-There is a way to switch off Dandelion++ which, in general, is not recommended of course, but useful for using the MMS as of now:
+Es besteht die Möglichkeit, Dandelion++ auszuschalten. Dies wird natürlich nicht empfohlen, kann für den Augenblick allerdings durchaus nützlich sein, um das MMS verwenden zu können:
 
-* Locate PyBitmessage's config file `keys.dat`
-* Make a new section there named `[network]`
-* Add the following line to this new section: `dandelion = 0`
-* Restart PyBitmessage
+* Lokalisiere die PyBitmessage-Konfigurationsdatei `keys.dat`
+* Erstelle dort einen neuen, `[network]` genannten Abschnitt
+* Füge zu diesem neuen Abschnitt folgende Zeile hinzu: `dandelion = 0`
+* Starte PyBitmessage erneut
 
-As a "good citizen" you may consider to open your PC for access from other Bitmessage nodes to your node from the outside by opening port 8444. You find background info about that in their [FAQ](https://bitmessage.org/wiki/FAQ). It's not strictly necessary however for your client to function.
+Als "guter Bürger" möchtest du anderen Bitmessage-Nodes eventuell den Zugriff auf deinen Node ermöglichen. Dies erreichst du durch Öffnen des Ports 8444. Hintergrundinformationen darüber findest du im [Bitmessage-FAQ](https://bitmessage.org/wiki/FAQ). Damit dein Client funktioniert, ist dies aber nicht unbedingt notwendig. 
 
-## MMS Command Overview
+## Befehlsübersicht des MMS
 
-There is only **one** new command in the CLI wallet that gives access to the MMS, sensibly called `mms`. That command has however quite a number of subcommands to handle all the various functions of the MMS. Here a list of the commands; for details each command has its own chapter later in the manual:
+Es gibt lediglich **einen** neuen Befehl im CLI-Wallet, der den Zugriff auf das MMS ermöglicht und - ganz zweckmäßig - die Bezeichnung `mms` trägt. Allerdings hat dieser Befehl eine ganze Zahl an Unterbefehlen, mit denen die verschiedenen Funktionen des MMS bedient werden. Hier ist eine Liste dieser Befehle; jeder Befehl hat aber auch im späteren Verlauf dieser Anleitung sein eigenes, detailliertes Kapitel.
 
-    init        Initialize and configure the MMS
-    info        Display current MMS configuration
-    signer      Define a signer by giving a single-word label, a transport address, and a Monero address, or list all defined signers
-    list        List all messages
-    next        Evaluate the next possible multisig-related action(s) according to wallet state, and execute or offer for choice
-    sync        Force generation of multisig sync data regardless of wallet state, to recover from special situations like "stale data" errors
-    transfer    Initiate transfer with MMS support; arguments identical to normal 'transfer' command arguments, for info see there
-    delete      Delete a single message by giving its id, or delete all messages by using 'all'
-    send        Send a single message by giving its id, or send all waiting messages
-    receive     Check right away for new messages to receive
-    note        Send a one-line note message to a signer, identified by its label, or show all unread notes
-    show        Show detailed info about a single message
-    export      Export the content of a message to file
-    set         Set options, 'auto-send' being the only one so far
-    
-    start_auto_config   Start the auto-config process at the auto-config manager's wallet by creating new tokens
-    auto_config         Start auto-config by using the token received from the auto-config manager
-    stop_auto_config    Delete any tokens and abort an auto-config process
-    send_signer_config  Send your complete signer configuration to all other signers
-    
-You get the list of commands by issuing `help mms`, and help for a particular subcommand by using `help mms <subcommand>`, e.g. `help mms next`. You can alternatively use `mms help <subcommand>` if that feels more natural.
+    init        MMS initialisieren und einstellen
+    info        Aktuelle MMS-Einstellung anzeigen
+    signer      Einen Unterzeichner durch ein Ein-Wort-Label, eine Transportadresse und eine Monero-Adresse bestimmen oder alle festgelegten Unterzeichner auflisten
+    list        Alle Nachrichten auflisten
+    next        Die nächste(n) potentielle(n) Multisig-bezogenen Aktion(en) gemäß Wallet-Status auswerten und wahlweise zeigen oder ausführen 
+    sync        Erstellung von Multisig-Synchronisationsdaten ungeachtet des Wallet-Status, um nach besonderen Situationen, etwa Fehlern aufgrund "veralteter Daten", wiederherzustellen
+    transfer    Übertragung mit MMS-Unterstützung einleiten; Argumente sind identisch mit üblichen "transfer"-Befehlen, für Infos dort nachsehen
+    delete      Eine einzelne Nachricht durch Angabe ihrer ID löschen oder unter Verwendung von "all" alle Nachrichten löschen
+    send        Eine einzelne Nachricht durch Angabe ihrer ID versenden oder alle ausstehenden Nachrichten senden
+    receive     Unmittelbar auf zu empfangene Nachrichten überprüfen
+    note        Eine einzeilige, durch ihr Label gekennzeichnete Notiz als Nachricht an einen Unterzeichner senden oder alle ungelesenen Notizen anzeigen
+    show        Detaillierte Infos über eine einzelne Nachricht anzeigen
+    export      Den Inhalt einer Nachricht in eine Datei exportieren
+    set         Einstellungen festlegen; die einzige Option ist bislang 'auto-send'    
+    start_auto_config   Den Auto-Config-Prozess im Wallet des Auto-Config-Managers durch Erstellen neuer Token starten
+    auto_config         Auto-Config unter Verwendung des vom Auto-Config-Manager erhaltenen Token starten
+    stop_auto_config    Jegliche Token löschen und Auto-Config-Prozess abbrechen  
+    send_signer_config  Deine gesamte Unterzeichner-Konfiguration an alle anderen Unterzeichner senden
 
-## Configuring a Wallet for Use with the MMS
+Du erhältst die Liste der Befehle durch Erteilen des `help mms`-Befehls. Durch `help mms <subcommand>` (bspw. `help mms next`) erhältst du Hilfestellung für einen bestimmten Unterbefehl. Alternativ kannst du `mms help <subcommand>` nutzen, wenn dir das natürlicher erscheint.
 
-### Addresses and Labels
+## Ein Wallet zur Nutzung mit MMS einrichten
 
-First for better understanding some basic facts about addressing and referring to signers (or their wallets respectively) in the MMS:
+### Adressen und Labels
 
-If you create a new wallet it gets (of course) its own, unique public Monero address. If you later configure the wallet for multisig, the wallet **changes** its public address to the common multisig address that you share with all the other authorized signers.
+Zwecks besserer Verständlichkeit hier einige grundlegende Fakten zum Adressieren von Unterzeichnern und Verweisen an ebendiese (bzw. ihre Wallets) via MMS:
 
-The MMS uses the first, "original" public Monero address over the whole wallet lifetime for addressing, before **and** after "going multisig". It may be a little confusing that a wallet should have **two** public addresses somehow, but once you got the original address into your signer configuration you can more or less forget about it.
+Wenn du ein neues Wallet erstellst, bekommt dieses (natürlich) seine eigene, einzigartige, öffentliche Monero-Adresse. Konfigurierst du das Wallet später für Multisig, **ändert** das Wallet seine öffentliche Adresse in die gemeinsame Multisig-Adresse, welche du mit allen anderen autorisierten Unterzeichnern teilst, ab.
 
-The MMS uses *labels* that allow you to name yourself and the other signers, and that the MMS commands use when referring to signers. (Using Monero addresses or Bitmessage addresses in such commands would be quite cumbersome.)
+Das MMS nutzt über die gesamte Laufzeit des Wallets zum Adressieren die erste, "ursprüngliche", öffentliche Monero-Adresse, vor **und** nach dem Übergang zu Multisig. Es mag etwas verwirrend sein, dass ein Wallet irgendwie **zwei** öffentliche Adressen haben sollte; sobald die ursprüngliche Adresse in deine Unterzeichner-Einstellung integriert ist, musst du nicht mehr wirklich darüber nachdenken.
 
-Labels must be one word, and they must be unique within a single wallet. The example later on in this manual uses the labels `alice` and `bob` for a case of 2/2 multisig.
+Das MMS verwendet *Labels*, die es dir erlauben, dich selbst und andere Unterzeichner zu benennen. Diese Labels nutzt das MMS, wenn es an Unterzeichner verweist. (In solcherlei Befehlen wäre es ziemlich mühselig, Monero- oder Bitmessage-Adressen zu verwenden.)
 
-### Running CLI Wallet
+Labels müssen aus einem Wort bestehen und innerhalb eines einzelnen Wallets einzigartig sein. In einem späteren Beispiel innerhalb dieser Anleitung werden für ein 2/2-Multisig die Labels `alice` und `bob` genutzt.
 
-When you start the CLI wallet for use with the MMS there are the following two new (optional) command line parameters for connecting to PyBitmessage:
+### CLI-Wallet starten
+
+Wenn du das CLI-Wallet zum Gebrauch mit dem MMS öffnest, existieren zwei neue (optionale) Befehlszeilenparameter, um zu PyBitmessage zu verbinden:
 
     --bitmessage-address	Use PyBitmessage instance at URL <arg>
     --bitmessage-login		Specify <arg> as username:password for PyBitmessage API
 
-If you have PyBitmessage running on the same machine as the CLI wallet the default for the first parameter will do, and you should not need to set anything different. If it does not seem to find it despite running locally try to use `http://localhost` or `http://127.0.0.1` as argument for the first parameter.
+Wenn du auf dem gleichen Gerät sowohl PyBitmessage als auch das CLI-Wallet betreibst, ist die Voreinstellung des ersten Parameters ausreichend und es sollte nicht notwendig sein, eine andere Einstellung vorzunehmen. Wenn diese Voreinstellung trotz lokalen Betriebs nicht gefunden wird, kannst du versuchen, `http://localhost` oder `http://127.0.0.1` als Argument für den ersten Parameter zu verwenden.
 
-Beside that, you need of course either `--testnet` or `--stagenet` to connect to the right network. Also using `--log-level 0` could be useful: This instructs the wallet to write detailed info into its logfile that might help to find bugs or problems with the MMS.
+Um dich zum richtigen Netzwerk zu verbinden, benötigst du daneben natürlich entweder `--testnet` oder `--stagenet`. Auch der Gebrauch von `--log-level 0` könnte nützlich sein: Das Wallet wird hierdurch angewiesen, detaillierte Infos in seine Logdatei zu schreiben, welche zum Finden von Bugs oder Problemen innerhalb des MMS hilfreich sein könnten.
 
-So a complete command line for the CLI wallet could look like this:
+Eine komplette Befehlszeile für das CLI-Wallet könnte also so aussehen:
 
     ./monero-wallet-cli --testnet --bitmessage-login mmstest:p4ssw0rd --log-level 0
 
-### Initializing the MMS
+### MMS initialisieren
 
-After creating a new wallet you have to initialize it for use with the MMS; without that crucial first step you won't be able to use any MMS features. The command to do so is `mms init`:
+Nach dem Erstellen eines neuen Wallets musst du es zunächst für den Gebrauch mit dem MMS vorbereiten, da es dir ohne diesen essenziellen ersten Schritt nicht möglich sein wird, jegliche MMS-Funktionen zu nutzen. Der entsprechende Befehl lautet `mms init`:
 
     mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>
 
-`own_transport_address` is the Bitmessage address that you configured in your own PyBitmessage program. A full `init` command could look like this:
+`own_transport_address` ist die Bitmessage-Adresse, welche du in deinem eigenen PyBitmessage-Programm eingestellt hast. Ein kompletter `init`-Befehl könnte wie folgt aussehen:
 
     mms init 2/2 alice BM-2cUVEbbb3H6ojddYQziK3RafJ5GPcFQv7e
 
-Use that `init` command **only once**: Executing it a second time will completely re-initialize the MMS by deleting any signer info and any messages, which you don't want except in special circumstances.
+Nutze diesen `init`-Befehl nur **ein Mal**: Eine zweite Ausführung würde das MMS durch Löschen jeglicher Unterzeichner-Informationen und Nachrichten neu initialisieren; abgesehen von besonderen Umständen ist dies nicht gewünscht. 
 
-If you want to go through a MMS test as fast as possible you can instruct the wallet to ask for the password only when strictly necessary for technical reasons, and tell the MMS to send any generated message right away instead of prompting before doing so:
+Wenn du einen MMS-Test schnellstmöglich durchführen möchtest, kannst du dein Wallet anweisen, das Passwort nur im technisch unbedingt notwendigen Fall abzufragen. Außerdem kannst du dem MMS befehlen, jede erstellte Nachricht direkt und ohne vorheriges Anzeigen abzusenden: 
 
     set ask-password 0
     mms set auto-send 1
 
-(Both those settings are active during the 2/2 multisig example shown in this manual.)
+(Beide Einstellungen sind in dem in dieser Anleitung angeführten 2/2-Multisig-Beispiel aktiviert.)
 
-### Configuring Signers
+### Unterzeichner einrichten
 
-About each signer the MMS needs to know three things:
+Das MMS muss drei Infos eines jeden Unterzeichners wissen:
 
-* The one-word *label* that you will use to refer to that signer
-* The *transport address* which currently means their Bitmessage address as long as this is the only supported message transport system
-* The *Monero address* i.e. the "original" Monero address of their wallet
+* Das Ein-Wort-*Label*, um an diesen Unterzeichner weiterzuleiten
+* Die *Transportadresse*, was derzeit und bis zur Unterstützung anderer Nachrichtentransportsysteme die Bitmessage-Adresse ist
+* Die *Monero-Adresse*, sprich die *ursprüngliche* Monero-Adresse des Wallets
 
-(See also above chapter *Addresses and Labels*.)
+(Siehe auch das vorhergehende Kapitel *Adressen und Labels*.)
 
-You don't have to create signers; after the `mms init` command they are already all "there", although without any info yet with the exception of yourself. The commands for setting signer information refer to them by number, 1 up to the total number of authorized signers, so 1 and 2 in the following 2/2 multisig example with signers named *Alice* and *Bob* and thus with the labels *alice* and *bob*.
+Du musst die Unterzeichner nicht erst erstellen: Nach dem `mms init`-Befehl sind die bereits "da", obgleich bisher - mit Ausnahme von dir selbst - ohne jegliche Info. Die Befehle zum Einstellen der Unterzeichnerinformationen beziehen sich via Nummer auf die jeweiligen Unterzeichner, von eins bis hin zur Gesamtzahl der autorisierten Unterzeichner. Im folgenden 2/2-Multisig-Beispiel sind das also die Zahlen "1" und "2" für Unterzeichner mit den Namen "Alice" und "Bob" und damit den Labeln *alice* und *bob*.
 
-After the above sample `init` command the list of signers looks like that:
+Nach dem obigen, beispielhaftem Ausführen des `init`-Befehls würde die Unterzeichnerliste also so aussehen:
 
      # Label                Transport Address
        Auto-Config Token    Monero Address
@@ -281,37 +280,37 @@ After the above sample `init` command the list of signers looks like that:
      2 <not set>            <not set>
                             <not set>
 
-Note that signer #1 is always "me" i.e. your own label, transport address and Monero address. So in Alice's signer list #1 will be Alice and #2 will be Bob, while in Bob's wallet it will be exactly the other way round.
+Beachte, dass Unterzeichner Nr. 1 immer "du" bist, also dein eigenes Label, deine Transport- und deine Monero-Adresse. In Alice' Unterzeichnerliste wird Alice selbst als Nr. 1 und Bob als Nr. 2 aufgeführt sein. In Bobs Wallet wäre es dagegen genau umgekehrt.
 
-There are **three ways** to complete signer information: You can enter it manually, or you can use the auto-config mechanism that the MMS offers, which has a second, "semi-automatic" variant. With 2/2 there is hardly a difference in effort, but with higher numbers of signers auto-config is easier and more reliable. In any case, one advantage of auto-config is a secure transport of addresses because PyBitmessage is used.
+Zum Vervollständigen der Unterzeichnerinformationen gibt es **drei Wege**: Du kannst diese manuell eingeben oder den vom MMS angebotenen Auto-Config-Vorgang (oder dessen "halbautomatische" Variante) nutzen. Bei 2/2 macht dies wohl keinen großen Unterschied bezüglich des Arbeitsaufwands, mit höheren Anzahlen von Unterzeichnern ist Auto-Config jedoch leichter und verlässlicher. Ein Vorteil von Auto-Config ist aufgrund der Nutzung von PyBitmessage in jedem Fall ein sicherer Adressentransport.
 
-So pick **one** method from the three following chapters *Manually Configuring Signers*, *Auto-Config* and *Sending Signer Information*:
+Wähle also **eine** Methode aus den drei folgenden Kapiteln (*Unterzeichner manuell einrichten*, *Auto-Config* und *Unterzeichnerkonfiguration senden*) aus:
 
-### Manually Configuring Signers
+### Unterzeichner manuell einrichten
 
-The command to manually enter signer info and display the list of signers is `mms signer`:
+Zur manuellen Eingabe der Unterzeichnerinformationen und zum Anzeigen der Unterzeichnerliste wird der Befehl `mms signer` ausgeführt:
 
 	mms signer [<number> <label> [<transport_address> [<monero_address>]]]
 
-Without any argument the command displays the list of signers. With at least a number and a label you can set or change info about a particular signer. A full command to set everything about signer #2 could look like this:
+Ohne Argument zeigt dieser Befehl die Unterzeichnerliste an. Mit mindestens einer Nummer und einem Label kannst du Infos über einen bestimmten Unterzeichner festlegen oder ändern. Ein kompletter Befehl, mit welchem jegliche Infos über Unterzeichner Nr. 2 festgelegt werden, könnte in etwa so aussehen:
 
 	mms signer 2 bob BM-2cStcTfCx8D3McrMcmGZYZcF4csKcQT2pa 9yXKZ6UUdd8NnNN5UyK34oXV7zp7gjgZ4WTKHk8KzWsAAuyksfqoeRMLLkdWur85vnc1YL5E2rrMdPMHunA8WzUS9EL3Uoj
 
-A command to later change only the label of signer #2 could be:
+Zum späteren Abändern des Labels von Unterzeichner Nr. 2 könnte der Befehl wie folgt aussehen:
 
 	mms signer 2 bob-the-builder
 
-With this manual method it's up to the signers *how* they all get to know each other's addresses.
+Bei dieser manuellen Methode ist es Sache der Unterzeichner, *wie* jeder die Adressen der jeweils anderen erfährt.
 
-Be careful while entering signer information: Any mistakes like wrong Bitmessage addresses will probably make it impossible to correctly transact later on.
+Lasse während der Eingabe von Unterzeichnerinformationen Sorgfalt walten: Jegliche Fehler (etwa falsche Bitmessage-Adressen) werden eine korrekte Transaktion wahrscheinlich später unmöglich machen.
 
-Before you go out and start to exchange signer information over insecure channels like IRC or plain unencrypted e-mail, please note that there are certain dangers in doing so. If somebody can e.g. intercept your e-mails and get hold of your addresses that you send to a signer that person can then impersonate the signer.
+Bevor du nun aber anfängst, Unterzeichnerinformationen über unsichere Kanäle wie IRC oder mithilfe gewöhnlicher, unverschlüsselter E-Mails auszutauschen, beachte bitte, dass diese Vorgehensweise bestimmte Gefahren mit sich bringen kann. Sollte jemand bspw. deine E-Mails abfangen und so an deine Adressen, die du eigentlich an einen Unterzeichner gesendet hast, gelangen, könnte sich diese Person als der jeweilige Unterzeichner ausgeben.
 
-There is also the danger that in a 2/3 multisig scenario for *escrow* signer Bob can set up a second wallet for the trusted third-party Trent beside his own and trick Alice into sending everything to that wallet instead of Trent's. After this Bob will be able to transact alone and steal coins from Alice.
+In einem Szenario mit einem 2/3-Multisig zwecks *Hinterlegung* besteht außerdem die Gefahr, dass Unterzeichner Bob neben seinem eigenen Wallet ein zweites für den vertrauenswürdigen Dritten Trent eröffnet und Alice dazu verleitet, alles an dieses anstatt an Trents eigentliches Wallet zu senden. Danach wäre Bob in der Lage, eigenständig zu transferieren und Coins von Alice zu stehlen.
 
-You find a more detailed explanation of this second danger in chapter *Security* towards the end of the manual or [here](https://taiga.getmonero.org/project/rbrunner7-really-simple-multisig-transactions/wiki/multisig-and-insecure-communication-channels). Auto-config mitigates this danger to quite some extent.
+Eine detailliertere Erklärung dieser zweiten Gefährdung findet sich gegen Ende der Anleitung im Kapitel *Sicherheit* oder auch [hier](https://taiga.getmonero.org/project/rbrunner7-really-simple-multisig-transactions/wiki/multisig-and-insecure-communication-channels). Auto-Config schwächt diese Gefahr in einem ganz guten Ausmaß ab.
 
-Alice's complete signer list looks like this:
+Alice' vollständige Unterzeichnerliste sieht so aus:
 
      # Label                Transport Address
        Auto-Config Token    Monero Address
@@ -323,46 +322,46 @@ Alice's complete signer list looks like this:
 
 ### Auto-Config
 
-MMS auto-config is based on so-called *auto-config tokens*. Such tokens are always 11 characters long, the fixed string "mms" followed by 8 hexadecimal digits. Examples for such tokens are `mms561832e3eb` and `mms62cb2b87e2`.
+MMS-Auto-Config basiert auf den sogenannten *Auto-Config-Token*. Derlei Token haben stets eine Länge von elf Zeichen: die feste Reihung von "mms" gefolgt von acht Hexadezimalstellen. Beispiele für diese Art von Token sind `mms561832e3eb` und `mms62cb2b87e2`.
 
-The basic trick: Unlike Bitmessage addresses and Monero addresses those tokens are short enough to type them easily and e.g. use reasonably safe smartphone messenger apps or SMS to transmit them, or dictate them over the phone, again not perfectly safe, but still much safer than plain e-mail or IRC.
+Der simple Trick: Diese Token sind im Gegensatz zu Bitmessage- und Monero-Adressen kurz genug, um sie leicht eintippen zu können und z.B. in halbwegs sicheren Nachrichten-Apps auf dem Smartphone oder via SMS zu übersenden, oder auch telefonisch zu übermitteln - auch nicht absolut sicher, aber immer noch weitaus sicherer als E-Mail oder IRC.
 
-The workflow is as follows - it's simpler than it looks at first sight, go once through it in practice and it makes sense:
+Der Arbeitsablauf ist einfacher, als es auf den ersten Blick erscheint; nachdem er einmal praktisch durchgegangen wurde, ergibt alles Sinn. Er läuft ab wie folgt:
 
-* One signer takes on the job to lead and organize configuration, furthermore called *manager*
-* The manager assigns a label to each signer and enters all labels into the signer configuration, either using `mms signer` commands or giving them as arguments of the `mms start_auto_config` command in the next step
-* The manager uses the command `mms start_auto_config` to generate auto-config tokens for all other signers, one distinct token per signer
-* The manager transmits the tokens to their respective signers outside of the MMS
-* All other signers enter their token with `mms auto_config <token>`
-* Their wallets will generate messages that send their addresses to the manager's wallet, already using PyBitmessage
-* As soon as all those messages arrive there the manager can in turn send messages to all other signers containing the complete signer information by doing `mms next`
-* The other signers process those messages to complete their signer information with `mms next`
+* Ein Unterzeichner übernimmt Führung und Einrichtungsorganisation; im weiteren Verlauf *Manager* genannt
+* Der Manager weist jedem Unterzeichner ein Label zu und fügt alle Label in die Unterzeichnerkonfiguration (entweder durch `mms signer`-Befehle oder als Argumente des `mms start_auto_config`-Befehls im nächsten Schritt) ein
+* Der Manager nutzt den Befehl `mms start_auto_config` zum Erstellen von Auto-Config-Token für alle anderen Unterzeichner (jeweils ein eigener Token für jeden Unterzeichner)
+* Der Manager übermittelt die Token an die entsprechenden Unterzeichner außerhalb des MMS
+* Alle anderen Unterzeichner geben ihre Token mit dem Befehl `mms auto_config <token>` ein
+* Die Wallets der Unterzeichner erstellen nun (bereits unter Verwendung von PyBitmessage) Nachrichten, mit welchen die eigene Adresse an das Wallet des Managers gesendet wird
+* Sobald all diese Nachrichten im Wallet des Managers eingegangen sind, kann dieser wiederum durch Ausführen des Befehls `mms next` Nachrichten mit den gesammelten Unterzeichnerinformationen an alle anderen Unterzeichner senden
+* Um ihre Unterzeichnerinformationen zu vervollständigen, verarbeiten die anderen Unterzeichner diese Nachrichten mit `mms next`
 
-Several points are noteworthy here. Manual configuration with e.g. 5 signers could mean 5 times 4 = 20 initial manual information transfers, if each of the 5 signers sends addresses to 4 others. Even a more clever approach with someone collecting all addresses first and sending the complete list to all others then would take 4 plus 4 = 8 information transfers. With auto-config there are only **4** such manual transfers - 4 tokens from the manager out to the other signers; after that point it's already messages over PyBitmessage.
+Mehrere Punkte sind hierbei beachtenswert. Eine manuelle Einrichtung mit bspw. fünf Unterzeichnern könnte in zwanzig anfänglichen Informationsübertragungen resultieren, wenn jeder der fünf Unterzeichner Adressen an vier andere schickt (5 x 4 = 20). Selbst bei einem schlaueren Ansatz, bei welchem eine Person zunächst alle Adressen sammelt und diese als komplette Liste an alle Unterzeichner sendet, würde es zwei mal vier und damit schlussendlich immer noch acht Informationsübertragungen benötigen. Mit Auto-Config gibt es lediglich **vier** solcher manuellen Übertragungen - vier Token, die vom Manager an die anderen Unterzeichner gesendet werden. Danach findet der Nachrichtenaustausch bereits über PyBitmessage statt.
 
-You may wonder how the other signers' wallets can send their Bitmessage addresses back to the manager by using PyBitmessage. Doesn't this snake bite its own tail? The solution: A temporary, "throw-away" Bitmessage address is derived from each token and used just for this transfer, and temporary keys are derived as well for encrypting message content.
+Vielleicht wunderst du dich darüber, wie die Wallets der anderen Unterzeichner ihre Bitmessage-Adressen via PyBitmessage zurück an den Manager senden können. Beißt sich die Schlange hier nicht selbst in den Schwanz? Die Lösung: Es wird von jedem Token eine temporäre Wegwerf-Bitmessage-Adresse abgeleitet, die einzig und allein für diese Übertragung genutzt wird. Zwecks Verschlüsselung des Nachrichteninhalts werden zudem temporäre Schlüssel abgeleitet.
 
-Part of the increased safety of the auto-config process is the fact that each signer gets its own, distinct token. In 2/3 multisig, just make sure Bob cannot get hold of Trent's own token, and already Bob has no way to "play" Trent and set up a second wallet to be able to sign transactions all on his own.
+Bestandteil der erhöhten Sicherheit des Auto-Config-Vorgangs ist die Tatsache, dass jeder Unterzeichner seinen eigenen, individuellen Token erhält. Stelle schlicht sicher, dass Bob im Falle eines 2/3-Multisigs Trents eigenen Token nicht in die Finger bekommt; schon hat Bob keine Möglichkeit mehr, sich als Trent auszugeben und ein zweites Wallet zu erstellen, um jegliche Transaktionen auf eigene Faust zu signieren.
 
-### Sending Signer Configuration
+### Unterzeichnerkonfiguration senden
 
-Beside full auto-config there is a second, alternative way to make configuration easier, based on a command called `send_signer_config`. It's less "automatic", but you may prefer it because it's more transparent what happens.
+Nebst der vollen Auto-Config besteht mit dem Befehl `send_signer_config` eine zweite, alternative Möglichkeit, um die Einrichtung einfacher zu gestalten. Diese ist zwar weniger "automatisch", könnte aber aufgrund ihrer Transparenz innerhalb des Ablaufs präferiert werden.
 
-Here the workflow is as follows:
+Der Arbeitsablauf sieht wie folgt aus:
 
-* One signer takes on the job to lead and organize configuration, furthermore called *manager*
-* The manager receives from all other signers their addresses over channels outside the MMS, e.g. encrypted and signed e-mail
-* The manager enters complete signer information into their wallet, using `mms member` commands
-* The manager uses the `mms send_signer_config` command to send the completed information to all other signers
-* The other signers process the messages containing signer information with `mms next`
+* Ein Unterzeichner übernimmt Führung und Einrichtungsorganisation; im weiteren Verlauf *Manager* genannt
+* Der Manager erhält über Kanäle außerhalb des MMS, etwa via verschlüsselter und signierter E-Mail, von allen anderen Unterzeichnern die jeweiligen Adressen
+* Der Manager gibt unter Verwendung der `mms member`-Befehle die kompletten Unterzeichnerinformationen in seinem Wallet ein
+* Zum Senden der vervollständigten Informationen an alle anderen Unterzeichner nutzt der Manager den Befehl `mms send_signer_config`
+* Die anderen Unterzeichner verarbeiten die die Unterzeichnerinformationen enthaltenden Nachrichten mit `mms next`
 
-For all signers except the manager this is nearly as comfortable as auto-config. Note however that the security of the scheme depends on securing the sending of info to the manager: If some signer can posit as not only themselves, but as other signers as well, they will be able to control several wallets and undermine the whole signing process. (See also chapter *Manually Configuring Signers* for more about such dangers.)
+Außer für den Manager ist diese Option für alle Unterzeichner beinahe so komfortabel wie Auto-Config. Beachte jedoch, dass die Sicherheit eines so ausgeführten Systems von der Absicherung der Sendung von Infos an den Manager abhängt: Wenn einige Unterzeichner sich als mehrere einzelne Unterzeichner ausgeben können, werden diese in der Lage sein, mehrere Wallets zu kontrollieren und den gesamten Signierprozess zu untergraben. (Für weitere Infos über solcherlei Gefahren siehe Kapitel *Unterzeichner manuell einrichten*.)
 
-## Establishing the Multisig Address
+## Multisig-Adresse herleiten
 
-In general, there are no MMS commands to execute particular steps regarding multisig transactions (with the exception of starting a transfer using `mms transfer` and force sync with `mms sync`). You just use the `mms next` command, and the MMS will do whatever is next in the "multisig workflow", and if nothing is ready, e.g. because some messages are still missing, will tell you the reason why nothing is "next" yet.
+Grundsätzlich gibt es keine MMS-Befehle, mit denen bestimmte Schritte bezüglich Multisig-Transaktionen ausgeführt werden können (mit Ausnahme des Einleitens eines Transfers mit `mms transfer` und des Erzwingens der Synchronisierung mit `mms sync`). Du verwendest einfach den `mms next`-Befehl und das MMS führt den jeweils folgenden Schritt im "Multisig-Arbeitsablauf" aus. Ist noch nichts bereit (bspw. weil noch einige Nachrichten fehlen), wird dir der Grund dafür ausgegeben. 
 
-So, after you completed the info about all signers, either manually or through auto-config, you just issue a `mms next` command, and the MMS will start with the first step needed to establish the multisig address: Calculate *key sets* for all coalition members and set up messages to send those to them. The whole scene might look like this for Alice:
+Nachdem du nun alle Infos aller Unterzeichner, entweder manuell oder via Auto-Config, zusammengesammelt hast, erteilst du lediglich den `mms next`-Befehl. Durch diesen beginnt das MMS mit dem ersten notwendigen Schritt zur Etablierung bzw. Herleitung der Multisig-Adresse: Ermittle *Schlüsselsätze* für alle Gruppenmitglieder und setze Nachrichten auf, mit denen du diese Infos an die entsprechenden Mitglieder sendest. Der gesamte Vorgang könnte bei Alice wie folgt aussehen:
 
     [wallet A1VRwm]: mms next
     prepare_multisig
@@ -374,37 +373,37 @@ So, after you completed the info about all signers, either manually or through a
        1 out  bob: BM-2cStcTfCx8D3McrMcmGZ.. key set                     0   0 ready to send   2018-12-26 07:46:21, 1 seconds ago      
     Queued for sending.
 
-The `prepare_multisig` output there is a hint that the MMS works by putting something like a "wrapper" about the CLI wallet `pepare_multisig` command, it even displays the `MultisigV1` string for confirmation. Now you don't have to send that manually to the other signer somehow: The MMS prepares a message for that and sends it in a fully automatic way.
+Die `prepare_multisig`-Ausgabe ist hier ein Hinweis darauf, dass das MMS funktioniert, indem eine Art "Verpackung" um den CLI-Befehl `prepare_multisig` "geschlagen" wird. Zur Bestätigung wird sogar die `MultisigV1`-Zeichenkette angezeigt. Du musst dies nun nicht manuell auf irgendeinem Weg an die Unterzeichner senden: Das MMS bereitet dazu eine Nachricht vor und sendet diese vollautomatisch.
 
-After Alice receives Bob's key set, another `mms next` command will process it and establish the multisig address:
+Nachdem Alice den Schlüsselsatz von Bob erhalten hat, wird ein weiterer `mms next`-Befehl diesen verarbeiten und die Multisig-Adresse daraus herleiten:
 
     [wallet A1VRwm]: mms next
     make_multisig
     Wallet password: 
     2/2 multisig address: 9uWY5Kq6XocGGqUByp22ty4HYxj4CfjCXdRrZ24EKvYW2U7fudSzCvTRRT35tMNx5heQfqKmVmFjahWUZ1BENnzH8UvyVF7
 
-The wallet may be "out of sync" after this step; if yes, just do a quick `refresh`.
+Nach diesem Schritt kann es passieren, dass dein Wallet nicht mehr synchronisiert ist. Wenn dem so ist, führe einen kurzen `refresh` aus.
 
-In the case of non-symmetrical M/N multisig, with M different from N, like e.g. in 2/3, it's not enough that each signer sends one key set to every other signer: There will be several *rounds* of key set exchanges. However the MMS knows about this and will automatically take care of almost everything: For a particular wallet it waits until the key sets of all other signers have arrived before going on. If there is another key exchange round necessary, `mms next` will then start a new one. If not, the command will process the last key set(s) and establish the multisig address.
+Im Falle eines unsymmetrischen M/N-Multisigs, mit M ungleich N (etwa bei 2/3), reicht ein Austausch der Schlüsselsätze von jedem Unterzeichner mit allen anderen Unterzeichnern nicht aus: Es wird verschiedene *Runden* geben, in welchen Schlüsselssätze ausgetauscht werden. Das MMS wird sich jedoch automatisch um fast alles kümmern: Es wartet zunächst, bis für ein bestimmtes Wallet die Schlüsselsätze aller Unterzeichner angekommen sind, und fährt dann erst fort. Ist eine weitere Runde des Austauschs notwendig, wird eine solche durch `mms next` eingeleitet. Wenn nicht, verarbeitet der Befehl die letzten Schlüsselsätze und erstellt daraus anschließend die Multisig-Adresse.
 
-It's possible that a future enhanced version of the MMS will do this in a fully automatic way, i.e. sending all necessary key sets around without further intervention until the multisig address is configured. For now however you have to push things along yourself by issuing `mms next` commands.
+Möglicherweise wird eine zukünftige, verbesserte Version des MMS all dies vollautomatisch machen, indem sie alle notwendigen Schlüsselsätze ohne darüber hinausgehenden Eingriff umhersendet, bis die Multisig-Adresse eingerichtet ist. Aktuell musst du den Vorgang allerdings eigenständig durch Eingabe der `mms next`-Befehle anstoßen.
 
-## Funding the Multisig Wallet
+## Finanzausstattung des Multisig-Wallets
 
-With the multisig address established the wallet is now ready to receive funds. Here the MMS plays no role, nor does multisig in general: Just transfer some coins to the address, to have something to transfer out later, and wait until they arrive.
+Mit der eingerichteten Multisig-Adresse kann das Wallet nun Gelder empfangen. Hierbei spielt weder das MMS noch Multisig allgemein eine Rolle: Sende einfach einige Coins an die Adresse, um später etwas zum Ausgeben zu haben, und warte auf deren Eingang in das Wallet.
 
-## Syncing Wallets
+## Wallets synchronisieren
 
-Every time after receiving or sending coins multisig wallets must exchange some info with each other to get "into sync" again. That's the case whenever the CLI wallet tells you about *partial key images* like in this `balance` command output:
+Um wieder "in den Takt" zu kommen, müssen Multisig-Wallets zwecks Synchronisierens nach jedem Geldaus- oder -eingang einige Infos miteinander austauschen. Dies ist immer dann der Fall, wenn dir das CLI-Wallet etwas bezüglich *unvollständiger Schlüsselbilder* (wie etwa hier in dieser `balance`-Befehlsausgabe, eng. "partial key images") anzeigt:
 
     [wallet 9uWY5K]: balance
     Currently selected account: [0] Primary account
     Tag: (No tag assigned)
     Balance: 7.000000000000, unlocked balance: 7.000000000000 (Some owned outputs have partial key images - import_multisig_info needed)
 
-That "import_multisig_info needed" thing is perhaps the single most tiresome aspect of CryptoNote multisig transactions and quite some work e.g. in the case of 3/3 or 2/3 multisig where already a total of **six** pieces of information must be passed around each time, only to finalize reception of some coins and/or being able to transfer again after a transfer.
+Der "import_multisig_info needed"-Teil ist der wohl ermüdendste Aspekt von CyptoNote-Multisig-Transaktionen und erfordert einen ziemlichen Aufwand, bspw. im Falle von 3/3- oder 2/3-Multisig, bei welchen so schon jedes Mal insgesamt **sechs** Information herumgereicht werden müssen - und das nur, um den Empfang von Coins zu finalisieren und/oder nach einer Überweisung wieder transferieren zu können.
 
-At least, with the MMS, it's only a case of issuing `mms next` commands until all sync data is sent and received and the wallets get into sync again: It guides you automatically through the necessary `export_multisig_info` and `import_multisig_info` commands. Here again how Alice sees this:
+Wenigstens benötigt es beim MMS lediglich die Eingabe von `mms next`-Befehlen, bis alle Synchronisationsdaten gesendet und empfangen wurden und die Wallets wieder synchron(isiert) sind; du wirst automatisch durch die notwendigen Befehle - `export_multisig_info` und `import_multisig_info` - geleitet. Bei Alice sieht dies wie folgt aus:
 
     [wallet 9uWY5K]: mms next
     export_multisig_info
@@ -420,19 +419,19 @@ At least, with the MMS, it's only a case of issuing `mms next` commands until al
     Height 1117984, txid <b515082063a6242f1b62f21c80f95c90801f14ce3f48f51094d069e3580a78aa>, 7.000000000000, idx 0/0
     Multisig info imported03
 
-Don't worry if you receive such sync messages from other signers already before you are able to start sending yours: The MMS will handle this situation quite fine and send first, process afterwards.
+Keine Sorge, wenn du solcherlei Synchronisationsnachrichten schon empfängst, bevor du die deinige überhaupt absenden konntest: Das MMS geht mit solcherlei Situationen ziemlich gut um, indem es die Daten zunächst sendet und erst danach verarbeitet.
 
-Check the chapter *Troubleshooting* if you ever get stuck somehow: E.g. there is a way to force sync even if `mms next` gets confused and thinks that syncing is not necessary or not possible. 
+Solltest du nicht weiterkommen, lies dir zunächst das Kapitel *Fehlerbehebung* durch: Es gibt bspw. die Möglichkeit, den Synchronisationsvorgang zu erzwingen - selbst, wenn `mms next` durcheinandergerät und denkt, dass das Synchronisieren nicht notwendig oder unmöglich ist.
 
-## Making Multisig Transactions
+## Multisig-Transaktionen erstellen
 
-For initiating multisig transactions there is the command `mms transfer` instead of the normal `transfer` command. The MMS variant supports all the parameter variations of the normal command; thus to get help use `help transfer`.
+Um Multisig-Transaktionen einzuleiten, gibt es anstelle des normalen `transfer`-Befehls den Befehl `mms transfer`. Die MMS-Variante unterstützt alle Parametervariationen des normalen Befehls; für Hilfestellung kann also `help transfer` verwendet werden.
 
-The MMS does not care about subaddresses and accounts; whatever address you use for sending (and receiving) transactions, the MMS only cares about the data that the particular event creates, about the right moment to process that and about sending it to the right recipient(s).
+Dem MMS sind Subadressen und Konten relativ egal; welche Adresse du auch immer zum Senden (und Empfangen) von Transaktionen nutzen möchtest - das MMS interessieren nur die Daten, welche in einem bestimmten Vorgang erstellt wurden, der richtige Zeitpunkt, um diese zu verarbeiten und das Senden an den (oder die) richtigen Empfänger.
 
-If you don't like your transaction data to become part of the `.mms` file in the form of stored message content, you can use the normal `transfer` command, but then it's of course your problem to send the partially signed transaction to the next signer.
+Wenn du nicht möchtest, dass deine Transaktionsdaten in Form gespeicherter Nachrichteninhalte Teil der `.mms`-Datei werden, kannst du den normalen `transfer`-Befehl nutzen. Dann ist es allerdings natürlich deine Aufgabe, die teilweise signierte Transaktion an den nächsten Unterzeichner zu übersenden.
 
-With multisig the `mms transfer` command does of course not yet transfer, but produces a partially-signed transaction instead. This stretches the concept of messages a bit because `mms transfer` produces a message to "me" i.e. the owner of the wallet itself, with the partially-signed transaction as content. Check message #7 below to Alice:
+Der `mms transfer`-Befehl beim MMS führt natürlich noch keinen Transfer durch, erzeugt jedoch eine teilsignierte Transaktion. Dies dehnt das Konzept von Nachrichten etwas aus, da `mms transfer` eine Nachricht an "mich", also den Besitzer des Wallets selbst, mit der teilsignierten Transaktion als Inhalt erstellt. Siehe unten die Nachricht Nr. 7 an Alice:
 
     [wallet 9uWY5K]: mms transfer 9zo5QDV9YivQ8Fdygt7BNdGo1c98yfAWxAz6HMwsf15Vf1Gkme9pjQG2Typ9JnBKv5goziC2MT93o3YDUfoWdU9XUinX5kS 5
     No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): y
@@ -447,9 +446,9 @@ With multisig the `mms transfer` command does of course not yet transfer, but pr
       ...
        7 in   alice: BM-2cUVEbbb3H6ojddYQz.. partially signed tx         1   0 waiting         2018-12-26 09:10:42, 40 seconds ago     
 
-The idea behind this: In this state, with the transaction waiting, and depending on the number of required signers, `mms next` will result in a question what to do with it: Especially in the case of 2/3 multisig, it's central to be able to decide **where** to send the transaction for the second signature that will make it valid, i.e. to **which** of the two possible signers.
+Die Idee dahinter: In diesem Stadium - mit der ausstehenden Transaktion und in Abhängigkeit von der Anzahl der erforderlichen Unterzeichner - wird `mms next` in der Frage resultieren, was getan werden soll: Besonders im Falle einer 2/3-Multisig ist die Entscheidungsmöglichkeit darüber, **wohin** die Transaktion zwecks zweiter Signatur zur Validierung gesendet wird (also zu **welchem** der zwei möglichen Unterzeichner), essenziell.
 
-This could look like in this case of 2/4 multisig:
+Das könnte wie in diesem 2/4-Multisig-Fall aussehen:
 
     Unsigned transaction(s) successfully written to MMS
     [wallet 9vAbBk]: mms next
@@ -458,7 +457,7 @@ This could look like in this case of 2/4 multisig:
     2: Send the tx for signing to three: BM-2cStcTfCx8D3McrMcmGZYZcF4csKcQT2pa
     3: Send the tx for signing to four: BM-2cUjNoSxPkUY7ho4sPcEA6Rr26jqcasKiE
 
-In the case of the 2/2 multisig example in this manual, there is no choice however: The transaction started by Alice has to go to Bob as the only other authorized and required signer:
+Im Fall des 2/2-Multisig-Beispiels in dieser Anleitung gibt es allerdings keine Wahl: Die von Alice eingeleitete Transaktion muss an Bob als den einzig anderen autorisierten Unterzeichner gehen:
 
     [wallet 9uWY5K]: mms next
     Send tx
@@ -466,7 +465,7 @@ In the case of the 2/2 multisig example in this manual, there is no choice howev
        8 out  bob: BM-2cStcTfCx8D3McrMcmGZ.. partially signed tx         1   0 ready to send   2018-12-26 09:29:30, 0 seconds ago      
     Queued for sending.
 
-After receiving Bob signs, as usual not with a dedicated signing command that does not exist, but by simply using `mms next`:
+Nach dem Empfang signiert Bob, indem er schlicht `mms next` eingibt (ein bestimmter Signierbefehl existiert nicht):
 
     [wallet 9uWY5K]: mms next
     sign_multisig
@@ -477,7 +476,7 @@ After receiving Bob signs, as usual not with a dedicated signing command that do
     Transaction successfully signed to file MMS, txid c1f603a9045f28b28f221eddf55be41e95f2ac7213384a32d35cadc0a8be3026
     It may be relayed to the network with submit_multisig
 
-Yet another `mms next` does result in a choice for Bob, because he can either submit the transaction to the network himself, **or** send it back to Alice for doing so:
+Ein weiterer `mms next`-Befehl resultiert für Bob in einer Wahlmöglichkeit; er kann die Transaktion entweder selbst im Netzwerk einreichen **oder** sie dazu an Alice zurücksenden:
 
     [wallet 9uWY5K]: mms next
     Choose processing:
@@ -485,380 +484,381 @@ Yet another `mms next` does result in a choice for Bob, because he can either su
     2: Send the tx for submission to alice: BM-2cUVEbbb3H6ojddYQziK3RafJ5GPcFQv7e
     Choice: 
 
-As already mentioned elsewhere after the transaction is submitted to the network and processed you have to sync the wallets before you can do another transfer. Also note that regardless of any syncing needs it's a restriction of Monero multisig that you must do **strictly one transaction after the other**. For example you can't put away fully-signed transactions for submitting them later and already start a new one to submit that first. (For some such scenarious the MMS is not smart enough to prevent you from trying; see chapter *Troubleshooting* about how you can recover by deleting messages containing unprocessable transactions and forcing sync.)
+Wie zuvor bereits erwähnt, musst du die Wallets nach dem Absenden und Verarbeiten der Transaktion zunächst synchronisieren, bevor du eine weitere Überweisung tätigen oder auch empfangen kannst. Beachte auch, dass es abgesehen von irgendwelchen Synchronisationsbedarfen eine Einschränkung von Monero-Multisig ist, dass du **strikt eine Transaktion nach der anderen** durchführen musst. Du kannst bspw. keine komplett signierten Transaktionen zum späteren Absenden beiseitelegen und dann eine neue Transaktion erstellen, um ebendiese zuerst zu senden. (In manchen solcher Szenarien ist das MMS nicht clever genug, dich vom Versuch abzuhalten; im Kapitel *Fehlerbehebung* kannst du nachlesen, wie du wiederherstellen kannst, indem du Nachrichten mit nicht verarbeitbar Transaktionen löschst und die Synchronisation erzwingst.)
 
-As already mentioned you can keep out your transaction data out of the `.mms` file in the form of stored message content and use the normal `transfer` command, but then it's of course your problem to send the partially signed transaction to the next signer. Note also that the MMS does not support cold signing; that would be another reason to directly use `transfer` instead of `mms transfer`. You can, however, export transaction data contained in a message with the `mms export` command.
+Wie schon erwähnt kannst du die Speicherung deiner Transaktionsdaten aus der `.mms`-Datei vermeiden und dazu den normalen `transfer`-Befehl verwenden, es liegt dann allerdings auch in deinen Händen, die teilsignierte Transaktion an den nächsten Unterzeichner zu übermitteln. Beachte auch, dass das MMS ein "Cold-Signieren" nicht unterstützt; ein weiterer Grund, direkt den `transfer`-Befehl anstelle von `mms transfer` zu nutzen. Du kannst in Nachrichten enthaltene Transaktionsdaten jedoch mit dem Befehl `mms export` exportieren.
 
-## The Commands in Detail
+## Die Befehle im Detail
 
 ### mms init
 
     mms init <required_signers>/<authorized_signers> <own_label> <own_transport_address>
 
-Example:
+Beispiel:
 
     mms init 2/2 alice 2cUVEbbb3H6ojddYQziK3RafJ5GPcFQv7e
 
-Prepare a wallet for use with the MMS. You can later change your own label and your own transport address using `mms signer`, but the two numbers, required signers and authorized signers, cannot be changed without issuing `mms init` again which will erase all signer information and all messages. The command will lead to the creation of an additional file with an extension of `.mms` for the wallet.
+Bereitet dein Wallet für den Gebrauch mit dem MMS vor. Dein eigenes Label und deine eigene Transportadresse kannst du später mit `mms signer` ändern. Die zwei Zahlen, die jeweils die Anzahl erforderlicher und autorisierter Unterzeichner angeben, können nicht ohne erneutes Ausführen des Befehls `mms init`, welcher jegliche Unterzeichnerinformationen und Nachrichten löscht, geändert werden. Dieser Befehl resultiert in der Erstellung zusätzlicher Dateien mit der Dateiendung `.mms` für dieses Wallet.
 
-For wallets created in "pre-MMS times" (before the MMS code was included in Monero) it's only possible to initialize the MMS if the wallet is not yet multisig. For wallets created with Monero code already present it's possible to initialize even with the wallet multisig already: When the wallet switched to multisig the "original" Monero address needed by the MMS was saved before it got replaced by the common multisig address.
+Für in Vorzeiten des MMS (bevor der MMS-Code in Monero integriert wurde) erstellte Wallets ist es nur möglich, das MMS zu initialisieren, wenn das Wallet noch nicht über Multisig verfügt. Bei Wallets, bei deren Erstellung der MMS-Code bereits enthalten war, kann das MMS auch trotz bereits bestehenden Multisigs initialisiert werden: Als das Wallet auf Multisig umgeschaltet wurde, wurde die ursprüngliche, vom MMS benötigte Monero-Adresse gesichert, bevor sie durch die gemeinschaftliche Multisig-Adresse ersetzt wurde.
 
-There is no command to deactivate the MMS. If you no longer want to use it for a particular wallet, just delete the `.mms` file or at least move it out of the way.
+Es gibt keinen Befehl zur Deaktivierung des MMS. Wenn du es bei einem bestimmten Wallet nicht mehr verwenden möchtest, kannst du einfach die `.mms`-Datei löschen oder diese zumindest aus dem Weg räumen.
 
 ### mms info
 
     mms [info]
 
-Display whether the MMS is active or not, and if yes, show the number of required signers and number of authorized signers. This is the only MMS command allowed with the MMS inactive.
+Zur Anzeige, ob das MMS aktiv ist oder nicht, und falls ja, Einblendung der jeweiligen Anzahlen erforderlicher und autorisierter Unterzeichner. Dies ist der einzig zulässige MMS-Befehl bei Inaktivität des MMS.
 
 ### mms signer
 
     mms signer [<number> <label> [<transport_address> [<monero_address>]]]
 
-Examples:
+Beispiele:
 
     mms signer
 	mms signer 2 bob BM-2cStcTfCx8D3McrMcmGZYZcF4csKcQT2pa 9yXKZ6UUdd8NnNN5UyK34oXV7zp7gjgZ4WTKHk8KzWsAAuyksfqoeRMLLkdWur85vnc1YL5E2rrMdPMHunA8WzUS9EL3Uoj
 	mms signer 2 bob-the-builder
 
-Without argument, show the list of signers and their info, as far as known. Things never set and therefore still unknown are displayed as `<not set>`. Note that you don't have to and can't create signers: After `mms init` they already all "exist", although without any information set, with the exception of signer #1 which is always "me" i.e. the current wallet itself. Their number is fixed, it's the number of authorized signers as specified with `mms init`.
+Ohne Argument wird hiermit die Liste von Unterzeichnern und deren Infos (soweit bekannt) angezeigt. Bisher nicht eingestellte und damit unbekannte Dinge werden als `<not set>` angezeigt. Beachte, dass du Unterzeichner nicht erstellen musst und auch gar nicht kannst: Nach dem Ausführen von `mms init` "existieren" diese bereits, wenn auch ohne eingestellte Informationen. Ausgenommen davon ist der Unterzeichner Nr. 1, der immer "ich" bzw. das aktuelle Wallet selbst ist. Die Anzahl ist festgelegt; diese ist die im Zuge von `mms init` angegebene Anzahl an autorisierten Unterzeichnern.
 
-With at least a number and a label as argument, set information about a signer, or change any information already set. You can always freely change labels and transport addresses, but for technical reasons Monero addresses can only be changed as long as there are no messages. In the worst case do `mms init` again and start from scratch.
+Mit mindestens einer Zahl und einem Label als Argument können Unterzeichnerinformationen festgelegt oder bereits bestehende Infos geändert werden. Labels und Transportadressen können beliebig abgeändert werden; aus technischen Gründen ist es allerdings nur möglich, Monero-Adressen zu ändern, solange keine Nachrichten existieren. Schlimmstenfalls muss mit `mms init` komplett von Grund auf neu gestartet werden.
 
-Numbers start with 1 and go up to the number of authorized signers.
+Zahlen starten bei 1 und gehen hoch bis zur Anzahl autorisierter Unterzeichner.
 
-A *label* must be a single word. Use characters like minus "-" or underscore "_" to write more complex labels like e.g. `alice_in_wonderland`. Labels must be unique for all signers. There is no fixed maximal length for labels but some output will look strange or become hard to read with very long labels.
+Ein *Label* muss ein einzelnes Wort sein. Um komplexere Labels, etwa `alice_in_wonderland`, zu erstellen, können Minuszeichen (-) oder Tiefstriche (_) verwendet werden. Labels müssen für alle Unterzeichner einzigartig sein. Es gibt für Labels keine festgelegte maximale Länge, manche Ausgaben könnten mit sehr langen Labels jedoch seltsam aussehen oder schwer lesbar sein.
 
-A *transport address* can currently only be a Bitmessage address like e.g. `BM-2cStcTfCx8D3McrMcmGZYZcF4csKcQT2pa`, PyBitmessage being the only supported program for actual message transport. Transport addresses are not checked for syntax or validity by the MMS; if you enter a malformed address you will get an error message from PyBitmessage only later at first (attempted) use.
+Mit PyBitmessage als einzigem unterstützten Programm zum derzeitigen Nachrichtentransport kann eine *Transportadresse* gegenwärtig nur eine Bitmessage-Adresse wie etwa `BM-2cStcTfCx8D3McrMcmGZYZcF4csKcQT2pa` sein. Transportadressen werden vom MMS nicht hinsichtlich Satzbau oder Richtigkeit überprüft. Gibst du eine fehlgebildete Adresse an, zeigt dir PyBitmessage nur bei der ersten (versuchten) Verwendung eine Fehlermeldung an.
 
-If you enter a wrong address i.e. not the correct address for the respective signer most probably nothing will happen, the messages will just not reach the intended recipient; if nobody holds the key for that address, with a Bitmessage client configured to receive messages to it, the message will just "float around" the Bitmessage network for a while and finally expire.
+Wenn du eine falsche Adresse (sprich nicht die korrekte Adresse für den jeweiligen Unterzeichner) eingibst, wird sehr wahrscheinlich gar nichts passieren; die Nachrichten werden den für sie bestimmten Empfänger schlicht nicht erreichen. Wenn niemand über den Schlüssel für diese Adresse - mit einem auf den Empfang von Nachrichten in diesem Wallet eingerichteten Bitmessage-Client - verfügt, wird die Nachricht lediglich für eine Zeit lang im Bitmessage-Netzwerk "umherschweben" und schlussendlich ungültig werden.
 
 ### mms list
 
     mms list
 
-List all stored messages. There are no separate inbox and outbox; all messages are contained in a single chronological list. The columns in detail:
+Listet alle gespeicherten Nachrichten auf. Es gibt keines separaten Ein- und Ausgang; alle Nachrichten sind in einer einzelnen chronologischen Liste enthalten. Die Spalten im Detail:
 
-* `Id`: The unique id of the message that you can use to refer to the message in commands like `mms show` and `mms send`. Message ids count strictly upwards from 1. Ids of deleted messages won't get "recycled".
-* `I/O`: Message direction. `in` denotes a message that you received, `out` a message that you sent. Note than for some message types you can receive a message from yourself, e.g. a partially signed transaction that you started yourself.
-* `Authorized Signer`: In case of a received message, the sender, in case of a sent message, the recipient. Listed are the label and, within the width limit of the column, the transport address of the signer.
-* `Message Type`: The type of the message telling what kind of data it contains. For a complete list of possible message types see below.
-* `Height`: The number of transfers contained in the wallet at the time of message construction or reception. Used to group the "right" sync data messages which all must be from the same "height" for all other signers before sync can be successful. This height is unimportant for you except in cases where something went wrong; for more see chapter *Troubleshooting*.
-* `R`: The number of the key exchange round a key set belongs to, if the type of multisig requires more than one round in the first place, like e.g. 2/3. 0 for all other message types.
-* `Message State`: The current state of the message. `waiting` or `sent` for outgoing messages, `waiting` or `processed` for incoming messages. You can't directly change this state, it's always the result of the execution of commands.
-* `Since`: Point in time and time span since the message got its current message state. Times are in UTC, not local time. If you re-send a message, this timestamp is not adjusted and continues to display the time of the first sending.
+* `Id`: Die einzigartige ID der Nachricht, unter deren Verwendung du dich in Befehlen wie `mms show` und `mms send` auf genau diese Nachricht beziehen kannst. Nachrichten-IDs zählen streng von 1 aufwärts. IDs gelöschter Nachrichten werden nicht wiederverwendet.
+* `I/O`: Richtung der Nachrichten. `in` kennzeichnet eine empfangene, `out` eine gesendete Nachricht. Beachte, dass du im Falle mancher Nachrichtenformen eine Nachricht von dir selbst erhalten kannst, bspw. eine teilsignierte Transaktion, welche du selbst eingeleitet hast.
+* `Authorized Signer`: Im Falle einer empfangenen Nachricht ist dies der Sender, bei einer gesendeten Nachricht der Empfänger. Aufgelistet sind das Label und, innerhalb der Höchstbreite der Spalte, die Transportadresse des Unterzeichners.
+* `Message Type`: Der Typ einer Nachricht, welcher dir sagt, welche Art von Daten sie enthält. Eine komplette Liste möglicher Nachrichtentypen findet sich unten.
+* `Height`: Die zur Zeit der Erstellung/des Empfangs gültige Anzahl von Transfers. Genutzt, um die "richtigen" Synchronisationsdatennachrichten zusammenzufassen, welche alle dieselbe "Höhe" für alle anderen Unterzeichner haben müssen, bevor erfolgreich synchronisiert werden kann. Für dich ist diese Höhe unwichtig, außer für Fälle, in denen etwas schiefgelaufen ist. Mehr Infos finden sich im Kapitel *Fehlerbehebung*.
+* `R`: Benötigt ein Multisig-Typ (etwa 2/3) mehr als einen Durchgang des Austauschs von Schlüsseln, zeigt dies die Zahl der jeweiligen Runde, zu welcher ein Schlüsselsatz gehört, an. 0 für alle anderen Nachrichtentypen.
+* `Message State`: Der aktuelle Status der Nachricht. `waiting` oder `sent` für ausgehende, `waiting` oder `processed` für eingehende Nachrichten. Diesen Status kannst du nicht direkt ändern; es ist immer das Ergebnis ausgeführter Befehle.
+* `Since`: Zeitpunkt und Zeitspanne von/nach dem Erhalt des aktuellen Nachrichtenstatus. Zeitangaben in UTC, nicht Ortszeit. Wenn du eine Nachricht erneut sendest, wird dieser Zeitstempel nicht angepasst und zeigt weiterhin die Zeit des ersten Sendens an.
 
-The complete list of message types:
+Die komplette Liste von Nachrichtentypen:
 
-* `key_set`: Data about keys that wallets must exchange with each other for establishing multisig addresses
-* `additional_key_set`: A key set for an additional key exchange round, after the original one, as necessary for non-symmetric multisig types like e.g. 2/3
-* `multisig_sync_data`: Data that wallets must exchange with each other to correctly and completely interpret incoming and outgoing transactions; see also chapter *Syncing Wallets*
-* `partially_signed_tx`: A transaction that has not yet the necessary number of signatures (= number of required signers) to commit it
-* `fully_signed_tx`: A transaction with a full set of required signatures, ready for submission to the Monero network; any signer could submit this
-* `note`: A message containing a note; see command `mms note`
-* `signer_config`: Full information about all signers, to be sent as part of an auto-config process or as a result of a `mms send_signer_config` command
-* `auto_config_data`: Address data from a signer to send back to the auto-config manager after entering a token with `mms auto_config`
+* `key_set`: Daten über Schlüssel, welche Wallets zum Erstellen von Multisig-Adressen miteinander austauschen müssen
+* `additional_key_set`: Ein Schlüsselsatz für eine zusätzliche Schlüsselaustauschrunde (nach der ursprünglichen), wie für nichtsymmetrische Multisig-Typen (etwa 2/3) notwendig
+* `multisig_sync_data`: Daten, die Wallets zur korrekten Interpretation aus- und eingehender Transaktionen austauschen müssen; siehe auch Kapitel *Wallets synchronisieren*
+* `partially_signed_tx`: Eine Transaktion, die noch nicht die zum Absenden notwendige Anzahl von Signaturen (= Anzahl erforderlicher Unterzeichner) hat
+* `fully_signed_tx`: Eine Transaktion mit einem vollständigen Satz erforderlicher Unterzeichner, fertig zum Absenden zum Monero-Netzwerk; jeder Unterzeichner könnte diese senden
+* `note`: Eine Nachricht, die eine Anmerkung enthält; siehe Befehl `mms note`
+* `signer_config`: Gesamtinformationen aller Unterzeichner, die als Teil eines Auto-Config-Vorgangs gesendet werden können oder aus einem `mms send_signer_config`-Befehl resultieren
+* `auto_config_data`: Adressdaten eines Unterzeichners, welche nach Eingabe eines Tokens mit `mms auto_config` zurück an den Auto-Config-Manager gesendet werden
 
 ### mms next
 
     mms next [sync]
 
-*The* central and probably most useful command of the MMS: Check the state of the wallet plus the received and sent messages and their message state, and decide which action is the next one to execute, and then actually execute it.
+*Der* zentrale und vermutlich nützlichste Befehl des MMS: Überprüfe den Status des Wallets plus die empfangenen und gesendeten Nachrichten wie auch deren Status; entscheide dann, welcher der nächste auszuführende Schritt ist - und führe diesen anschließend aus.
 
-When in doubt, just issue a `mms next` command; the MMS will either execute the proper next command according to Monero's "multisig workflow rules", or tell you what it's waiting for before it can proceed. For "dangerous" things you can count on confirming prompts before the real action happens. Worst case a `mms next` can execute something earlier than you might have intended, but otherwise can hardly do any harm. 
+Wenn du dir unsicher bist, kannst du einfach einen `mms next`-Befehl eingeben; das MMS führt daraufhin entweder den gemäß Moneros "Regeln des Multisig-Arbeitsablaufs" nachfolgenden Befehl aus oder sagt dir, worauf es zum Fortfahren wartet. Bei "gefährlichen" Dingen kannst du dich auf eine letzte Sicherheitsabfrage vor dem Eintreten der wirklichen Aktion verlassen. Schlimmstenfalls kann ein `mms next`-Befehl etwas früher als von dir geplant ausführen, ansonsten kann es so gut wie keinen Schaden anrichten.
 
-Note how for many actions there is **no** dedicated command, and `mms next` the **only** way to move things forward. Don't look e.g. for commands to selectively process certain messages: If it's time to process some received messages in state *waiting*, the command will do so.
+Für viele Aktionen gibt es **keinen** bestimmten Befehl; `mms next` ist der **einzige** Weg, Dinge voranzutreiben. Suche nicht nach z.B. Befehlen zur selektiven Verarbeiten bestimmter Nachrichten: Wenn es an der Zeit ist, einige empfangene Nachrichten in der Warteschleife zu verarbeiten, wird der Befehl dies tun.
 
-Interestingly and maybe surprisingly, in Monero it's **always** clear what has to happen next regarding multisig, except in the case of partially signed transactions where you can decide **which** signer sending them to, and in the case of fully signed transactions that you can submit yourself to the network or send them to another signer for submission by them.
+Interessanter- und vielleicht überraschenderweise ist es bei Monero **immer** klar, was hinsichtlich Multisig als Nächstes passieren muss. Ausgenommen hiervon sind der Fall teilsignierter Transaktionen, für welche du entscheiden kannst, an **welchen** Unterzeichner sie gehen sollen, und der Fall komplett signierter Transaktionen, die du selbst an das Netzwerk leiten oder zwecks Einreichens auch an einen anderen Unterzeichner senden kannst.
 
-The special command form `mms next sync` is for cases where sync data is waiting that the MMS on its own would not process because it "thinks" the wallet is in a state needing no new sync - which might be wrong. More about this in chapter *Troubleshooting*.
+Eine besondere Form des Befehls - `mms next sync` - ist für den Fall, dass Synchronisationsdaten ausstehen, während das MMS "glaubt", im aktuellen Status nicht neu synchronisieren zu müssen und diese Daten demnach nicht verarbeitet - was falsch sein könnte. Mehr dazu findet sich im Kapitel *Fehlerbehebung*.
 
 ### mms sync
 
     mms sync
 
-Manually start a round of syncing forcibly i.e. even if the MMS is of the opinion that no exchange of sync data is currently necessary. More about this in chapter *Troubleshooting*.
+Manueller Start eines erzwungenen Synchronisationsdurchgangs, selbst, wenn das MMS nicht der Meinung ist, dass ein Austausch von Synchronisationsdaten gerade nicht notwendig ist. Mehr dazu im Kapitel *Fehlerbehebung*
 
 ### mms transfer
 
     mms transfer <transfer_command_arguments>
 
-Start a transfer under the control of the MMS, the difference to the standard `transfer` command being that the resulting partially signed transaction won't be written to a file that you have to handle further yourself, but that a message containing the transaction will result. Use `mms next` after `mms transfer` to ask the MMS to actually process the message which in effect means deciding which signer send it to for the next signature and create another message for that.
+Initiation eines Transfers unter Kontrolle des MMS, mit dem Unterschied zum standardmäßigen `transfer`-Befehl, dass die resultierende teilsignierte Transaktion nicht auf eine Datei geschrieben wird, für die du später zuständig bist, sondern, dass eine die Transaktion enthaltende Nachricht ausgegeben wird. Nutze `mms next` nach `mms transfer`, um das MMS aufzufordern, die Nachricht tatsächlich zu verarbeiten. Das bedeutet, dass über einen Unterzeichner entschieden werden muss, an welchen diese Nachricht zwecks der nächsten Signatur gehen soll, und, dass dazu eine weitere Nachricht erstellt werden muss.
 
-The arguments of the `mms transfer` command are exactly the same of those of the standard `transfer` command. Check the info about that command with `help transfer` to learn about all the various possible parameters and parameter combinations.
+Die Befehle des `mms transfer`-Befehls sind exakt dieselben des standardmäßigen `transfer`-Befehls. Um mehr über die zahlreichen möglichen Parameter(-kombinationen) zu erfahren, kann mit `help transfer` die Befehlsinfo angezeigt werden.
 
-Note that quite in general the MMS does not care about addresses, subaddresses and acccounts. Regardless of what you specify in this regard for a `mms transfer` command afterwards there will always be a single new message containing the partially signed transaction.
+Allgemein betrachtet interessieren Adressen, Subadressen und Konten das MMS nicht. Ungeachtet dessen, was du in diesem Bezug für einen `mms transfer`-Befehl festlegst, wird es immer eine einzelne neue Nachricht mit der teilsignierten Transaktion geben.
 
-Even with MMS active you can still use the standard `transfer` command; you are then simply on your own regarding handling the transaction. Try to use the right command variant; `transfer` won't ask for confirmation whether you really intend to use it instead of `mms transfer`. If you issued `transfer` but really wanted the MMS variant, ignore the written transaction file and simply go on with `mms transfer`.
+Selbst mit aktivem MMS kannst du noch immer den normalen `transfer`-Befehl ausführen; du bist dann schlicht bezüglich dieser Transaktion auf dich allein gestellt. Versuche, die richtige Befehlsvariante zu nutzen; `transfer` wird nicht nach der Bestätigung dessen fragen, ob du es tatsächlich anstelle von `mms transfer`verwenden möchtest. Wenn du `transfer` erteilt hast, aber eigentlich die MMS-Variante nutzen wolltest, ignoriere die geschriebene Transaktionsdatei und fahre einfach mit `mms transfer` fort.
 
-The MMS does not, or at least not yet, keep track how many signatures a transaction actually has and who signed already and who not yet. Because of this weakness it can include choices that do not make sense, e.g. a choice to send a partially signed transaction to somebody who signed already.
+Das MMS zeichnet (zumindest bisher) nicht auf, wie viele Signaturen eine Transaktion tatsächlich hat, wer bereits unterzeichnet hat und wer noch nicht. Wegen dieser Schwäche kann es passieren, dass Entscheidungen, die keinen Sinn ergeben, eingebunden werden, etwa die Entscheidung, eine teilsignierte Transaktion an jemanden zu senden, der bereits unterzeichnet hat.
 
-This hardly matters with multisig types like 2/2 or 2/3, but of course the higher the number of authorized signers, the more acute this can become. Some attention by the signers is needed to do the right thing. You can't go wrong in an absolute sense however: The CLI wallet, or more exactly the CLI commands called internally by the MMS, will reject any attempts to do invalid actions.
+Bei Multisig-Formen wie 2/2 oder 2/3 spielt dies kaum eine Rolle, aber je höher die Zahl autorisierter Unterzeichner ist, desto wichtiger kann es werden. Um alles richtig zu machen, wird ein wenig Aufmerksamkeit seitens der Unterzeichner benötigt. Im absoluten Sinne kannst du aber so oder so nicht wirklich etwas falsch machen: Das CLI-Wallet, genauer gesagt die intern durch das MMS aufgerufenen CLI-Befehle werden jegliche Versuche zum Ausführen ungültiger Aktionen ablehnen.
 
 ### mms delete
 
     mms delete (<message_id> | all)
 
-Delete a single message given its message id, or delete all messages by using the `all` parameter. Single messages will be deleted without confirmation even if not yet sent or not yet processed. A deleted message is gone for good, there is no undo, and it's gone from PyBitmessage's store as well. (If you loose a message you can ask the sender to re-send it to you.)
+Löschung einer einzelnen Nachricht unter Angabe ihrer Nachrichten-ID, oder Löschen aller Nachrichten unter Verwendung des `all`-Parameters. Einzelne Nachrichten werden ohne Bestätigung gelöscht, selbst wenn sie noch nicht gesendet oder noch nicht verarbeitet wurden. Eine gelöschte Nachricht ist endgültig vernichtet; die Löschung kann nicht ungeschehen gemacht werden und ist auch aus dem Speicher von PyBitmessage entfernt. (Solltest du eine Nachricht verloren haben, kannst du den Sender darum bitten, diese nochmal abzusenden.)
 
-There are situations where you have to clear by deleting messages that did not get processed, got unprocessable and now "disturb the workflow"; more see chapter *Troubleshooting*. Deleting is also useful when somebody re-sends you a message and the original message finally reaches you as well later on.
+Es gibt Situationen, in welchen du Nachrichten löschen musst, die nicht verarbeitet wurden, als nicht verarbeitbar markiert wurden und nun den "Arbeitsablauf stören"; mehr im Kapitel *Fehlerbehebung*. Das Löschen ist außerdem nützlich, wenn dir jemand eine Nachricht erneut zusendet und die ursprüngliche Nachricht schließlich doch bei dir eintrifft.
 
-You could say that the value of a sent or processed message itself is not very high as in most cases you won't ever need it again, and for many messages there are no commands to process them again on demand anyway. But of course the list of messages itself can be quite valuable to see what happened, and when, so better not delete messages without a good reason.
+Man könnte sagen, dass der Wert einer gesendeten oder verarbeiteten Nachricht selbst gar nicht wirklich hoch ist, da du sie niemals wieder benötigen wirst; für viele Nachrichten gibt es sowieso keine Befehle, um sie auf Abruf erneut verarbeiten zu können. Die Liste der Nachrichten selbst kann allerdings zur Anzeige dessen, was wann passiert ist, ziemlich nützlich sein, also lösche besser keine Nachrichten ohne wirklichen Grund.
 
 ### mms send
 
     mms send [<message_id>]
 
-Example:
+Beispiel:
 
     mms send 14
 
-Without parameter send any messages in status *ready to send*. With a message id as parameter send or re-send that particular message. To be able to re-send a message is part of the "messaging system UX" and makes for a quite robust processing because there are very few situations that you can't recover from: The Bitmessage network ate your message? No problem, re-send. PyBitmessage crashed? No problem, restart PyBitmessage and re-send your message.
+Ohne Parameter werden alle Nachrichten mit dem Status *ready to send* abgesendet. Mit einer Nachrichten-ID als Parameter wird die jeweilige Nachricht (erneut) gesendet. Die Möglichkeit, eine Nachricht erneut zu senden, ist Teil der "Benutzererfahrung des Nachrichtensystems" und sorgt für eine ziemlich robuste Verarbeitung, da es sehr wenige Situationen gibt, von welchen du nicht wiederherstellen kannst: Das Bitmessage-Netzwerk hat deine Nachricht gefressen? Kein Problem, sende sie erneut. PyBitmessage ist abgestürzt? Kein Problem, starte PyBitmessage neu und sende deine Nachricht nochmal ab.
 
-Whether messages are immediately sent or whether the MMS asks for confirmation to do so first depends on the value of the `auto-send` parameter; see `mms set` command. Getting each message to send presented that way may be useful for beginners because it's clearer to see what happens; on the other hand it hardly ever makes sense to postpone sending because something else has to be sent first.
+Ob Nachrichten unmittelbar gesendet werden oder ob das MMS dafür zunächst nach einer Bestätigung fragt, hängt vom Wert des `auto-send`-Parameters ab (siehe `mms set`-Befehl). Gerade für Anfänger kann dies nützlich sein, da deutlicher ist, was eigentlich passiert. Ansonsten ergibt es beinahe niemals Sinn, das Senden aufzuschieben, weil etwas anderes zuerst abgeschickt werden muss.
 
-"Sending" does not mean really send; the MMS just submits the message to PyBitmessage and *that* program will actually send. The MMS cannot give any feedback whether a message is still waiting to go out to the Bitmessage network or went out already. When in doubt, check in PyBitmessage itself.
+"Senden" meint kein wirkliches Senden; das MMS leitet die Nachricht schlicht an PyBitmessage weiter und *dieses* Programm sendet sie dann tatsächlich. Das MMS kann keinerlei Rückmeldung dazu geben, ob eine Nachricht noch darauf wartet, ins Bitmessage-Netzwerk zu gelangen, oder ob sie bereits erloschen ist. Wenn du dir nicht sicher bist, überprüfe es direkt bei PyBitmessage.
 
-Any mistakes in Bitmessage addresses will only be detected at the moment of sending; the MMS itself does not check those addresses.
+Jegliche Fehler in Bitmessage-Adressen werden lediglich im Moment des Sendens aufgespürt; das MMS selbst überprüft diese Adressen nicht.
 
 ### mms receive
 
     mms receive
 
-Force an immediate check for received messages, or more exactly force an immediate query of the MMS to PyBitmessage whether there are any new messages.
+Eine unmittelbare Überprüfung auf empfangene Nachrichten erzwingen, oder genauer eine unmittelbare Anfrage des MMS an PyBitmessage bezüglich neuer Nachrichten erzwingen.
 
-The MMS checks for new incoming messages with the same frequence the CLI wallet checks for incoming transactions: Once very 90 seconds. And the setting to decide whether checking automatically or not is the same as well, `auto-refresh`.
+Das MMS überprüft auf neu eingehende Nachrichten mit der Frequenz, mit welcher das CLI-Wallet auf eingehende Transaktionen überprüft: einmal alle 90 Sekunden. Die Einstellung, mit welcher die automatische Überprüfung ein- oder ausschaltet werden kann, ist ebenfalls dieselbe: `auto-refresh`.
 
 ### mms note
 
     mms note [<label> <text>]
 
-Examples:
+Beispiele:
 
     mms note
     mms note bob Did you already submit the last transaction?
     mms note alice Yes, just waiting for the next block :)
 
-Without parameters display any notes not yet read. With a label and further text as parameters send the text as a message of type `note` to the signer with the label.
+Ohne Parameter Anzeige jeglicher ungelesener Notizen. Mit Label und weiterem Text als Parameter kann der Text als Nachricht vom Typ `note` an den Unterzeichner mit dem entsprechenden Label versendet werden.
 
-Sending notes to each other directly from one Monero wallet to the next might be a fun way to avoid having to use additional communication channels for talking to signers.
+Sich gegenseitig Notizen direkt von einem Monero-Wallet zum Nächsten zu senden kann eine lustige Möglichkeit sein, um ohne zusätzliche Kanäle mit anderen Unterzeichnern zu kommunizieren.
 
-If you want to read or re-read a particular note use the `mms show` command and look at the last line with the message content, in this case the text of the note.
+Wenn du eine bestimmte Notiz lesen bzw. erneut lesen möchtest, nutze dazu den `mms show`-Befehl und schaue in die letzte Zeile mit dem Nachrichteninhalt, in diesem Falle der Text der Notiz.
 
 ### mms show
 
     mms show <message_id>
 
-Show detailed information about the message with the id used as command parameter. Useful to read or re-read notes. Binary message content is not displayed; use the `mms export` command and inspect the resulting file if you need to check such a message content.
+Detaillierte Informationen bezüglich der Nachricht unter Gebrauch der ID als Befehlsparameter anzeigen. Keine Anzeige von Binärnachrichteninhalten; nutze den `mms export`-Befehl und untersuche die resultierende Datei, wenn du einen solchen Nachrichteninhalt überprüfen musst.
 
 ### mms export
 
     mms export <message_id>
 
-Export the content of the message with the given id into a file with the fixed name `mms_message_content` in the current directory. An already existing file will be silently overwritten.
+Den Inhalt einer Nachricht unter Angabe ihrer ID in eine Datei mit dem festen Namen `mms_message_content` in das aktuelle Verzeichnis exportieren. Eine bereits bestehende Datei wird hinweislos überschrieben.
 
-There is no `mms import` counterpart command yet.
+Bisher gibt es kein `mms import`-Gegenstück.
 
 ### mms set
 
     mms set <option_name> [<option_value>]
 
-Example:
+Beispiel:
 
     mms set auto-send 1
 
-The MMS equivalent of the general `set` command. With only the name of an option show the current value of that option. With option name and option value set that option to the given value.
+Das Äquivalent des allgemeinen `set`-Befehls mit lediglich dem Namen einer Option und dem derzeitigen Wert ebendieser. Stelle diese Option mittels Eingabe ihres Optionsnamens und des Optionswerts auf den gegebenen Wert ein. 
 
-The only MMS-specific setting so far that this command handles is the `auto-send` setting. If set messages are not sent out automatically right after they are created but the MMS asks for confirmation first. See also `mms send` command. As soon as you are familiar with the MMS and comfortable using it it may be a good idea to set `auto-send` to 1 for less prompts and speedier progressing.
+Die bisher einzige MMS-spezifische Einstellung, welche dieser Befehl bewerkstelligt, ist die `auto-send`-Einstellung, mittels derer festgelegt wird, ob gesendete Nachrichten direkt nach ihrer Erstellung abgesendet werden oder das MMS vor dem Senden nach einer Bestätigung fragen soll (siehe auch `mms send`-Befehl). Sobald du mit dem MMS vertraut bist und dir der Umgang damit bequem von der Hand geht, könnte es eine gute Idee sein, `auto-send` für weniger Abfragen und eine schnellere Verarbeitung auf 1 festzulegen.
 
 ### mms start\_auto\_config
 
     mms start_auto_config [<label> <label> ...]
 
-Example:
+Beispiel:
 
     mms start_auto_config bob trent
 
-Start an auto-config process at the wallet of the "config manager" by creating auto-config tokens for every signer expect "me" i.e. the first one and do a `mms signer` command to display the tokens. Asks for confirmation if auto-config is seemingly already running because there are already tokens for signers in the signer configuration.
+Initiieren eines Auto-Config-Vorgangs im Wallet des "Config-Managers", indem Auto-Config-Token für jeden Unterzeichner außer "mir", sprich dem Ersten, erstellt werden. Führe einen `mms signer`-Befehl aus, um die Token anzuzeigen. Sicherheitsabfrage, weil es bereits Token für Unterzeichner in der Unterzeichnerkonfiguration gibt und Auto-Config daher bereits zu laufen scheint.
 
-The manager has to transmit the auto-config tokens to the respective signers outside the MMS. Note that those tokens are sensitive information: A token in the hand of a non-signer or in the hand of the wrong signer will enable that person to impersonate the rightful signer i.e. take part in all transactions in stead of that signer.
+Der Manager muss nun diese Auto-Config-Token an die jeweiligen Unterzeichner außerhalb des MMS übermitteln. Beachte, dass diese Token sensible Informationen sind: Ein Token in Händen eines Nicht-Unterzeichners oder des falschen Unterzeichners wird diese Person dazu befähigen, sich als der rechtmäßige Unterzeichner auszugeben und so anstelle des eigentlichen Unterzeichners an allen Transaktionen teilzunehmen.
 
-Precondition for starting auto-config is *all* signers having a label assigned. The idea is that auto-config establishes the **same** labels in the wallets of all signers to make it clear to everybody who is who. (Only the order of the signers in each wallet will be different, because the owner of the wallet will always be signer #1.) Later the signers are free to change labels they don't like, as long as there is no danger to confound signers of course.
+Voraussetzung des Startens von Auto-Config ist, dass *alle* Unterzeichner ein zugewiesenes Label haben. Die Idee dahinter ist, dass Auto-Config **dieselben** Labels in den Wallets aller Unterzeichner einrichtet, damit jedem klar ist, wer wer ist. (Lediglich die Reihenfolge der Unterzeichner wird in jedem Wallet unterschiedlich sein, weil der Besitzer eines Wallets stets Unterzeichner Nr. 1 ist.) Später ist es den Unterzeichnern freigestellt, unbeliebte Labels zu ändern, solange natürlich keine Gefahr besteht, andere Unterzeichner zu verwirren.
 
-You can establish labels for all signers using the `mms signer` command beforehand, or more comfortably right with the `mms start_auto_config` command itself, by listing all labels except the label for "me" in the correct order as command arguments.
+Du kannst im Vorfeld Labels für alle Unterzeichner mit dem `mms signer`-Befehl erstellen. Mit `mms start_auto_config` direkt geht das noch bequemer, indem alle Labels (außer das Label für "mich") in der richtigen Reihenfolge als Befehlsargumente aufgelistet werden.
 
-The command can be issued at basically any time, although of course it makes most sense at the beginning where for the wallets of all signers only `mms init` commands were executed yet.
+Dieser Befehl kann im Grunde jederzeit erteilt werden, wobei es natürlich zu Beginn, wenn für die Wallets aller Unterzeichner bisher lediglich `mms init` ausgeführt wurde, am meisten Sinn ergibt.
 
-Check chapter *Auto-Config* for a description of the following steps after this command.
+Siehe Kapitel *Auto-Config* zwecks Beschreibung der diesem Befehl nachfolgenden Schritte.
 
 ### mms auto\_config
 
     mms auto_config <auto_config_token>
 
-Example:
+Beispiel:
 
     mms auto_config mms561832e3eb
 
-Process an auto-config token that you received from the "config manager" during an auto-config process through some reasonably secure communication channel outside of the MMS, e.g. SMS, smartphone messenger app, encrypted e-mail or phone call. Each signer gets their own distinct token. Treat any MMS auto-config tokens as confidential information.
+Verarbeitet einen Auto-Config-Token, welchen du im Zuge eines Auto-Config-Vorgangs vom "Config-Manager" mittels eines angemessen sicheren Kommunikationskanals außerhalb des MMS erhalten hast (etwa via SMS, Nachrichten-App auf dem Smartphone, verschlüsselter E-Mail oder mittels Anruf). Jeder Unterzeichner erhält einen eigenen, individuellen Token. Behandle jegliche Auto-Config-Token des MMS wie eine vertrauliche Information.
 
-This will result in a message of type `auto-config data` to send your Bitmessage address and your Monero address to the manager. (Transmission of that message is already as secure as any later MMS message, as long as nobody else knows your token.)
+Dies resultiert in einer Nachricht des Typs `auto-config data`, mit welcher deine Bitmessage- und deine Monero-Adresse an den Manager gesendet werden. (Die Übertragung dieser Nachricht ist bereits so sicher wie jede spätere MMS-Nachricht, solange niemand deinen Token kennt.)
 
-There is some tolerance in the way the MMS interprets entered tokens (e.g. they are not case-sensitive), and any typo will result in an invalid token with a high degree of probability and will be detected.
+Es besteht etwas Toleranz bei der Art und Weise, auf welche das MMS eingegebene Token interpretiert (z.B. beachtet es keinerlei Groß- oder Kleinschreibung), und jeglicher Tippfehler wird mit hoher Wahrscheinlichkeit in einem ungültigen Token resultieren und aufgespürt werden.
 
-If it was decided to do auto-config best refrain from entering any signer information yourself manually with `mms signer`. (The MMS won't prevent it however.)
+Wenn über die Verwendung von Auto-Config entschieden wurde, unterlasse es besser, irgendwelche Unterzeichnerinformationen manuell mit `mms signer` einzugeben. (Das MMS wird dies jedoch nicht verhindern.)
 
-Check chapter *Auto-Config* for a complete list of all steps of an auto-config process.
+Siehe Kapitel *Auto-Config* für eine komplette Liste aller Schritte eines Auto-Config-Ablaufs.
 
 ### mms stop\_auto\_config
 
     mms stop_auto_config
 
-Delete any auto-config tokens from signer configuration and stop any running auto-config process that way. 
+Löschung jeglicher Auto-Config-Token der Unterzeichnerkonfiguration und daraus resultierend das Beenden jedes laufenden Auto-Config-Vorgangs.
 
-Deleted tokens cannot be recoverd or reconstructed, as they are random. If you are the "config manager" and delete tokens you will never become able again to receive auto-config messages that other signers send to you using those deleted tokens. (Nobody else will receive them either, however.) Everybody will need new tokens issued by you.
+Gelöschte Token können weder wiederhergestellt noch rekonstruiert werden, da sie zufällig sind. Wenn du als "Config-Manager" Token löschst bist du nicht mehr in der Lage, von anderen Unterzeichnern unter Verwendung dieser gelöschten Token gesendete Auto-Config-Nachrichten zu empfangen (aber auch niemand sonst wird sie empfangen). Jeder wird neue, von dir ausgegebene Token benötigen.
+
 
 ### mms send\_signer\_config
 
     mms send_signer_config
 
-Manually send your complete signer configuration to all other signers as messages of type `signer config`. After receiving your message they will be able to replace their signer configuration by yours with a `mms next` command. There will be a security prompt before that happens.
+Manuelles Senden deiner gesamten Unterzeichnerkonfiguration in Form einer Nachricht des Typs `signer config` an alle anderen Unterzeichner. Nach dem Empfang deiner Nachricht können diese ihre Unterzeichnerkonfiguration mithilfe eines `mms next`-Befehls mit der deinen ersetzen. Davor wird es aber eine Sicherheitsabfrage geben.
 
-Each signer will get their label overwritten with the label you entered for them, but their own Bitmessage address and Monero address will be preserved.
+Das Label jedes Unterzeichners wird mit dem von dir für ihn eingegebenen Label überschrieben, die eigenen Bitmessage- und Monero-Adressen werden jedoch aufbewahrt.
 
-This command and its capability to "broadcast" a particular signer configuration can serve as a building block for something like a "semi-auto-config". See also chapter *Sending Signer Configuration*. Sending out a complete signer configuration is also part of fully-automatic config, although without needing a separate `mms send_signer_config` command.
+Dieser Befehl und seine Fähigkeit, eine bestimmte Unterzeichnerkonfiguration zu "übertragen", kann als Baustein für etwas wie ein "Halb-Auto-Config" dienen. Siehe auch Kapitel *Unterzeichnerkonfiguration senden*. Das Entsenden einer kompletten Unterzeichnerkonfiguration ist zudem Teil von Voll-Auto-Config, allerdings ohne Erfordernis eines separaten `mms send_signer_config`-Befehls.
 
-## Security
+## Sicherheit
 
-The MMS was carefully designed and implemented as a system offering a high degree of security.
+Das MMS wurde mit Sorgfalt entwickelt und als ein System implementiert, das einen hohen Grad an Sicherheit bietet.
 
-Which was not particularly easy: Monero multisig itself is already a multi-faceted if not to say complex process and thus not trivial to secure, and the MMS is a powerful if not to say complex system on top of that, so it's no wonder that there are various possible security issues.
+Dies war nicht besonders einfach: Monero-Multisig selbst ist bereits ein facettenreicher, um nicht zu sagen komplexer Prozess und daher nicht einfach zu sichern; darüber hinaus ist auch das MMS ein leistungsstarkes, um nicht zu sagen komplexes System. Es ist also kein Wunder, dass verschiedene eventuelle Sicherheitsprobleme bestehen.
 
-Note that this the very **first** version of the MMS, and it may well be that people using it in different circumstances will uncover new security problems beyond those mentioned here, or let some of them appear in a different light. There is reasonable hope however that the MMS does not have any deep and basically "unrepairable" conceptual flaws.
+Beachte, dass dies die **allererste** Version des MMS ist und es daher gut sein könnte, dass Menschen durch dessen Gebrauch in diversen Umständen neben den hier genannten Sicherheitsproblematiken auch neue Probleme aufdecken oder bekannte in ein anderes Licht stellen könnten. Dennoch besteht die begründete Hoffnung, dass das MMS im Grunde keine tiefgreifenden und irreparablen konzeptuellen Schwächen hat.
 
-TL;DR: If in doubt, start to use the MMS only after you have configured your multisig wallets yourself on your own, presumably in more secure ways than the MMS could provide (not trivial, but doable). If in even more doubt, don't use the MMS.
+Kurz gesagt: Wenn du dir unsicher bist, verwende das MMS erst, nachdem du deine Multisig-Wallets selbstständig eingerichtet hast - vermutlich auf gesicherteren Wegen als sie das MMS bereitstellen könnte (nicht einfach, aber machbar).
 
-### Use of Encryption and Signatures
+### Nutzen von Verschlüsselung und Signaturen
 
-All message content is encrypted either using the Monero viewkeys of the signers' Monero wallets, or with randomly generated keys of the same strength in the case of auto-config message contents. This may seem a little excessive given that PyBitmessage encrypts all messages itself already, but first PyBitmessage is a third-party software that you may not want to trust, and second with this feature the MMS is already prepared to some degree for less secure communication systems that don't encrypt themselves.
+Jeglicher Nachrichteninhalt wird entweder unter Verwendung der View-Keys der Monero-Wallets der Unterzeichner oder, im Falle von Auto-Config-Nachrichteninhalten, mit zufällig erstellten Schlüsseln derselben Stärke verschlüsselt. Angesichts der Tatsache, dass PyBitmessage selbst bereits alle Nachrichten verschlüsselt, mag dies ein wenig übertrieben scheinen. PyBitmessage ist jedoch erstens eine Fremdsoftware, der du eventuell nicht vertrauen möchtest, und zweitens ist das MMS mit dieser Funktion bereits zu einem gewissen Teil auf weniger sichere Kommunikationssysteme, die selbst nicht verschlüsseln, ausgerichtet.
 
-Messages are signed by the sender using their view private key. This is used for authentication: The MMS will reject a message from a signer that does not carry a valid signature that only that signer, and nobody else, could have made. Furthermore, a hash secures the message content against any changes. Lastly only messages from signers are accepted: A message from a Monero address that is not listed in the signer configuration gets rejected, even if it carries a valid signature.
+Nachrichten werden durch den Sender mithilfe seines privaten View-Keys signiert. Dies wird zur Authentifizierung benötigt: Eine Nachricht eines Unterzeichners, die über keine gültige Signatur (welche nur der Unterzeichner selbst und niemand sonst getätigt haben könnte) verfügt, wird vom MMS abgelehnt werden. Außerdem sichert auch ein Hash den Nachrichteninhalt gegenüber jeglicher Änderungen. Letztlich werden nur Nachrichten von Unterzeichnern akzeptiert: Eine Nachricht von einer nicht in der Unterzeichnerkonfiguration gelisteten Monero-Adresse wird abgelehnt, selbst, wenn sie mit einer gültigen Signatur versehen ist.
 
-The viewkey is also used to encrypt the content of the `.mms` file that contains signer configuration and all sent and received messages.
+Der View-Key wird zudem dazu verwendet, den Inhalt der `.mms`-Datei, welche die Unterzeichnerkonfiguration und alle gesendeten und empfangenen Nachrichten enthält, zu verschlüsseln.
 
-Still, regarding data transmission security requirements one should probably stay realistic: Of course you don't want the various data packets that get shuttled back and forth between the signers' wallets to get into the wrong hands, but it would not be easy to cause real harm for an attacker holding some of that data. After all, the whole point of multisig is that only a group of people **cooperating** can sign off and submit a transaction. An attacker that gets hold of a partially signed transaction won't be able to do much with it.
+Trotzdem sollte man wohl angesichts der Sicherheitsanforderungen von Datenübertragungen realistisch bleiben: Natürlich ist nicht gewollt, dass die diversen Datenpakete, die zwischen den Wallets der Unterzeichner hin- und herpendeln, in die falschen Hände gelangen; für einen Angreifer, der über einige dieser Daten verfügt, wäre es jedoch nicht einfach, einen wirklichen Schaden anzurichten. Letzten Endes ist es das Ziel von Multisig, dass nur eine Gruppe **kooperierender** Menschen eine Transaktion unterzeichnen und damit genehmigen und absenden kann. Ein Angreifer, der eine teilsignierte Transaktion in die Finger bekommt, wird nicht viel damit anfangen können.
 
-(An attacker eavesdropping on **all communication** from the very start probably could, if data was not encrypted, collect all keys and build a fully working Monero "single-sig" wallet for the multisig address and steal coins, but that's a pretty drastic scenario, and data sent by the MMS **is** encrypted.)
+(Ein Angreifer, der von Beginn an **jegliche Kommunikation** abhört, könnte vermutlich alle Schlüssel sammeln und ein voll funktionsfähiges Monero-"Single-Sig"-Wallet für diese Multisig-Adresse erstellen und Coins stehlen, wenn Daten nicht verschlüsselt wurden. Dies ist aber ein ziemlich drastisches Szenario - vom MMS gesendete Daten **sind** verschlüsselt.)
 
-### Communication MMS to PyBitmessage
+### Kommunikation von MMS zu PyBitmessage
 
-Communication between the MMS and PyBitmessage is, unfortunately, not encrypted. Here, HTTP is used, not its encrypted counterpart HTTPS. Message content is of course encrypted **before** the MMS transmits a message to PyBitmessage, and any content changes would be detected when receiving messages, but somebody listening there could learn things from the "metadata": Who sends what to whom at which point in time.
+Unglücklicherweise ist die Kommunikation zwischen MMS und PyBitmessage nicht verschlüsselt. Hierbei wird HTTP verwendet, nicht dessen verschlüsseltes Gegenstück HTTPS. Nachrichteninhalte werden natürlich **vor** der Übertragung von MMS an PyBitmessage verschlüsselt, und jegliche Änderungen des Inhalts würden beim Empfang der Nachricht aufgespürt. Ein "Zuhörer" könnte jedoch Informationen aus den "Metadaten" ziehen - etwa darüber, wer was an wen zu welchem Zeitpunkt sendet.
 
-As long as your Monero wallet with the MMS and PyBitmessage run on the same machine, that's not a big danger in itself, because anybody who can listen on such strictly local communication `localhost` to `localhost` already sits inside your computer, in which case you have probably lost anyway, with the trojan listening to the traffic between MMS and PyBitmessage being the least of your worries.
+Solange dein Monero-Wallet gemeinsam mit dem MMS und PyBitmessage auf demselben Gerät läuft, ist dies an und für sich keine große Gefahr: Jeder, der eine solche, strikt lokale Kommunikation - `localhost` an `localhost` - abhören kann, ist bereits in deinem Computer; in dem Fall hast du wahrscheinlich eh schon verloren und der Trojaner, der den Verkehr zwischen MMS und PyBitmessage abhorcht, ist dann vermutlich deine letzte Sorge. 
 
-But because of this it's not a good idea to set up a PyBitmessage instance reachable over the Internet, as some kind of "public node".
+Aufgrunddessen ist es keine gute Idee, eine PyBitmessage-Instanz einzurichten, die über das Internet erreichbar ist (wie eine Art "öffentlicher Node").
 
-There is a second problem: The PyBitmessage API is only secured by a username and a password that has to be transmitted in cleartext with every HTTP request. It would be not very hard for an attacker to pick up username and password and starting DOS-type attacks, e.g. by deleting all messages in 10-second intervals.
+Es gibt zudem ein zweites Problem: Der PyBitmessage-API wird nur durch einen Nutzernamen und ein Passwort geschützt, welche als Klartext mit jeder HTTP-Anfrage übermittelt werden müssen. Für einen Angreifer wäre es nicht besonders schwer, Nutzernamen und Passwort abzufangen und Angriffe des DOS-Typs zu starten, etwa durch das Löschen aller Nachrichten in 10-Sekunden-Intervallen.
 
-(In PyBitmessage's defense one must say that is was **not** designed as a server that can face the big wide bad Internet, but as a program to run locally; it's hardly surprising that running it outside its intended use case leads to problems.)
+(Zur Verteidigung von PyBitmessage muss gesagt werden, dass es **nicht** als Server, der dem großen, weiten, bösen Internet gegenübertreten kann, sondern als ein lokal laufendes Programm entworfen wurde. Es ist nicht wirklich überraschend, dass bei der Ausführung außerhalb des angedachten Anwendungsfalls Problemen auftreten.)
 
-### Impersonation
+### Identitätsbetrug
 
-If Alice the buyer and Bob the seller use 2/3 multisig for *escrow* there will be Trent as a trusted third person that can arbitrate in case of problems and either help Alice get her money back if Bob does not deliver by signing a transaction started by Alice, or helping Bob getting his money if Alice likely got her wares but pretends otherwise and refuses to sign the payment to Bob.
+Wenn Alice, die Käuferin, und Bob, der Verkäufer, zur *Hinterlegung* ein 2/3-Multisig verwenden, wird es Trent als vertrauten Dritten geben, der im Falle von Problemen zwischen beiden Parteien vermitteln kann: Er kann entweder Alice durch das Signieren einer von ihr initiierten Transaktion helfen, ihr Geld zurückzubekommen, falls Bob nicht liefern sollte, oder ebendiesen unterstützen, wenn Alice die Ware mit großer Wahrscheinlichkeit erhalten hat, diese das aber abstreitet und sich weigert, die an Bob gehende Zahlung zu signieren.
 
-In this *escrow* situation you really want **three** distinct persons in play. If Bob somehow can *impersonate* Trent by posing as him, by pretending to Alice to be two persons Bob plus Trent, and set up **two** different wallets with two sets of keys, Bob will be able to make those 2/3 multisig transactions valid all on his own and cheat.
+In eine solche Situation der *Hinterlegung* wirst du tatsächlich **drei** verschiedene Personen einbinden wollen. Sollte es Bob irgendwie gelingen, sich Alice gegenüber als Trent auszugeben und zudem **zwei** verschiedene Wallets mit zwei Schlüsselsätzen einzurichten, wird er durch diesen Identitätsbetrug in der Lage sein, solcherlei 2/3-Multisig-Transaktionen selbst zu validieren.
 
-How big this danger of impersonation is depends on how secure the initial exchange of key sets is at the very beginning of the whole process, when configuring the wallets and finally "going multisig": If you can assure that only the right people get the right key sets, and nobody can pose somehow as somebody else, everything is alright. If not, you may loose.
+Wie groß die Gefahr eines Identitätsbetrugs ist, liegt von dem Sicherheitslevel des ursprünglichen Austauschs der Schlüsselsätze ganz zu Beginn des Vorgangs ab, während die Wallets eingerichtet und schließlich in den Multisig-Modus umgestellt werden: Kannst du versichern, dass ausschließlich die richtigen Personen die richtigen Schlüsselsätze erhalten haben und sich somit niemand als jemand anderen ausgeben kann, dann ist alles in Ordnung. Wenn nicht, könntest du den Kürzeren ziehen.
 
-If you use the full capabilities of the MMS you don't use it only to transact, but already before that, to exchange key sets between all signers. Especially for higher forms of multisig like 2/4 with multiple key exchange rounds this is very helpful and less error-prone than some manual process. So, the task to prevent impersonation shifts from securing the exchange of keys to securely setting up signer addresses in the MMS: If Bob can somehow trick Alice into accepting one of **his** Monero and Bitmessage addresses in stead of those of Trent, he has won.
+Wenn du die vollen Möglichkeiten des MMS ausschöpfst, nutzt du es nicht nur zum Durchführen von Transaktionen, sondern bereits davor zum Austauschen der Schlüsselsätze unter allen Unterzeichnern. Besonders für höhere Typen von Multisig, wie etwa 2/4 mit zahlreichen Austauschrunden, kann dies wirklich hilfreich und weniger fehlerhaft als so mancher manuelle Ablauf sein. Es gilt also, einem möglichen Identitätsbetrug vom Sichern des Schlüsselaustauschs bis hin zum sicheren Einrichten von Unterzeichneradressen ins MMS vorzubeugen: Wenn Bob Alice auf irgendeine Weise dazu bringen kann, dass sie eine **seiner** Monero- und Bitmessage-Adressen anstelle der von Trent akzeptiert, hat er gewonnen.
 
-The three methods of setting up signer addresses that the MMS supports, manually configuring signers, auto-config and the "semi-automatic" sending of completed signer information, all have different risks associated with them regarding impersonation. Check the respective chapters *Manually Configuring Signers*, *Auto-Config* and *Sending Signer Information* for some more info about this.
+Alle drei vom MMS unterstützten Methoden zum Einrichten von Unterzeichneradressen - Unterzeichner manuell einrichten, Auto-Config und das "halbautomatische" Senden vervollständigter Unterzeichnerinformationen - haben unterschiedliche, mit ihnen verbundene Risiken bezüglich Identitätsbetrugs. In den jeweiligen Kapiteln finden sich weitere Infos darüber: *Unterzeichner manuell einrichten*, *Auto-Config* und *Unterzeichnerkonfiguration senden*. 
 
-Auto-config is by far the easiest to secure: You only have a tiny bit of information, an 11-character auto-config token, to transmit securely to each signer, and if you can do that, you have already won. (The "config manager" is of course assumed as trustworthy here.)
+Auto-Config ist bei Weitem am einfachsten zu sichern: Du musst nur ein winzigkleines Bisschen an Information - einen Auto-Config-Token mit elf Schriftzeichen - sicher an jeden Unterzeichner übersenden, und wenn du dies tun kannst, hast du schon gewonnen. (Der "Config-Manager" wird hier natürlich als vertrauenswürdig angenommen.)
 
-If this all sounds too complicated and therefore not trustworthy to you, you do have the option to configure wallets and establishing the multisig address leaving the MMS completely out of the picture and only later using it to comfortably send partially signed transactions around and relieve you from the tedious manual syncing of wallets after each transaction.
+Wenn sich das für dich alles zu kompliziert und deshalb nicht vertrauenswürdig anhört, hast du die Möglichkeit, ganz ohne das MMS Wallets einzurichten und Multisig-Adressen herzuleiten. Erst später kommt das MMS zwecks des bequemen Umhersendens teilsignierter Transaktionen, und um dich vom ermüdenden manuellen Synchronisieren nach jeder Transaktion zu befreien, ins Spiel. 
 
-### Attacker-Controlled Data
+### Von Angreifern kontrollierte Daten
 
-There are two situations where your MMS-using wallet receives data from another signer where that other signer, if acting in bad faith, could try to deceive you or trick you into doing something harmful:
+Es gibt zwei Situationen, in denen dein das MMS nutzende Wallet Daten eines anderen Unterzeichner empfängt und dieser andere Unterzeichner in böser Absicht versuchen könnte, dich zu betrügen oder dich dazu zu bringen, etwas Schädliches zu tun:
 
-Notes as transmitted by the `mms note` command can be used for "social engineering". An attacker could e.g. try to formulate a note that looks like an error message in an attempt to deceive. The technical possibilities here are quite limited however: Notes are strictly textual only, and when displaying them the MMS filters out characters with ASCII codes less than 32 and the two characters "<" and ">" that could be used to build HTML or XML that might get interpreted somehow (very unlikely in the CLI wallet, but somewhat more likely in GUI-based wallets.) There is also a length limit for notes.
+Notizen, wie sie vom `mms note`-Befehl übermittelt werden, können zum "Social Engineering" eingesetzt werden. Ein Angreifer könnte bspw. versuchen, jemanden mittels einer wie eine Fehlermeldung erscheinenden Notiz zu täuschen. Die technischen Möglichkeiten sind hier allerdings begrenzt: Notizen sind ausschließlich textlichen Inhalts. Zeigt das MMS eine Notiz an, filtert es Schriftzeichen mit ASCII-Codes von weniger als 32 Zeichen Länge und den Zeichen "<" und ">", die zum Konstruieren von möglicherweise interpretierbarem HTML oder XML genutzt werden könnten, heraus (sehr unwahrscheinlich im CLI-Wallet, aber etwas wahrscheinlicher in GUI-basierenden Wallets). Außerdem besteht für Notizen eine Längenbegrenzung.
 
-The second way is an attempt to deceive with labels that are sent through `mms send_signer_config`. Bob could label Alice as *trent* and Trent as *alice*, send that signer configuration to Alice and somehow convince her to use that. This is the reason why a message of type `singer config` if sent outside of auto-config with an explicit `mms send_signer_config` is not processed right away, but displayed first together with a confirmation prompt.
+Der zweite Weg ist ein Betrugsversuch mittels Labels, die durch den `mms send_signer_config`-Befehl gesendet werden. Bob könnte Alice als *Trent* und Trent als *Alice* labeln, die Unterzeichnerkonfiguration an Alice senden und diese irgendwie von deren Verwendung überzeugen. Das ist der Grund dafür, dass eine Nachricht des Typs `signer config` (falls außerhalb des Auto-Configs mit einem expliziten `mms send_signer_config`-Befehl gesendet) nicht sofort verarbeitet, sondern zunächst zusammen mit einer Sicherheitsabfrage angezeigt wird.
 
-## Troubleshooting
+## Fehlerbehebung
 
-### Solving Syncing Troubles
+### Synchronisationsprobleme lösen
 
-As explained in the chapter *Syncing Wallets* Monero multisig requires the exchange of some data between wallets after sending as well as receiving transactions, called *multisig sync data* in the MMS.
+Wie im Kapitel *Wallets synchronisieren* erklärt, benötigt Monero-Multisig nach dem Senden wie auch nach dem Empfangen von Transaktionen den Austausch einiger Daten zwischen Wallets. Diese werden im MMS *multisig sync data* genannt.
 
-Sometimes things get out of sync somehow. There are four possible signs that this may have happened:
+Manchmal geraten Dinge irgendwie "aus dem Takt". Es gibt vier mögliche Anzeichen dafür, dass dies passiert sein könnte:
 
-* The `balance` command shows a message *Some owned outputs have partial key images - import\_multisig\_info needed* that "refuses go away"
-* The wallet tells you *That signature was made with stale data* and refuses to process a transaction further
-* The wallet tells you about missing keys when you try to sign a transaction
-* The wallet accuses you of a double-spending attempt with you probably trying nothing like that
+* Der `balance`-Befehl zeigt eine Nachricht ("*Some owned outputs have partial key images - import\_multisig\_info needed*"), die sich "weigert", zu verschwinden.
+* Das Wallet sagt dir: "*That signature was made with stale data*", und verweigert die Weiterverarbeitung einer Transaktion.
+* Das Wallet teilt dir beim Versuch des Signierens einer Transaktion mit, dass Schlüssel fehlen.
+* Das Wallet lastet dir an, versucht zu haben, Gelder doppelt zu senden, obwohl du (wahrscheinlich) nichts dergleichen getan hast.
 
-In some such cases the MMS fails to become aware of the problem and simply tells you after `mms next` that there is nothing to do instead of starting a sync round.
+In manchen solcher Fälle scheitert das MMS daran, das Problem zu erkennen, und teilt dir nach dem `mms next`-Befehl einfach mit, dass es nichts zu tun gibt, anstatt eine Synchronisationsrunde einzuleiten.
 
-Because of this there is a way to **force sync** at basically any time:
+Aus diesem Grund gibt es einen Weg, die **Synchronisation** jederzeit zu **erzwingen**:
 
-* All signers issue a `mms sync` command instead of simply `mms next` to send sync info to each other
-* After receiving those messages all signers issue a `mms next sync` command - note the extra argument `sync`
+* Alle Unterzeichner erteilen zum Senden von Synchronisationsinfos anstelle des einfachen `mms next` einen `mms sync`-Befehl.
+* Nach dem Empfang dieser Nachrichten erteilen alle Unterzeichner einen `mms next sync`-Befehl - beachte das zusätzliche Argument `sync`.
 
-For syncing to work all information must be from the same "height" i.e. produced with the same number of transfers recorded in the wallets of all signers: If for example one signer somehow does not receive a transaction and sends out sync information in this state, it will be of no value to other signers with complete wallets.
+Damit die Synchronisation funktioniert, müssen alle Informationen von derselben "Höhe" sein, sprich mit einer von allen Unterzeichner-Wallets übereinstimmend aufgezeichneten Anzahl von Transfers: Wenn bspw. ein Unterzeichner eine Transaktion aus irgendeinem Grund nicht erhält und in diesem Stadium Synchronisationsinformationen versendet, werden diese für andere Unterzeichner mit kompletten Wallets nicht von Nutzen sein.
 
-If the MMS seems to ignore not yet processed sync data messages in state `waiting` most probably it does so because of this reason. When in doubt check the column `Height` in a list of messages that you get with `mms list`.
+Falls das MMS noch nicht verarbeitete Nachrichten mit Synchronisationsdaten mit dem Status `waiting` zu ignorieren scheint, passiert dies höchstwahrscheinlich aus genau diesem Grund. Wenn du dir unsicher bist, überprüfe die Spalte `Height` in einer Nachrichtenliste, welche du mit `mms list` erhältst.
 
-Sometimes such not yet processed messages that became unprocessable trip up the `mms next` command. If that happens use `mms delete` to delete any message with a too-low height.
+Es kommt vor, dass solche bisher nicht verarbeiteten Nachrichten, die schließlich "nicht mehr verarbeitbar" werden, dem `mms next`-Befehl ein Bein stellen. Wenn das passiert, kannst du mit `mms delete` jegliche Nachrichten mit zu niedriger Höhe löschen.
 
-### Redirecting a Transaction to Another Signer
+### Eine Transaktion an einen anderen Unterzeichner umleiten/weiterleiten
 
-If in cases like 2/3 multisig you sent a partially-signed tx to somebody, but later change your mind and want to send it to somebody else, there is a little trick to do so: Locate the message of type `partially signed tx` addressed **to yourself** and issue a `mms send` command for that message. After reception, do `mms next`. You will be given choice again what to do with it.
+Wenn du in in Fällen wie 2/3-Multisig eine teilsignierte Transaktion an jemanden gesendet hast, es dir aber später anders überlegst und sie vielleicht an jemand anderen schicken möchtest, gibt es dazu einen kleinen Trick: Lokalisiere die **an dich** adressierte Nachricht des Typs `partially signed tx` und erteile einen `mms send`-Befehl für ebendiese Nachricht. Nach dem Empfang führst du `mms next` aus. Dir wird dann erneut die Wahl gegeben, was du mit dieser Nachricht machen möchtest.
 
-Of course you are free to ignore that transaction and start a new one. Just consider that this new transaction might run into a roadblock later on if the first one gets fully signed and submitted to the network **earlier** than this second one.
+Natürlich kannst du diese Transaktion auch ignorieren und eine neue initialisieren. Dabei solltest du nur beachten, dass diese neue Transaktion im späteren Verlauf auf eine Blockade stoßen könnte, wenn die erste **früher** als diese zweite komplett signiert an das Netzwerk weitergeleitet wird.
 
-### Ignoring Uncooperative Signers when Syncing
+### Unkooperative Unterzeichner beim Synchronisieren ignorieren
 
-The normal MMS wallet syncing process assumes that all signers are cooperative and send out sync data messages after sending or receiving a transaction. `mms next` will therefore wait until it holds sync data messages (for the same "height") from **all** other signers before usually processing them.
+Der normale Synchronisationsvorgang des MMS-Wallets geht davon aus, dass alle Unterzeichner kooperativ sind und nach dem Senden/Empfangen einer Transaktion Nachrichten mit Synchronisationsdaten versenden. `mms next` wartet daher solange, bis es diese Synchronisationsdatennachrichten (für dieselbe "Höhe") von **allen** anderen Unterzeichnern erhalten hat, und verarbeitet sie erst dann wie üblich.
 
-However, with *M* being smaller than *N* in configurations like 2/3 multisig you can successfully sync with only (number of required signers minus 1) sync messages. `mms next` will tell you when you have reached this lower threshold and give a hint how to override and go ahead early: Use `mms next sync`.
+Da *M* in Konfigurationen wie 2/3-Multisig kleiner als *N* ist, kannst du allerdings erfolgreich mit lediglich (Anzahl erforderlicher Unterzeichner minus 1) Synchronisationsnachrichten synchronisieren. `mms next` sagt dir Bescheid, sobald du diese untere Schwelle erreicht hast, und gibt dir zudem einen Hinweis zum Überschreiben und damit zum zeitigen Fortfahren: Verwende `mms next sync`.
 
-If later you receive more sync data messages nevertheless just delete them with `mms delete`: They are unneeded, unprocessable for you and worst case will mess up the the next sync round.
+Wenn du dennoch später weitere Nachrichten mit Synchronisationsdaten erhältst, lösche diese einfach mit `mms delete`: Sie sind unnötig und für dich nicht verarbeitbar und bringen im schlimmsten Fall die nächste Synchronisationsrunde durcheinander.
 
-Usually if you initiate sync the MMS will create messages to *all* other signers. If you want to prevent that to make it as hard as possible for other signers to transact further, make sure to set `auto-send` to false, answer "No" when first being asked to send, and manually delete any unwanted messages before sending the rest out with `mms send`.
+Initiierst du die Synchronisation, so erstellt das MMS üblicherweise Nachrichten an *alle* anderen Unterzeichner. Wenn du dies unterbinden und es anderen damit so schwer wie möglich machen möchtest, die Transaktion fortzuführen, stelle sicher, dass du `auto-send` auf "false" stellst, auf die erste Sendeaufforderung mit "No" antwortest und jegliche ungewollten Nachrichten manuell löschst, bevor du den Rest mit `mms send` verschickst.
 
-### Recovering from Lost or Duplicate Messages
+### Von abhandengekommenen oder doppelten Nachrichten wiederherstellen
 
-If you miss a message for any reason, because PyBitmessage failed to deliver it or because you deleted it too early, ask the sender of the message to send it again using the `mms send` command.
+Wenn dir eine Nachricht aus irgendeinem Grund - etwa weil PyBitmessage an ihrer Lieferung scheitert oder du sie zu früh gelöscht hast - entgeht, bitte den Sender darum, die jeweilige Nachricht unter Verwendung des `mms send`-Befehls erneut zu senden.
 
-Note that messages sent multiple times do *not* automatically cancel out each other on the receiving end. If you resend e.g. just because somebody is impatient the addressed signer may end up receiving *two* messages of the same type with the same content.
+Beachte, dass sich mehrfach gesendete Nachrichten auf der Empfangsseite *nicht* automatisch gegenseitig aufheben. Wenn du eine Nachricht z.B. aus schlichter Ungeduld erneut sendest, könnte der adressierte Unterzeichner zwei Nachrichten desselben Typs und mit demselben Inhalt empfangen.
 
-If later the missing message belatedly shows up, that's not good, but you can solve this easily by using a `mms delete` command and get rid of one of the two copies.
+Wenn die fehlende Nachrichte später nachträglich erscheint, ist das nicht gut; du kannst die Situation jedoch leicht lösen, indem du eine der zwei Kopien mit dem `mms delete`-Befehl beseitigst.
 
-### Correcting / Updating Signer Information
+### Informationen von Unterzeichnern korrigieren/aktualisieren
 
-You can use the `mms signer` command to change a label `bob` that you don't like anymore:
+Mit dem `mms signer`-Befehl kannst du ein Label (`bob`) ändern, wenn es dir nicht mehr gefällt: 
 
     mms member 2 bob-the-builder
 
-With one more argument you can change Bitmessage addresses if needed:
+Mit einem weiteren Argument kannst du Bitmessage-Adressen bei Bedarf ändern:
 
     mms member 2 bob BM-2cSrgmut9AD6bdU8b8GXd36iUYDjCS9xJb
 
-You can even change Monero addresses in the same way (with the exception of your own of course), but with a limitation, only as long as there are no received messages. As soon as wallets are multisig it does not make sense anymore to change any Monero addresses anymore anyway.
+Du kannst auf dieselbe Weise sogar Monero-Adressen ändern (natürlich mit Ausnahme deiner eigenen Adresse), allerdings mit der Beschränkung, dass dies nur funktioniert, solange es keine empfangenen Nachrichten gibt. Sobald Wallets im "Multisig-Modus" sind, ergibt es eh keinen Sinn mehr, Monero-Adressen zu ändern.
 
-### Starting from Scratch
+### Von Grund auf beginnen
 
-If the state of the MMS for a wallet is messed-up beyond repair and you want to start from scratch, or if you want to stop using the MMS for a particular wallet, locate the wallet files in the file system and just delete the file with the `.mms` extension.
+Wenn bei einem Wallet der Zustand des MMS irreparabel beschädigt ist und du ganz von Grund auf beginnen möchtest oder du das MMS bei einem bestimmten Wallet nicht mehr verwenden willst, lokalisiere die Wallet-Dateien im Dateisystem und lösche die Datei mit der `.mms`-Dateierweiterung.
 
-### MMS / PyBitmessage Interactions
+### Interaktion von MMS/PyBitmessage
 
-Here some details about the interaction between the MMS and PyBitmessage to better understand any problems that may occur there:
+Nachfolgend einige Details über die Interaktion zwischen dem MMS und PyBitmessage für ein besseres Verständnis dort möglicherweise auftretender Probleme:
 
-The MMS tries to limit the number of messages that pile up in PyBitmessage's store and deletes them. However, for enhanced reliability it does not delete right after receiving already but only after a message changes its state from `waiting` to `processed`, or if you delete it from the message store. Sometimes messages get orphaned and the MMS has no chance to delete; you can safely delete such messages interactively in PyBitmessage itself.
+Das MMS versucht, die Anzahl der Nachrichten, die sich in PyBitmessages Speicher anhäufen, zu limitieren und löscht sie. Zwecks verbesserter Zuverlässigkeit löscht es jedoch nicht direkt nach dem Empfang, sondern erst, nachdem eine Nachricht ihren Status von `waiting` zu `processed` geändert hat oder du sie aus dem Nachrichtenspeicher gelöscht hast. Manchmal "verwaisen" Nachrichten regelrecht, und dennoch hat das MMS keine Möglichkeit, sie zu löschen. Du kannst solcherlei Nachrichten sicher und interaktiv bei PyBitmessage selbst löschen.
 
-If you use auto-config new addresses / identities will be created in PyBitmessage automatically for the MMS. It tries to delete those after finishing config, but note that the current version of PyBitmessage continues to display deleted addresses until next program restart: Harmless in principle, but somewhat confusing.
+Wenn du Auto-Config verwendest, werden in PyBitmessage automatisch neue Adressen/Identitäten für das MMS erstellt. Es versucht, diese nach der Fertigstellung der Einrichtung zu entferne. Beachte jedoch, dass die aktuelle PyBitmessage-Version gelöschte Adressen weiterhin bis zum nächsten Neustart des Programms anzeigt: Prinzipiell harmlos, aber doch irgendwie verwirrend.
 
-If such dynamic auto-config addresses don't get deleted at all e.g. because you delete a wallet beforehand unfortunately it seems there is no simple way in the current PyBitmessage version to get rid of them: You will have to manually locate and edit the `keys.dat` file and delete the corresponding lines (while hopefully not damaging anything else in there...)
+Falls solche dynamischen Auto-Config-Adressen gar nicht entfernt werden (z.B. weil du im Vorfeld ein Wallet gelöscht hast und es in der aktuellen PyBitmessage-Version unglücklicherweise keinen einfachen Weg gibt, diese loszuwerden): Du musst dazu die `keys.dat`-Datei manuell lokalisieren und editieren, indem du die entsprechenden Zeilen (hoffentlich ohne Schädigung von irgendetwas anderem darin...) löschst.
 
-Sometimes messages seem to get stuck and not sent out; try to restart PyBitmessage in such cases.
+Es scheint, als würden Nachrichten manchmal "feststecken" und nicht abgesendet werden; versuche es in solchen Fällen mit einem Neustart von PyBitmessage.

--- a/_i18n/de/resources/user-guides/tor_wallet.md
+++ b/_i18n/de/resources/user-guides/tor_wallet.md
@@ -1,85 +1,85 @@
-{% include disclaimer.html translated="no" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-Below we'll show an example configuration that allows you to run a Monero daemon (eg on a home server or VPS) that you can connect to from another computer running your wallet.  We do this over the Tor anonymity network to retrieve the transaction information needed by your wallet.  The benefit of this approach is that the daemon (`monerod`) can stay on all of the time sending / receiving blocks, while the wallet can connect when needed and have access to the full blockchain. [Monerujo](https://www.monerujo.io/) should also work via [Orbot](https://guardianproject.info/apps/org.torproject.android/).  Because Tor hidden services provide encryption and authentication, you can be confident that your RPC credentials will not be sent in the clear.  Tor also solves problems often seen on home servers related to port-forwarding, IP addresses changing, etc -- it just works.  This setup will also obfuscate the fact that you are connecting to a remote Monero node. Tested with Monero `v0.15.0.1` connecting a Mac laptop wallet to a remote Linux node (Ubuntu 18.04.2).
+Unten findest du eine beispielhafte Konfiguration, mit welcher es dir möglich ist, einen Monero-Hintergrunddienst (etwa auf einem Heim-Server oder VPS) zu betreiben, zu dem du dich von einem anderen Rechner, auf welchem dein Wallet läuft, verbinden kannst. Über das Anonymitätsnetzwerk Tor werden die für dein Wallet benötigten Transaktionsinformationen wiederhergestellt. Das Gute an dieser Herangehensweise ist, dass der Hintergrunddienst (`monerod`) allzeit betrieben werden und damit dauerhaft Blöcke senden/empfangen kann, während das Wallet lediglich bei Bedarf - wenn es Zugriff auf die gesamte Blockchain benötigt - zu diesem verbunden werden kann. [Monerujo](https://www.monerujo.io/) sollte auch via [Orbot](https://guardianproject.info/apps/org.torproject.android/) laufen. Da Tors versteckte Dienste Verschlüsselung und Authentifizierung bieten, kannst du dir sicher sein, dass deine RPC-Anmeldedaten nicht ins "Clear(net)" gesendet werden. Tor behebt außerdem Probleme (etwa im Zusammenhang mit Portweiterleitungen oder IP-Adressenwechseln), die häufig bei Privatservern auftreten - es funktioniert einfach. Diese Einrichtung verschleiert zudem den Umstand, dass du dich zu einem Monero-Remote-Node verbindest. Getestet wurde die Verbindung eines Mac-Laptops zu einem Linux-Remote-Node (Ubuntu 18.04.2) mit der Monero-Version `v0.15.0.1`.
 
-## Create a Tor hidden service for RPC
+## Erstelle einen versteckten Tor-Dienst für RPC
 
-Make sure [Tor is installed](https://community.torproject.org/relay/setup/bridge/debian-ubuntu/) and running correctly, then proceed.
+Stelle sicher, dass [Tor installiert ist](https://community.torproject.org/relay/setup/bridge/debian-ubuntu/) und richtig läuft. Fahre erst dann fort.
 
-We only need to configure the RPC server to run as a hidden service here on port `18081`.
+Der RPC-Server muss lediglich so eingerichtet werden, dass er als versteckter Dienst, hier auf Port `18081`, läuft.
 
-File: `/etc/torrc`
+Datei: `/etc/torrc`
 
 ```
 HiddenServiceDir /var/lib/tor/monero-service/
 HiddenServicePort 18081 127.0.0.1:18081
 ```
-Restart Tor:
+Starte Tor neu:
 ```
 sudo systemctl restart tor@default
 ```
 
-Make sure Tor started correctly:
+Stelle sicher, dass Tor richtig gestartet hat:
 ```
 sudo systemctl status tor@default.service
 ```
 
-If everything looks good, make a note of the hidden service (onion address) name:
+Wenn soweit alles gut aussieht, mache eine Notiz des Namens des versteckten Dienstes (Onion-Adresse):
 ```
 sudo cat /var/lib/tor/monero-service/hostname
 ```
-It will be something like 4dcj312uxag2r6ye.onion -- use this for `HIDDEN_SERVICE` below.
+Dieser wird ungefähr so wie "4dcj312uxag2r6ye.onion" aussehen. Du nutzt ihn weiter unten für `HIDDEN_SERVICE`.
 
-### Configure Daemon to allow RPC
+### Hintergrunddienst für RPC einrichten
 
-In this example, we don't use Tor for interacting with the p2p network, just to connect to the monero node, so only RPC hidden service is needed.
+In diesem Beispiel wird Tor nicht zur Interaktion mit dem P2P-Netzwerk genutzt, sondern lediglich, um sich zum Monero-Node zu verbinden; dadurch wird nur der versteckte RPC-Dienst benötigt.
 
-File: `~/.bitmonero/bitmonero.conf` (in the home directory of the Monero user)
+Datei: `~/.bitmonero/bitmonero.conf` (im Home-Verzeichnis des Monero-Nutzers)
 
 ```
 no-igd=1
 restricted-rpc=1
 rpc-login=USERNAME:PASSWORD
 ```
-(Make up a USERNAME and PASSWORD to use for RPC)
+(Denke dir einen NUTZERNAMEN und ein PASSWORT für den RPC aus)
 
-Restart the Daemon: `monerod stop_daemon; sleep 10; monerod --detach`
+Starte den Hintergrunddienst neu: `monerod stop_daemon; sleep 10; monerod --detach`
 
-Make sure the daemon started correctly:
+Stelle sicher, dass der Hintergrunddienst richtig gestartet hat:
 ```
 tail -f ~/.bitmonero/bitmonero.log
 ```
 
-## Connecting to your node from a local wallet
+## Von einem lokalen Wallet zu deinem Node verbinden
 
-Make sure you have Tor running locally so you can connect to the Tor network. One simple way on the Mac is to just start the Tor browser and use its Tor daemon.
+Stelle sicher, dass Tor lokal bei dir läuft, sodass du dich zum Tor-Netzwerk verbinden kannst. Auf dem Mac ist ein einfacher Weg dazu das simple Starten des Tor-Browsers und die Nutzung des Tor-Hintergrunddienstes.
 
-Then test a simple RPC command, eg:
+Teste dann einen einfachen RPC-Befehl, etwa:
 ```
 curl --socks5-hostname 127.0.0.1:9150 -u USERNAME:PASSWORD --digest -X POST http://HIDDEN_SERVICE.onion:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json'
 ```
-Replace `USERNAME`, `PASSWORD`, and `HIDDEN_SERVICE` with values from above.  Change `9150` to another port if needed by your local Tor daemon.
+Ersetze `USERNAME`, `PASSWORD` und `HIDDEN_SERVICE` mit den obigen Werten. Ändere `9150` zu einem anderen Port ab, wenn von deinem lokalen Tor-Hintergrunddienst benötigt.
 
-When you execute the command, you should get some info about the remote daemon if everything is working correctly.  If not, add a ` -v ` to the beginning and try to debug why it's not connecting, check firewalls, password, etc.
+Wenn alles korrekt läuft, solltest du nach dem Ausführen des Befehls Infos zum Remote-Hintergrunddienst erhalten. Falls dem nicht so ist, füge ` -v ` an den Anfang an und teste dann, aus welchem Grund keine Verbindung hergestellt wird; überprüfe Firewalls, das Passwort etc.
 
-Once it is working, you can connect using your cli wallet:
+Sobald alles funktioniert, kannst du via CLI-Wallet verbinden:
 ```
 ./monero-wallet-cli --proxy 127.0.0.1:9150 --daemon-host HIDDEN_SERVICE.onion --trusted-daemon --daemon-login USERNAME:PASSWORD --wallet-file ~/PATH/TO/YOUR/WALLET
 ```
-Replace values above as needed.
+Ersetze die Werte nach Bedarf.
 
 ## GUI
 
-If you are interested in experimenting with the GUI over Tor, you can try `torsocks` (note this may leak info -- do not rely on it if your life depends on maintaining anonymity).  Here is an example on MacOS, adjust as needed for the Linux GUI:
+Wenn du daran interessiert bist, mit dem GUI via Tor herumzuexperimentieren, kannst du es mit `torsocks` versuchen (beachte jedoch, dass hierdurch Informationen durchsickern könnten - verlasse dich besser nicht darauf, wenn dein Leben von der Erhaltung deiner Anonymität abhängt). Dieses Beispiel bezieht sich auf MacOS, du kannst es nach Bedarf für das Linux-GUI anpassen:
 ```
 torsocks --port 9150 /Applications/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui
 ```
 
-This will allow the GUI to communicate with the Tor network.  Once the GUI is open and a wallet loaded, you must configure it to connect to your Tor hidden service by adding your onion address to:  "Settings > Node > Remote node > Address".
+Dies erlaubt dem GUI die Kommunikation mit dem Tor-Netzwerk. Sobald das GUI geöffnet und ein Wallet geladen ist, musst du es für die Verbindung zum Tor-Netzwerk einrichten. Dies tust du, indem du deine Onion-Adresse hier hinzufügst: "Einstellungen > Node > Remote-Node > Adresse".
 
-In future versions of the GUI, we expect to add direct Tor / I2P support so that `torsocks` + commandline are not needed.
+Wir rechnen damit, dass in zukünftigen Versionen des GUI eine direkte Tor/I2P-Unterstützung eingebunden wird, sodass `torsocks` + Befehlszeile nicht benötigt werden.
 
-# Additional resources
+# Zusätzliche Quellen
 
 * [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)


### PR DESCRIPTION
German translation of the following user guides:

- Multisig transactions with MMS and CLI wallet
- Connecting your local wallet to your own daemon over Tor