### PR TITLE
dev guides: make 'g' in 'go' uppercase

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -540,7 +540,7 @@ developer-guides:
   monero-java: A Java library for using Monero.
   monero-cpp: A C++ library for using Monero.
   vanity-monero: Generate vanity address for CryptoNote currency (Monero etc.).
-  go-monero-rpc-client: A go client for the Monero wallet and daemon RPC.
+  go-monero-rpc-client: A Go client for the Monero wallet and daemon RPC.
   monero-rs: Library with support for (de)serialization on block data structures and key/address generation and scanning related to Monero cryptocurrency.
   csharp-monero: A wallet and daemon client to interface with Monero's JSON-RPC API, built on .netstandard2.1
 


### PR DESCRIPTION
Translators confuse it with the verb.