### PR TITLE
Add missing DIV tag ('Join the Community' section)

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@ permalink: index.html
                     <p>{% t home.researchlab_para %}</p>
                     <p><a href="{{site.baseurl}}/resources/research-lab/" class="btn-link btn-fixed">{% t home.visitmrl %}</a></p>
                 </div>
+           </div>
         </div>
     </section> 
     <!-- END Full Block -->


### PR DESCRIPTION
Fix W3C errors:
- [End tag section seen, but there were open elements](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fwww.getmonero.org%2F#l528c14)
- [Unclosed element div](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fwww.getmonero.org%2F#l504c32)

![image](https://user-images.githubusercontent.com/8020386/101460904-29ca1b00-3975-11eb-88b6-1d784992cb8a.png)
