### PR TITLE
Do not cache temporary redirects

### DIFF
--- a/_config/nginx.conf
+++ b/_config/nginx.conf
@@ -46,59 +46,73 @@ server {
     # Downloads!
     location /win64 {
         rewrite ^ https://$server_name/cli/monero-win-x64-v0.17.1.1.zip redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /win32 {
         rewrite ^ https://$server_name/cli/monero-win-x86-v0.17.1.1.zip redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /mac64 {
         rewrite ^ https://$server_name/cli/monero-mac-x64-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /linux64 {
         rewrite ^ https://$server_name/cli/monero-linux-x64-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /linux32 {
         rewrite ^ https://$server_name/cli/monero-linux-x86-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /linuxarm7 {
         rewrite ^ https://$server_name/cli/monero-linux-armv7-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /linuxarm8 {
         rewrite ^ https://$server_name/cli/monero-linux-armv8-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /androidarm7 {
         rewrite ^ https://$server_name/cli/monero-android-armv7-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /androidarm8 {
         rewrite ^ https://$server_name/cli/monero-android-armv8-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /freebsd64 {
         rewrite ^ https://$server_name/cli/monero-freebsd-x64-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     # GUI downloads
     location /gui/win64install {
         rewrite ^ https://$server_name/gui/monero-gui-install-win-x64-v0.17.1.1.exe redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /gui/win64 {
         rewrite ^ https://$server_name/gui/monero-gui-win-x64-v0.17.1.1.zip redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /gui/mac64 {
         rewrite ^ https://$server_name/gui/monero-gui-mac-x64-v0.17.1.1.dmg redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     location /gui/linux64 {
         rewrite ^ https://$server_name/gui/monero-gui-linux-x64-v0.17.1.1.tar.bz2 redirect;
+        add_header Cache-Control "no-store, max-age=0";
     }
 
     # Other download redirects


### PR DESCRIPTION
Caching these locations led to the browser downloading older versions of Monero, when a link had been used before. 

For example: When I clicked the download link for the CLI-Wallet, Linux amd64 on https://www.getmonero.org/downloads/, Firefox downloaded `monero-linux-x64-v0.17.1.3.tar.bz2` instead of `monero-linux-x64-v0.17.1.6.tar.bz2`.

Note, that I never configured an nginx server before, so please double-check.