### PR TITLE
Downloads: add link to release notes

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -241,6 +241,7 @@ downloads:
   moreinfofaq: More info in the FAQ
   packages: There are also packages available for multiple Linux distributions.
   packages_link: See the list on GitHub
+  releasenotes: release notes
 
 press-kit:
   intro1: Here you'll find the Monero symbol and logo below. You can choose any size that you want, or download the .ai file to mess with the logo yourself.

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -63,7 +63,7 @@ permalink: /downloads/index.html
             </div>
             <div class="col-md-12 col-sm-12 col-xs-12">
               <h3>{% t titles.downloads %}</h3>
-                <p><i>{% t downloads.currentversion %}:</i> {{ item.version }}</p>
+                <p><i>{% t downloads.currentversion %}:</i> {{ item.version }} (<a href="{{ site.baseurl_root }}/blog/tags/releases.html">{% t downloads.releasenotes %}</a>)</p>
                 <div class="row">
                   <div class="col-md-4 col-sm-4 col-xs-4 desktop-only">
                     <ul>
@@ -152,7 +152,7 @@ permalink: /downloads/index.html
             </div>
             <div class="col-md-12 col-sm-12 col-xs-12">
               <h3>{% t titles.downloads %}</h3>
-                <p><i>{% t downloads.currentversion %}:</i> {{ item.version }}</p>
+                <p><i>{% t downloads.currentversion %}:</i> {{ item.version }} (<a href="{{ site.baseurl_root }}/blog/tags/releases.html">{% t downloads.releasenotes %}</a>)</p>
                 <div class="row">
                   <div class="col-md-4 col-sm-4 col-xs-4 desktop-only">
                     <ul>


### PR DESCRIPTION
Add 'release notes' link that points to the category "Releases" of the blog for both CLI and GUI releases.

![Screenshot from 2020-12-20 14-35-32](https://user-images.githubusercontent.com/28106476/102716009-e9ea2880-42d0-11eb-87ba-e36e6adf6787.png)

Open to suggestions for a better place for this.