### PR TITLE
Use darker color to increase contrast of topnav menu

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1869,7 +1869,7 @@ img.icon-language {
 }
 
 .topnav .topnav-list a, .topnav .topnav-list label {
-    color: #6B6B6B;
+    color: #4c4c4c;
     text-decoration: none;
     -webkit-transition: all ease-out .1s;
     -moz-transition: all ease-out .1s;


### PR DESCRIPTION
To increase visibility for visually impaired people and to make the "external" image blend in better.

Before:
![before](https://user-images.githubusercontent.com/28106476/100603335-d1ec3e00-32fc-11eb-9ea1-78ebc96e039a.png)


After:
![after](https://user-images.githubusercontent.com/28106476/100603342-d4e72e80-32fc-11eb-80ff-de5d918bb17d.png)
