### PR TITLE
FAQ: Standardize video hyperlinks

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -457,9 +457,10 @@ faq:
   avideos: >
     During the years the community has created a vast amount of informative content like articles and videos. Most of these videos are publicly available on platforms like YouTube. On this website we host a few videos that explain the fundamentals of Monero. To optimize their effectiveness, they should be viewed in sequence:
   video_intro: Introduction to Monero
-  video_essentials: "Monero: The Essentials"
+  video_essentials: The Essentials
   video_sa: Stealth Addresses
   video_ringsig: Ring Signatures
+  video_ringct: Ring Confidential Transactions
   mvideos: "More info on the Moneropedia entry:"
   aavailable: also available in
   and: and

--- a/get-started/faq/index.md
+++ b/get-started/faq/index.md
@@ -187,7 +187,7 @@ permalink: /get-started/faq/index.html
                             <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20The%20Essentials.m4v">{% t faq.video_essentials %}</a></li>
                             <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20Stealth%20Addresses.m4v">{% t faq.video_sa %}</a> - {% t faq.mvideos %} @stealth-addresses</li>
                             <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20Ring%20Signatures.m4v">{% t faq.video_ringsig %}</a> - {% t faq.mvideos %} @ring-signatures</li>
-                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20RingCT.m4v">RingCT</a> - {% t faq.mvideos %} @ring-ct</li>
+                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20RingCT.m4v">{% t faq.video_ringct %}</a> - {% t faq.mvideos %} @ring-ct</li>
                         </ol>
                     </div>
                 </div>


### PR DESCRIPTION
Removed 'Monero:' from the Essentials link and added an i18n key for Ring CT.