### PR TITLE
workgroups: change URL to /community/workgroups/

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,7 +31,7 @@
                     <label for="drop2">{% t navigation.community %}<div class="arrow-down"></div></label>
                     <input class="burger-checkdropdown" id="drop2" type="checkbox" tabindex="0">
                     <div class="dropdown-content">
-                      <a href="{{ site.baseurl }}/community/team/">{% t titles.workgroups %}</a>
+                      <a href="{{ site.baseurl }}/community/workgroups/">{% t titles.workgroups %}</a>
                       <a href="{{ site.baseurl }}/community/hangouts/">{% t titles.hangouts %}</a>
                       <a href="{{ site.baseurl }}/community/sponsorships/">{% t titles.sponsorships %}</a>
                       <a href="{{ site.baseurl }}/community/merchants/">{% t navigation.merchants %}</a>
@@ -146,7 +146,7 @@
                         <label for="desktopdrop2">{% t navigation.community %}<div class="arrow-down"></div></label>
                         <input class="burger-checkdropdown" id="desktopdrop2" type="checkbox" tabindex="0">
                         <div class="dropdown-content">
-                              <a href="{{ site.baseurl }}/community/team/">{% t titles.workgroups %}</a>
+                              <a href="{{ site.baseurl }}/community/workgroups/">{% t titles.workgroups %}</a>
                               <a href="{{ site.baseurl }}/community/hangouts/">{% t titles.hangouts %}</a>
                               <a href="{{ site.baseurl }}/community/sponsorships/">{% t titles.sponsorships %}</a>
                               <a href="{{ site.baseurl }}/community/merchants/">{% t navigation.merchants %}</a>

--- a/community/workgroups/index.md
+++ b/community/workgroups/index.md
@@ -1,7 +1,7 @@
 ---
 layout: custom
 title: titles.workgroups
-permalink: /community/team/index.html
+permalink: /community/workgroups/index.html
 ---
 
 {% t global.lang_tag %}


### PR DESCRIPTION
Now that #1260 is merged and live, we should change the URL of the Workgroups page from `/community/teams/` to `/community/workgroups/`.

@binaryFate we will need to set up a redirect.