### PR TITLE
Merchants: remove anycoindirect

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -7,8 +7,6 @@
       url: https://agoradesk.com
     - name: Alfacashier
       url: https://www.alfacashier.com/
-    - name: Anycoin Direct
-      url: https://anycoindirect.eu/buy/monero
     - name: BestChange
       url: https://www.bestchange.com
     - name: Bitci (XMR/BTCI, XMR/TRY, XMR/CHFT)


### PR DESCRIPTION
They recently delisted Monero: https://anycoindirect.eu/en/blog/current-and-upcoming-changes-to-our-platform