### PR TITLE
MRL: remove '(English)' from page header

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -668,7 +668,7 @@ roadmap:
 
 research-lab:
   intro: Monero is not only committed to making a fungible currency, but also to continued research into the realm of financial privacy as it involves cryptocurrencies. Below you'll find the work of our very own Monero Research Lab, with more papers to come.
-  mrl_papers: Monero Research Lab Papers (English)
+  mrl_papers: Monero Research Lab Papers
   abstract: Abstract
   introduction: Introduction
   read-paper: Read Paper


### PR DESCRIPTION
The page is being actively translated. The papers are not, but i guess people expect that, no need to specify anything.