### PR TITLE
Sponsorships: Remove link to fork networking since their certificate is invalid

### DIFF
--- a/community/sponsorships/index.md
+++ b/community/sponsorships/index.md
@@ -48,7 +48,7 @@ permalink: /community/sponsorships/index.html
                 <div class="info-block">
                     <div class="row center-xs">
                         <div class="col">
-                            <a class="ext-noicon" href="https://www.forked.net" target="_blank" rel="noreferrer"><img src="/img/sponsors/forked_logo.png" alt="Fork Networking logo"></a>
+                            <img src="/img/sponsors/forked_logo.png" alt="Fork Networking logo">
                             <p>{% t sponsorships.forknetworking %}</p>
                         </div>
                     </div>


### PR DESCRIPTION
We can revert this commit once they fixed the problem. I already tried to contact them in #1290