### PR TITLE
Remove banner 'network upgrade'

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -16,10 +16,6 @@ global:
   outdated: The content of this page is outdated and the might be not valid anymore. Contact the community if you need support.
   outdatedMin: This page has been updated since the translation. You can use this version, but it may be incomplete. Please use the
   outdatedVersion: English version
-  upgradoct: Make sure your software is up-to-date with the
-  upgradeoctlink: "October 17th network upgrade."
-  upgrdecont: To continue using Monero after that date,
-  dwlsoftware: Download Monero "Oxygen Orion" (0.17).
   lang_tag: "@lang_tag_en"
 
 titles:

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -4,7 +4,7 @@
   {% include head.html %}
 
   <body>
-    {% include upgrade.html %}
+    <!-- {% include upgrade.html %} -->
     <div class="page-wrapper">
         {% include header.html %}
         {{content}}


### PR DESCRIPTION
The network upgrade was about two months ago, i think it's time to remove the warning in the homepage. I also removed the text, so that translators won't waste time translating it. We will have to add new text for the next network upgrade anyway.