### PR TITLE
contributing: add link to openhub

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -366,6 +366,8 @@ contributing:
   donate-other_para2: for alternative means of donating or if you would like to become a sponsor for the Monero Project.
   supportdev: Support the developers
   supportdev_p: The developers working on Monero are mostly indepentent volunteers, but some of them may be funded through CCS proposals. If you wish to support their efforts by donating some XMRs, consider contacting them personally or using tipping services.
+  supportdev_p2: You can find an overview of the people who directly contribute, or have contributed, to the Monero repositories (along with other useful statistics) on
+  supportdev_link: Monero's OpenHub page
   sponsor: Sponsorships
   sponsor_p: You can also support Monero through a sponsorship program. See the dedicated 
   sponsor_link: Sponsorships page

--- a/get-started/contributing/index.md
+++ b/get-started/contributing/index.md
@@ -91,6 +91,7 @@ permalink: /get-started/contributing/index.html
                         <div class="col-xs-12">
                             <h3>{% t contributing.supportdev %}</h3>
                             <p>{% t contributing.supportdev_p %}</p>
+                            <p>{% t contributing.supportdev_p2 %} <a href="https://www.openhub.net/p/monero/contributors/summary">{% t contributing.supportdev_link %}</a>.</p>
                         </div>
                     </div>
                     <div class="row start-xs">


### PR DESCRIPTION
We used to link to this page from the 'Team' page. I removed it from there, but i think they have very useful info and statistics, so i'm adding the link in the 'Contributing' page.