### PR TITLE
Add Norwegian User Guides (2/2)

### DIFF
--- a/_i18n/nb-no/resources/user-guides/Offline_Backup.md
+++ b/_i18n/nb-no/resources/user-guides/Offline_Backup.md
@@ -1,0 +1,38 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+## Operativsystemer:  Ulike versjoner av Linux og Windows 7 og 8
+
+### Lommebokprogramvare:  Simplewallet
+
+#### Ressurser for å opprette oppstartbare disker:  [Linux](http://www.pendrivelinux.com/),       [Windows](https://www.microsoft.com/en-us/download/windows-usb-dvd-download-tool)
+
+#### Ressurser for Monero-binærfiler:  [Monero Binaries]({{ site.baseurl_root }}/downloads/)
+
+- Bruk en hvilken som helst PC som du har liggende, selv din arbeidsstasjon. Du synes kanskje det er lettere å bruke en eldre PC som ikke har WiFi eller Bluetooth dersom du er spesielt paranoid
+
+- Opprett en oppstartbar disk med Linux eller Windows, og sørg for at du har Monero-binærfilene på den samme disken eller på en sekundær disk (for Linux bør du sørge for at du også har lastet ned kopier av avhengighetsfilene du trenger, f.eks. libboost1.55 og miniupnpc)
+
+- Koble fra nettverket og/eller internettkablene fra PC-en din og fysisk fjern WiFi-kortet eller skru om mulig av Wifi/Bluetooth
+
+- Start opp i ditt oppstartsbare operativsystem og installer avhengighetsfiler om nødvendig
+
+- Kopier Monero-binærfilene til en RAM-disk (/dev/shm i Linux. Oppstartsbare ISO-er i Windows har normalt en Z:-stasjon eller noe)
+
+- Ikke kjør Monero @daemon. Bruk i stedet kommandolinjen, og bruk monero-wallet-cli for å opprette en ny Monero @konto
+
+- Når du blir bedt om et navn, kan du gi det et. Det har uansett ikke noe å si
+
+- Når du blir bedt om å oppgi et passord, tast inn 50–100 tilfeldige tegn. Ikke bekymre deg om at du ikke husker passordet, bare gjøre det LANGT
+
+- **KRITISK TRINN**: Skriv ned (på papir) ditt @mnemoniske frø på 25 ord.
+**ADVARSEL**:  Hvis du glemmer å skrive ned denne informasjonen, kan pengene dine gå tapt for alltid
+
+- Skriv ned (på telefonen din, på papir, på en annen PC eller hvor enn du vil) adressen og visningsnøkkelen din
+
+- Slå av PC-en, fjern batteriet om det er mulig, og la den være fysisk slått av i noen timer
+
+Kontoen du har opprettet ble opprettet i RAM, og de digitale filene er nå utilgjengelige. Hvis en uvedkommende på en eller annen måte klarer å få tilgang til dataene, vil de mangle det lange passordet for å åpne det. Hvis du må motta betalinger, har du din offentlige adresse, og du har visningsnøkkelen om det blir behov for den. Hvis du trenger tilgang til den, har du ditt @mnemoniske frø på 25 ord, og du kan nå skrive ut flere kopier av den, inkludert en kopi som befinner seg på et annet område (f.eks. i en bankboks).
+
+Takk til:  Riccardo Spagni
+
+Relatert innhold:  [Offline kontogenerator](http://moneroaddress.org/)

--- a/_i18n/nb-no/resources/user-guides/Offline_Backup.md
+++ b/_i18n/nb-no/resources/user-guides/Offline_Backup.md
@@ -33,6 +33,4 @@
 
 Kontoen du har opprettet ble opprettet i RAM, og de digitale filene er nå utilgjengelige. Hvis en uvedkommende på en eller annen måte klarer å få tilgang til dataene, vil de mangle det lange passordet for å åpne det. Hvis du må motta betalinger, har du din offentlige adresse, og du har visningsnøkkelen om det blir behov for den. Hvis du trenger tilgang til den, har du ditt @mnemoniske frø på 25 ord, og du kan nå skrive ut flere kopier av den, inkludert en kopi som befinner seg på et annet område (f.eks. i en bankboks).
 
-Takk til:  Riccardo Spagni
-
 Relatert innhold:  [Offline kontogenerator](http://moneroaddress.org/)

--- a/_i18n/nb-no/resources/user-guides/Offline_Backup.md
+++ b/_i18n/nb-no/resources/user-guides/Offline_Backup.md
@@ -14,9 +14,9 @@
 
 - Koble fra nettverket og/eller internettkablene fra PC-en din og fysisk fjern WiFi-kortet eller skru om mulig av Wifi/Bluetooth
 
-- Start opp i ditt oppstartsbare operativsystem og installer avhengighetsfiler om nødvendig
+- Start opp i ditt oppstartbare operativsystem og installer avhengighetsfiler om nødvendig
 
-- Kopier Monero-binærfilene til en RAM-disk (/dev/shm i Linux. Oppstartsbare ISO-er i Windows har normalt en Z:-stasjon eller noe)
+- Kopier Monero-binærfilene til en RAM-disk (/dev/shm i Linux. Oppstartbare ISO-er i Windows har normalt en Z:-stasjon eller noe)
 
 - Ikke kjør Monero @daemon. Bruk i stedet kommandolinjen, og bruk monero-wallet-cli for å opprette en ny Monero @konto
 

--- a/_i18n/nb-no/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/nb-no/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -11,7 +11,7 @@ Dette er tryggere enn andre tilnærminger som ruter lommebokens rpc over en skju
 
 + Opprett følgende to arbeidsstasjoner ved å bruke en Whonix-arbeidsstasjonmal:
 
-  - Den første arbeidssstasjonen vil brukes for lommeboken din, og vil refereres til som `monero-wallet-ws`. Du må sette din `NetVM` til `none`.
+  - Den første arbeidsstasjonen vil brukes for lommeboken din, og vil refereres til som `monero-wallet-ws`. Du må sette din `NetVM` til `none`.
 
   - Den andre arbeidsstasjonen vil være for `monerod`-daemonen, og vil refereres til som `monerod-ws`. Din `NetVM` må være satt til Whonix-porten `sys-whonix`.
 

--- a/_i18n/nb-no/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/nb-no/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -13,32 +13,14 @@ Dette er tryggere enn andre tilnærminger som ruter lommebokens rpc over en skju
 
   - Den første arbeidsstasjonen vil brukes for lommeboken din, og vil refereres til som `monero-wallet-ws`. Du må sette din `NetVM` til `none`.
 
-  - Den andre arbeidsstasjonen vil være for `monerod`-daemonen, og vil refereres til som `monerod-ws`. Din `NetVM` må være satt til Whonix-porten `sys-whonix`.
+  - Den andre arbeidsstasjonen vil være for `monerod`-daemonen, og vil refereres til som `monerod-ws`. Din `NetVM` må være satt til Whonix-porten `sys-whonix`. Før du går videre må du sørge for at denne arbeidsstasjonen har nok privat lagringsplass. Du kan anslå hvor mye lagringsplass du trenger ved å sjekke størrelsen på den [rå blokkjeden]({{ site.baseurl }}/downloads/#blockchain). Husk at blokkjeden over tid vil bruke oppta lagringsplass.
 
 ## 2. I AppVM-en `monerod-ws`:
 
-+ Last ned, verifiser og installer Monero-programvare.
-
-```
-user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl_root }}/downloads/hashes.txt"
-user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
-user@host:~$ gpg --verify hashes.txt
-gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
-gpg:                using RSA key 0x55432DF31CCD4FCD
-gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
-     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
-user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
-monero-linux-x64-v0.11.1.0.tar.bz2: OK
-user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
-user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
-```
 + Opprett en `systemd`-fil.
 
 ```
-user@host:~$ sudo gedit /home/user/monerod.service
+user@host:~$ sudo nano /home/user/monerod.service
 ```
 
 Lim inn følgende innhold:
@@ -55,7 +37,7 @@ Group=user
 Type=forking
 PIDFile=/home/user/.bitmonero/monerod.pid
 
-ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+ExecStart=/usr/bin/monerod --detach --data-dir=/home/user/.bitmonero \
     --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
     --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
 
@@ -66,16 +48,10 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-+ Kopier `monero-wallet-cli` som er kjørbar til `monero-wallet-ws`-VM-en.
-
-```
-user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
-```
-
 + Få `monerod` daemon til å kjøre på oppstart ved å redigere filen `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Legg til disse linjene nederst:
@@ -95,7 +71,7 @@ user@host:~$ sudo chmod +x /rw/config/rc.local
 
 ```
 user@host:~$ sudo mkdir /rw/usrlocal/etc/qubesp-rpc
-user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+user@host:~$ sudo nano /rw/usrlocal/etc/qubes-rpc/user.monerod
 ```
 
 Legg til denne linjen:
@@ -108,16 +84,10 @@ socat STDIO TCP:localhost:18081
 
 ## 3. I AppVM-en `monero-wallet-ws`:
 
-+ Flytt den eksekverbare `monero-wallet-cli`.
-
-```
-user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
-```
-
 + Rediger filen `/rw/config/rc.local`.
 
 ```
-user@host:~$ sudo gedit /rw/config/rc.local
+user@host:~$ sudo nano /rw/config/rc.local
 ```
 
 Legg til følgende linje nederst:

--- a/_i18n/nb-no/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
+++ b/_i18n/nb-no/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.md
@@ -1,0 +1,149 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Med [Qubes](https://qubes-os.org) + [Whonix](https://whonix.org) kan du ha en Monero-lommebok som er uten nettverking og som kjører på et virtuelt, isolert system fra Monero daemonen som har all sin trafikk tvunget over [Tor](https://torproject.org).
+
+Qubes gir fleksibiliteten til å enkelt opprette VM-er for ulike formål. Du må først opprette en Whonix-arbeidsstasjon for lommeboken uten nettverking. Deretter en annen Whonix-arbeidsstasjon for daemonen som bruker din Whonix-port i og med at den er NetVM. For kommunikasjon mellom lommebøkene og daemon, kan du bruke Qubes [qrexec](https://www.qubes-os.org/doc/qrexec3/).
+
+Dette er tryggere enn andre tilnærminger som ruter lommebokens rpc over en skjult Tor-service, eller en som bruker fysisk isolasjon men som fremdeles trenger nettverking for å koble seg til daemonen. På denne måten trenger du ikke en nettverksforbindelse til lommeboken. Du bevarer ressursene til Tor-nettverket, og det er også mindre latens.
+
+
+## 1. [Opprett Whonix AppVM-er](https://www.whonix.org/wiki/Qubes/Install):
+
++ Opprett følgende to arbeidsstasjoner ved å bruke en Whonix-arbeidsstasjonmal:
+
+  - Den første arbeidssstasjonen vil brukes for lommeboken din, og vil refereres til som `monero-wallet-ws`. Du må sette din `NetVM` til `none`.
+
+  - Den andre arbeidsstasjonen vil være for `monerod`-daemonen, og vil refereres til som `monerod-ws`. Din `NetVM` må være satt til Whonix-porten `sys-whonix`.
+
+## 2. I AppVM-en `monerod-ws`:
+
++ Last ned, verifiser og installer Monero-programvare.
+
+```
+user@host:~$ curl -O "https://downloads.getmonero.org/cli/monero-linux-x64-v0.11.1.0.tar.bz2" -O "{{ site.baseurl_root }}/downloads/hashes.txt"
+user@host:~$ gpg --recv-keys BDA6BD7042B721C467A9759D7455C5E3C0CDCEB9
+user@host:~$ gpg --verify hashes.txt
+gpg: Signature made Wed 01 Nov 2017 10:01:41 AM UTC
+gpg:                using RSA key 0x55432DF31CCD4FCD
+gpg: Good signature from "Riccardo Spagni <ric@spagni.net>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: BDA6 BD70 42B7 21C4 67A9  759D 7455 C5E3 C0CD CEB9
+     Subkey fingerprint: 94B7 38DD 3501 32F5 ACBE  EA1D 5543 2DF3 1CCD 4FCD
+user@host:~$ echo '6581506f8a030d8d50b38744ba7144f2765c9028d18d990beb316e13655ab248  monero-linux-x64-v0.11.1.0.tar.bz2' | shasum -c
+monero-linux-x64-v0.11.1.0.tar.bz2: OK
+user@host:~$ tar xf monero-linux-x64-v0.11.1.0.tar.bz2
+user@host:~$ sudo cp monero-v0.11.1.0/monerod /usr/local/bin/
+```
++ Opprett en `systemd`-fil.
+
+```
+user@host:~$ sudo gedit /home/user/monerod.service
+```
+
+Lim inn følgende innhold:
+
+```
+[Unit]
+Description=Monero Full Node
+After=network.target
+
+[Service]
+User=user
+Group=user
+
+Type=forking
+PIDFile=/home/user/.bitmonero/monerod.pid
+
+ExecStart=/usr/local/bin/monerod --detach --data-dir=/home/user/.bitmonero \
+    --no-igd --pidfile=/home/user/.bitmonero/monerod.pid \
+    --log-file=/home/user/.bitmonero/bitmonero.log --p2p-bind-ip=127.0.0.1
+
+Restart=always
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
++ Kopier `monero-wallet-cli` som er kjørbar til `monero-wallet-ws`-VM-en.
+
+```
+user@host:~$ qvm-copy-to-vm monero-wallet-ws monero-v0.11.1.0/monero-wallet-cli
+```
+
++ Få `monerod` daemon til å kjøre på oppstart ved å redigere filen `/rw/config/rc.local`.
+
+```
+user@host:~$ sudo gedit /rw/config/rc.local
+```
+
+Legg til disse linjene nederst:
+
+```
+cp /home/user/monerod.service /lib/systemd/system/
+systemctl start monerod.service
+```
+
+Gjør filen kjørbar.
+
+```
+user@host:~$ sudo chmod +x /rw/config/rc.local
+```
+
++ Opprett en rpc-handlingsfil.
+
+```
+user@host:~$ sudo mkdir /rw/usrlocal/etc/qubesp-rpc
+user@host:~$ sudo gedit /rw/usrlocal/etc/qubes-rpc/user.monerod
+```
+
+Legg til denne linjen:
+
+```
+socat STDIO TCP:localhost:18081
+```
+
++ Skru av `monerod-ws`.
+
+## 3. I AppVM-en `monero-wallet-ws`:
+
++ Flytt den eksekverbare `monero-wallet-cli`.
+
+```
+user@host:~$ sudo mv QubesIncoming/monerod-ws/monero-wallet-cli /usr/local/bin/
+```
+
++ Rediger filen `/rw/config/rc.local`.
+
+```
+user@host:~$ sudo gedit /rw/config/rc.local
+```
+
+Legg til følgende linje nederst:
+
+```
+socat TCP-LISTEN:18081,fork,bind=127.0.0.1 EXEC:"qrexec-client-vm monerod-ws user.monerod"
+```
+
+Gjør filen eksekverbar.
+
+```
+user@host:~$ sudo chmod +x /rw/config/rc.local
+```
+
++ Slå av `monero-wallet-ws`.
+
+## 4. I `dom0`:
+
++ Opprett filen `/etc/qubes-rpc/policy/user.monerod`:
+
+```
+[user@dom0 ~]$ sudo nano /etc/qubes-rpc/policy/user.monerod
+```
+
+Legg til følgende linje:
+
+```
+monero-wallet-ws monerod-ws allow
+```

--- a/_i18n/nb-no/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/nb-no/resources/user-guides/howto_fix_stuck_funds.md
@@ -16,15 +16,15 @@ i ledeteksten. Skriv ned frøet ditt på 25 ord dersom du ikke allerede har gjor
 
 - Sikkerhetskopier alle de lommebokrelaterte filene dine. Disse inkluderer:
 
-> yourwalletname.bin
-> yourwalletname.bin.keys
-> yourwalletname.bin.address.txt
+> dinlommebok.bin
+> dinlommebok.bin.keys
+> dinlommebok.bin.address.txt
 
 Dette kan gjøres ved å kopiere filene til en ny mappe.
 
-Av og til, når du oppretter lommeboken din, må du gi den et navn uten .bin-delen. I dette tilfellet vil lommebokfilen kalles for yourwalletname uten .bin på slutten.
+Av og til, når du oppretter lommeboken din, må du gi den et navn uten .bin-delen. I dette tilfellet vil lommebokfilen kalles for dinlommebok uten .bin på slutten.
 
-- Slett yourwallet.bin
+- Slett dinlommebok.bin
 
 - Last inn monero-wallet-cli, og tast inn navnet på lommeboken du nettopp slettet.
 

--- a/_i18n/nb-no/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/nb-no/resources/user-guides/howto_fix_stuck_funds.md
@@ -1,0 +1,32 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Av og til vil midlene dine bli «sittende fast» – du vil ha noen låste midler som aldri blir ulåst. Slik kan du fikse det:
+
+- Last inn lommeboken din i monero-wallet-cli.
+
+- Tast inn
+
+> seed
+
+i ledeteksten. Skriv ned frøet ditt på 25 ord dersom du ikke allerede har gjort det. Dette er den beste måten å sørge for at du ikke mister tilgang til midlene dine på.
+
+- Lukk monero-wallet-cli ved å taste inn
+
+> exit
+
+- Sikkerhetskopier alle dine lommeboksrelaterte filer. Disse inkluderer:
+
+> yourwalletname.bin
+> yourwalletname.bin.keys
+> yourwalletname.bin.address.txt
+
+Dette kan gjøres ved å kopiere filene til en ny mappe.
+
+Av og til, når du oppretter lommeboken din, må du gi den et navn uten .bin-delen. I dette tilfellet vil lommebokfilen kalles for yourwalletname uten .bin på slutten.
+
+- Slett yourwallet.bin
+
+- Last inn monero-wallet-cli, og tast inn navnet på lommeboken du nettopp slettet.
+
+- Skriv inn passordet. Lommeboken vil nå oppdateres, og forhåpentligvis vil de låste midlene dine nå bli ulåst.
+

--- a/_i18n/nb-no/resources/user-guides/howto_fix_stuck_funds.md
+++ b/_i18n/nb-no/resources/user-guides/howto_fix_stuck_funds.md
@@ -14,7 +14,7 @@ i ledeteksten. Skriv ned frøet ditt på 25 ord dersom du ikke allerede har gjor
 
 > exit
 
-- Sikkerhetskopier alle dine lommeboksrelaterte filer. Disse inkluderer:
+- Sikkerhetskopier alle de lommebokrelaterte filene dine. Disse inkluderer:
 
 > yourwalletname.bin
 > yourwalletname.bin.keys

--- a/_i18n/nb-no/resources/user-guides/importing_blockchain.md
+++ b/_i18n/nb-no/resources/user-guides/importing_blockchain.md
@@ -1,0 +1,62 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+### Hensikt og advarsel
+
+De fleste trenger ikke dette. For å bruke Monero, kan du bare starte programvaren, så vil den synkroniseres med seg selv med p2p-nettverket. Dette går normalt mye raskere enn å laste ned og importere blokkjeden, som beskrevet i denne guiden. Dette er fordi du må laste ned fra mange noder i stedet for en enkel server, og Monero @daemonen vil verifisere hver blokk mens den mottas istedenfor å verifisere den separat etter nedlasting.
+
+Dette valget er mest nyttig for utviklere, eller muligens dersom et uvanlig problem hindrer deg fra å synkronisere på en normal måte.
+
+**Aldri** bruk uverifiserte importeringsvalg da dette kun er for eksperter. Du bør spesielt ikke bruke det med en blokkjede du laster ned fra internett, inkludert den offisielel nettsiden. Det er kun trygt å bruke dersom du a) importerer en fil som du eksporterer lokalt på egenhånd *og* b) er helt sikker på at den allerede var fullt og skikkelig verifisert før den ble eksportert.
+
+### Trinn 1
+
+Last ned det gjeldende oppstartsprogrammet fra https://downloads.getmonero.org/blockchain.raw; du kan hoppe over dette trinnet hvis du importerer blokkjeden fra en annen kilde.
+
+### Trinn 2
+
+Finn stien som Monero-programvaren er installert på. Min er for eksempel:
+
+`D:\monero-gui-0.10.3.1`
+
+Stien din kan være en annen, avhengig av hvor du bestemte deg for å installere Monero-programvaren og hvilken versjon av programvaren du har.
+
+### Trinn 3
+
+Finn stien til den nedlastede blokkjede. Min var for eksempel:
+
+`C:\Users\KeeJef\Downloads\blockchain.raw`
+
+Din er kanskje en annen, avhengig av hvor du valgte å lagre blokkjeden.
+
+### Trinn 4
+
+Åpne kommandolinjevinduet. Du kan gjøre dette ved å holde inne Windows-tasten + R, deretter taste inn `CMD` i popupboksen, og deretter trykke på Enter.
+
+### Trinn 5
+
+Du må nå navigere ved å bruke CMD-vinduet til stien som Monero-programvaren din befinner seg i. Du kan gjøre dette ved å taste inn:
+
+`cd C:\YOUR\MONERO\PATH\HERE`
+
+Det bør se ut noe som dette:
+
+`cd D:\monero-gui-0.10.3.1`
+
+Dersom Monero-pregramvaren din er på en annen disk, kan du bruke `DriveLetter:` Hvis Monero-programvaren din for eksempel var på D-disken din, må du, før du bruker cd-kommandoen, bruke `D:`
+
+### Trinn 6
+
+Tast deretter inn i dette i ledetekstvinduet:
+
+`monero-blockchain-import --input-file C:\YOUR\BLOCKCHAIN\FILE\PATH\HERE`
+
+Jeg hadde for eksempel tastet inn:
+
+`monero-blockchain-import --input-file C:\Users\KeeJef\Downloads\blockchain.raw`
+
+### Trinn 7
+
+Etter blokkjeden er ferdig med å synkronisere, kan du åpne Monero-lommeboken din som normalt. Din nedlastede blockchain.raw kan slettes.
+
+
+Forfatter: Kee Jefferys

--- a/_i18n/nb-no/resources/user-guides/importing_blockchain.md
+++ b/_i18n/nb-no/resources/user-guides/importing_blockchain.md
@@ -6,7 +6,7 @@ De fleste trenger ikke dette. For å bruke Monero, kan du bare starte programvar
 
 Dette valget er mest nyttig for utviklere, eller muligens dersom et uvanlig problem hindrer deg fra å synkronisere på en normal måte.
 
-**Aldri** bruk uverifiserte importeringsvalg da dette kun er for eksperter. Du bør spesielt ikke bruke det med en blokkjede du laster ned fra internett, inkludert den offisielel nettsiden. Det er kun trygt å bruke dersom du a) importerer en fil som du eksporterer lokalt på egenhånd *og* b) er helt sikker på at den allerede var fullt og skikkelig verifisert før den ble eksportert.
+**Aldri** bruk uverifiserte importeringsvalg da dette kun er for eksperter. Du bør spesielt ikke bruke det med en blokkjede du laster ned fra internett, inkludert den offisielle nettsiden. Det er kun trygt å bruke dersom du a) importerer en fil som du eksporterer lokalt på egenhånd *og* b) er helt sikker på at den allerede var fullt og skikkelig verifisert før den ble eksportert.
 
 ### Trinn 1
 
@@ -42,7 +42,7 @@ Det bør se ut noe som dette:
 
 `cd D:\monero-gui-0.10.3.1`
 
-Dersom Monero-pregramvaren din er på en annen disk, kan du bruke `DriveLetter:` Hvis Monero-programvaren din for eksempel var på D-disken din, må du, før du bruker cd-kommandoen, bruke `D:`
+Hvis Monero-programvaren din ligger på en annen disk, kan du bruke `DriveLetter`: Hvis Monero-programvaren din for eksempel lå på D-disken din, må du, før du bruker cd-kommandoen, bruke `D:`
 
 ### Trinn 6
 

--- a/_i18n/nb-no/resources/user-guides/importing_blockchain.md
+++ b/_i18n/nb-no/resources/user-guides/importing_blockchain.md
@@ -57,6 +57,3 @@ Jeg hadde for eksempel tastet inn:
 ### Trinn 7
 
 Etter blokkjeden er ferdig med å synkronisere, kan du åpne Monero-lommeboken din som normalt. Din nedlastede blockchain.raw kan slettes.
-
-
-Forfatter: Kee Jefferys

--- a/_i18n/nb-no/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/nb-no/resources/user-guides/ledger-wallet-cli.md
@@ -158,6 +158,3 @@ Gratulerer. Du kan nå bruke Ledger Monero-lommeboken din sammen med CLI-en.
    Dersom lommebokfilene til Ledgeren ikke befinner seg i samme katalog som `monero-wallet-cli`, bør du åpne `monero-wallet-cli` med `--wallet-file /path/to/wallet.keys/file`-flagget. Alternativt kan du kopiere Ledger-lommebokfilene til samme katalog som `monero-wallet-cli`.
 
 5. Hvis du har flere spørsmål eller trenger hjelp, kan du legge igjen en kommentar på det opprinnelige [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli)-svaret.
-
-Forfatter: dEBRUYNE
-Sekundærforfatter: el00ruobuob

--- a/_i18n/nb-no/resources/user-guides/ledger-wallet-cli.md
+++ b/_i18n/nb-no/resources/user-guides/ledger-wallet-cli.md
@@ -1,0 +1,163 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+### Innholdsfortegnelse
+
+* [1. Windows](#1-windows)
+* [2. Mac OS X](#2-mac-os-x)
+* [3. Linux](#3-linux)
+* [4. Sluttmerknader](#4-a-few-final-notes)
+
+### 1. Windows
+
+Vi må først sørge for at vi er tilstrekkelig forberedt. Dette innebærer følgende:
+
+1. Denne veiledningen antar at du allerede har initialisert Ledger-lommeboken din og således generert et mnemonisk frø på 24 ord.
+
+2. Du må kjøre/bruke CLI v0.12.2.0, som du kan finne <a href="{{site.baseurl}}/downloads/">her</a>.
+
+3. Du må installere Ledger Monero-appen og konfigurere systemet ditt. Veiledninger til dette kan du finne [her](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (spesielt seksjonene 3.1.1 og 3.2.3). I tillegg må du sørge for å sette nettverket til `Mainnet`
+
+4. Ledgeren din må plugges inn, og Ledger Monero-appen må være i gang.
+
+5. Enten din @daemon (`monerod.exe`) bør kjøre og helst være helt synkronisert, eller så må du koble til en ekstern node.
+
+Nå som vi er ordentlig forberedt, la oss sette i gang!
+
+1. Gå til katalogen/mappen der monerod.exe og monero-wallet-cli.exe ligger.
+
+2. Åpne en ny ledetekst/powershell. Dette gjøres ved å først sørge for at markøren din ikke befinner seg på noen av filene og deretter trykke inn SHIFT + høyreklikke. Dette vil gi det et valg om å «Åpne kommandovinduet her». Hvis du bruker den siste versjonen av Windows 10, vil det gi deg et valg om å «åpne PowerShell-vinduet her».
+
+3. Nå kan du taste inn:
+
+`monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200` (Win 10)
+
+Merk at dette er en plassholder for det faktiske lommeboknavnet. Hvis du for eksempel vil kalle lommeboken din for `MoneroWallet`, er kommandoen som følger:
+
+`monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 7 + 8)
+
+`.\monero-wallet-cli.exe --generate-from-device MoneroWallet --subaddress-lookahead 3:200` (Win 10)
+
+4. CLI-en vil, etter at den ovennevnte kommandoen er utført, be deg om et passord. Sørg for å velge et sterkt passord og bekrefte det.
+
+5. Ledgeren vil be deg om hvorvidt du vil eksportere de private nøklene eller ikke. Midlene dine kan først og fremst ikke bli kompromittert med kun den private visningsnøkkelen. Å eksportere den private visningsnøkkelen gjør at klienten (Monero v0.12.2.0 på PC-en) kan skanne etter blokker og se etter transaksjoner som tilhører lommeboken/adressen din. Hvis dette valget ikke brukes, vil enheten (Ledgeren) skanne etter blokker, noe som går betraktelig saktere. Det er imidlertid én ting å passe seg for. Det er at dersom systemet ditt blir kompromittert, vil den uvedkommende muligens kunne kompromittere din private nøkkel i tillegg, som er ødeleggende for personvern. Dette er praktisk talt umulig når den private visningsnøkkelen ikke eksporteres.
+
+6. Du må muligens trykke på «Confirm» (Bekreft) to ganger før du kan fortsette.
+
+7. Ledger Monero-lommeboken din vil nå genereres. Merk at dette kan ta opptil 5–10 minutter. Videre vil det ikke komme en umiddelbar tilbakemelding, verken på CLI-en eller Ledgeren.
+
+8. `monero-wallet-cli` vil oppdateres. Vent til den er ferdig med å oppdatere.
+
+Gratulerer. Du kan nå bruke Ledger Monero-lommeboken din sammen med CLI-en.
+
+### 2. Mac OS X
+Vi må først sørge for at vi er tilstrekkelig forberedt. Dette innebærer følgende:
+
+1. Denne veiledningen antar at du allerede har initialisert Ledger-lommeboken din og således generert et mnemonisk frø på 24 ord.
+
+2. Du må kjøre/bruke CLI v0.12.2.0, som du kan finne <a href="{{site.baseurl}}/downloads/">her</a>.
+
+3. Du må installere Ledger Monero-appen og konfigurere systemet ditt. Veiledninger til dette kan du finne [her](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (spesielt seksjonene 3.1.1 og 3.2.2). I tillegg må du sørge for å sette nettverket til `Mainnet`.
+
+4. Merk at veiledningen for systemkonfigurasjoner (seksjon 3.2.2) på Mac OS X er ganske innviklede og kan virke noe kronglete. tficharmers har opprettet en guide [her](https://monero.stackexchange.com/questions/8438/how-do-i-make-my-macos-detect-my-ledger-nano-s-when-plugged-in) som du kan bruke som hjelp.
+
+5. Ledgeren din må plugges inn, og Ledger Monero-appen må være i gang.
+
+6. Enten din daemon (`monerod`) bør kjøre og helst være helt synkronisert, eller så må du koble til en ekstern node.
+
+Nå som vi er ordentlig forberedt, la oss sette i gang!
+
+1. Bruk Finder til å finne hvor katalogen/mappen `monero-wallet-cli` (CLI v0.12.2.0) ligger.
+
+2. Gå til skrivebordet ditt.
+
+3. Åpne en terminal (hvis du ikke vet hvordan man åpner terminalen, kan du se [her](https://apple.stackexchange.com/a/256263)).
+
+4. Dra `monero-wallet-cli` inn i terminalen. Det bør legge hele stien til terminalen. Ikke trykk på Enter.
+
+5. Nå kan du taste inn:
+
+`--generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Merk at dette er en plassholder for det faktiske lommeboknavnet. Hvis du for eksempel vil kalle lommeboken din for `MoneroWallet`, er kommandoen som følger:
+
+`--generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+Merk at den ovennevnte teksten vil føyes til stien til `monero-wallet-cli`. Før du trykker på Enter, bør terminalen din altså se slik ut:
+
+`/full/path/to/monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Den fulle stien er den faktiske stien på din Mac OS X.
+
+7.  CLI-en vil, etter at den ovennevnte kommandoen er utført, be deg om et passord. Sørg for å velge et sterkt passord og deretter bekrefte det.
+
+8. Ledgeren vil be deg om hvorvidt du vil eksportere de private nøklene eller ikke. Midlene dine kan først og fremst ikke bli kompromittert med kun den private visningsnøkkelen. Å eksportere den private visningsnøkkelen gjør at klienten (Monero v0.12.2.0 på PC-en) kan skanne etter blokker og se etter transaksjoner som tilhører lommeboken/adressen din. Hvis dette valget ikke brukes, vil enheten (Ledgeren) skanne etter blokker, noe som går betraktelig saktere. Det er imidlertid én ting å passe seg for. Det er at dersom systemet ditt blir kompromittert, vil den uvedkommende muligens kunne kompromittere din private nøkkel i tillegg, som er ødeleggende for personvernet. Dette er praktisk talt umulig når den private visningsnøkkelen ikke eksporteres.
+
+9. Du må muligens trykke på «Confirm» (Bekreft) to ganger før du kan fortsette.
+
+10. Ledger Monero-lommeboken din vil nå genereres. Merk at dette kan ta opptil 5–10 minutter. Videre vil det ikke komme en umiddelbar tilbakemelding, verken på CLI-en eller Ledgeren.
+
+11. `monero-wallet-cli` vil oppdateres. Vent til den er ferdig med å oppdatere.
+
+12. Gratulerer. Du kan nå bruke Ledger Monero-lommeboken din sammen med CLI-en.
+
+### 3. Linux
+Vi må først sørge for at vi er tilstrekkelig forberedt. Dette innebærer følgende:
+
+1. Denne veiledningen antar at du allerede har initialisert Ledger-lommeboken din og således generert et mnemonisk frø på 24 ord.
+
+2. Du må kjøre/bruke CLI v0.12.2.0, som du kan finne <a href="{{site.baseurl}}/downloads/">her</a>.
+
+3. Du må installere Ledger Monero-appen og konfigurere systemet ditt. Veiledninger til dette kan du finne [her](https://github.com/LedgerHQ/blue-app-monero/blob/master/doc/user/bolos-app-monero.pdf) (spesielt seksjonene 3.1.1 og 3.2.1). I tillegg må du sørge for å sette nettverket til `Mainnet`.
+
+4. Ledgeren din må plugges inn, og Ledger Monero-appen bør være i gang.
+
+5. Enten din daemon (`monerod`) bør kjøre og helst være helt synkronisert, eller så må du koble til en ekstern node.
+
+Nå som vi er tilstrekkelig forberedt, la oss sette i gang!
+
+1. Gå til katalogen/mappen der monero-wallet-cli og monerod ligger.
+
+2. Åpne en ny terminal
+
+3. Tast inn:
+
+`./monero-wallet-cli --generate-from-device <new-wallet-name> --subaddress-lookahead 3:200`
+
+Merk at dette er en plassholder for det faktiske lommeboknavnet. Hvis du for eksempel vil kalle lommeboken din for `MoneroWallet`, er kommandoen som følger:
+
+`./monero-wallet-cli --generate-from-device MoneroWallet --subaddress-lookahead 3:200`
+
+4. CLI-en vil, etter at den ovennevnte kommandoen er eksekvert, be deg om et passord. Sørg for å velge et sterkt passord og deretter bekrefte det.
+
+5. Ledgeren vil be deg om hvorvidt du vil eksportere de private nøklene eller ikke. Midlene dine kan først og fremst ikke bli kompromittert med kun den private visningsnøkkelen. Å eksportere den private visningsnøkkelen gjør at klienten (Monero v0.12.2.0 på PC-en) kan skanne etter blokker og se etter transaksjoner som tilhører lommeboken/adressen din. Hvis dette valget ikke brukes, vil enheten (Ledgeren) skanne etter blokker, noe som går betraktelig saktere. Det er imidlertid én ting å passe seg for. Det er at dersom systemet ditt blir kompromittert, vil den uvedkommende muligens kunne kompromittere din private nøkkel i tillegg, som er ødeleggende for personvern. Dette er praktisk talt umulig når den private visningsnøkkelen ikke eksporteres.
+
+6. Du må muligens trykke på «Confirm» (Bekreft) to ganger før du kan fortsette.
+
+7. Ledger Monero-lommeboken din vil nå genereres. Merk at dette kan ta opptil 5–10 minutter. Videre vil det ikke komme en umiddelbar tilbakemelding, verken på CLI-en eller Ledgeren.
+
+8. `monero-wallet-cli` vil oppdateres. Vent til den er ferdig med å oppdatere.
+
+Gratulerer. Du kan nå bruke Ledger Monero-lommeboken din sammen med CLI-en.
+
+### 4. Noen sluttmerknader
+
+1. Vi anbefaler på det sterkeste å først teste ut prosessen – med andre ord å først sende et lite beløp til lommeboken og deretter gjenopprette den (ved å bruke den ovennevnte veiledningen) for å bekrefte at du kan gjenopprette lommeboken. Merk at ved oppretting/gjenoppretting av lommeboken, bør du tilføye `--restore-height`-flagget (med blokkhøyden før høyden til den første transaksjonen til lommeboken din) til kommandoen i steg 3 (Windows), steg 5 (Mac OS X), eller steg 3 (Linux). Mer informasjon om gjenoppretting av høyde og hvordan å tilnærme det, kan du finne [her](https://monero.stackexchange.com/questions/7581/what-is-the-relevance-of-the-restore-height).
+
+2. Hvis du bruker en ekstern node, kan du tilføye `--daemon-address host:port`-flagget til kommandoen i steg 3 (Windows), steg 5 (Mac OS X), eller steg 3 (Linux).
+
+3. Hvis ønskelig, kan du manuelt justere `--subaddress-lookahead`-verdien. Den første verdien er antallet kontoer, og den andre verdien er antall underadresser per konto. Hvis du for eksempel vil forhåndsgenerere fem kontoer med 100 underadresse hver, kan du bruke `--subaddress-lookahead 5:100`. Husk at jo flere underadresser du genererer, jo lengre tar det for Ledgeren å opprette lommeboken din.
+
+4. Du trenger bare å bruke `--generate-from-device`-flagget én gang (altså når du oppretter lommeboken). Deretter bruker du den i bunn og grunn som du vanligvis bruker CLI-en. Det innebærer å:
+   1. Sørge for at Ledgeren din er plugget i og at Monero-appen er i gang.
+   2. Åpne `monero-wallet-cli`.
+   3. Legg inn lommeboknavnet til Ledger Monero-lommeboken din.
+   4. Legge inn passordet for å åpne lommeboken.
+
+   Dersom lommebokfilene til Ledgeren ikke befinner seg i samme katalog som `monero-wallet-cli`, bør du åpne `monero-wallet-cli` med `--wallet-file /path/to/wallet.keys/file`-flagget. Alternativt kan du kopiere Ledger-lommebokfilene til samme katalog som `monero-wallet-cli`.
+
+5. Hvis du har flere spørsmål eller trenger hjelp, kan du legge igjen en kommentar på det opprinnelige [StackExchange](https://monero.stackexchange.com/questions/8503/how-do-i-generate-a-ledger-monero-wallet-with-the-cli-monero-wallet-cli)-svaret.
+
+Forfatter: dEBRUYNE
+Sekundærforfatter: el00ruobuob

--- a/_i18n/nb-no/resources/user-guides/mine-to-pool.md
+++ b/_i18n/nb-no/resources/user-guides/mine-to-pool.md
@@ -1,0 +1,194 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+## Lommebok
+
+Før du begynner, må du allerede ha en konfigurert lommebok som virker. Monero-poolen må vite lommebokadressen din for å kunne sende betalinger dit. Se [Å ta imot Monero-guiden]({{ site.baseurl}}/get-started/accepting) for mer informasjon.
+
+## Lønnsomhet
+
+Før du utvinner, bør du avgjøre om det er verdt det eller ikke for deg. Du må avgjøre dette på egenhånd, på grunnlag strømkostnadene og maskinvaren du har. Det finnes mange nettsteder, som f.eks. [CryptoCompare](https://www.cryptocompare.com/mining/calculator/xmr), som lar deg legge inn hastigheten og strømforbruket på utvinneren din, og den viser seg også forventet profitt (eller tap) per uke/måned.
+
+## Nedlasting av utvinneren
+
+Det første steget er å laste ned utvinningsprogramvaren til PC-en din.
+
+### Windows
+
+XMRig-utvikleren gir forhåndsbyggede binærfiler for Windows-brukere. De er tilgjengelige på [GitHub release-siden](https://github.com/xmrig/xmrig/releases/latest).
+
+Bla ned til du ser `xmrig-VERSION-msvc-win64.zip`. Last ned denne filen og pakk ut arkivene til et sted du husker, som f.eks. skrivebordet ditt.
+
+### Ubuntu Linux
+
+MRig-utvikleren gir forhåndsbyggede binærfiler for Ubuntu Xenial
+Xerus (16.04). De kan fungere på andre Ubuntu-versjoner og på andre distribusjoner, men det er ikke garantert.
+
+Disse binærfilene er tilgjengelig på [GitHub release-siden](https://github.com/xmrig/xmrig/releases/latest).
+
+Bla ned til du ser `xmrig-VERSION-xenial-x64.tar.gz`. Last ned denne filen og pakk ut arkivene til et sted du husker, som f.eks. skrivebordet ditt.
+
+### Andre Linux-distribusjoner
+
+Brukere av andre Linux-distribusjoner kan kompilere XMRig fra bunnen av. Først må avhengighetsfilene installeres:
+
+```
+# For Debian-baserte distroer
+sudo apt install \
+	build-essential \
+	cmake \
+	git \
+	libhwloc-dev \
+	libssl-dev \
+	libuv1-dev
+```
+
+Last ned XMRig-kildekoden:
+
+```
+git clone https://github.com/xmrig/xmrig.git
+cd xmrig
+```
+
+Konfigurer og kompiler XMRig:
+
+```
+cmake -Bbuild
+make -Cbuild -j$(nproc)
+```
+
+Kopier binærfilene og konfigurasjonseksempelet til hjemmemappen din:
+
+```
+cp build/xmrig ~/
+cp src/config.json ~/
+```
+
+### macOS Build
+
+Installer først XCode og [Homebrew](https://brew.sh).
+
+Bruk Homebrew til å installere avhengighetsfiler:
+
+```
+brew install \
+	cmake \
+	hwloc \
+	libmicrohttpd \
+	libuv \
+	openssl
+```
+
+Last ned XMRig-kilder:
+
+```
+git clone https://github.com/xmrig/xmrig.git
+cd xmrig
+```
+
+Konfigurer og kompiler XMRig:
+
+```
+cmake -Bbuild -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+make -Cbuild -j$(nproc)
+```
+
+Kopier binærfilene og konfigurasjonseksempelet til hjemmemappen din:
+
+```
+cp build/xmrig ~/
+cp src/config.json ~/
+```
+
+## Å velge en pool
+
+Det er mange pools å velge blant. Du kan finne en liste på [miningpoolstats.stream/monero](https://miningpoolstats.stream/monero).
+
+Å velge en større pool betyr at du vil se hyppigere (men mindre) utbetalinger, men å velge en mindre pool holder nettverket desentralisert. [Utvinnere vil ikke miste inntekt ved å utvinne på en mindre pool](https://redd.it/g6uh2l).
+
+## Konfigurering av utvinneren
+
+Naviger til nettsiden til din valgte pool og les dokumentasjonen deres. De bør nevne en adresse og port som du kan legge inn i utvinneren din som f.eks. `pool.xmr.pt:3333`.
+
+Etter det, åpner du config.json-filen som du kopierte eller pakket ut tidligere i tekstbehandleren din. Bla nedover til linjene hvor det står `donate.v2.xmrig.com:3333` og endre teksten på innsiden av anførselstegnene til adressen til poolen din. Linjen under bør inneholde `YOUR_WALLET_ADDRESS`. Endre den til den faktiske lommebokadressen din.
+
+Etter disse endringene har blitt gjort, bør konfigurasjonen din se ut noe som dette:
+
+```
+{
+	// [...]
+	"pools": [
+		{
+			"url": "pool.xmr.pt:3333",
+			"user": "43YjW8SZov..."
+		}
+	],
+	// [...]
+}
+```
+
+## Å starte utvinneren
+
+Windows-brukere kan dobbeltklikke på xmrig.exe. Brukere til andre operativsystemer bør bruke `cd`-kommandoen til de kommer i mappeen som inneholder XMRig, og deretter taste inn `./xmrig` etterfulgt av enter.
+
+Hvis du ser grønne meldinger som sier at andelene har blitt godkjent – gratulerer, alt funker!
+
+## Feilsøking
+
+### Antiviruset fjerner stadig XMRig
+
+Noen antivirus flagger XMRig som skadevare fordi den ofte utplasseres i PC-en for å infisere PC-en din til å utvinne uten eierens samtykke. I og med at dette er din PC og du konfigurerer utvinneren til å utvinne for deg, er det trygt å legge XMRig til antivirus-tillatelseslisten din.
+
+### Kan ikke lese / stille inn MSR
+
+På noen CPU-er prøver XMRig å øke ytelsen ved å deaktivere visse funksjoner som forhåndshenting av instruksjonene til CPU-en din. Disse operasjonene krever root/administrator, så prøv å høyreklikke på xmrig.exe og kjøre den som administrator eller kjøre `sudo ./xmrig` på andre systemer.
+
+### Ukjent algoritme
+
+Finn linjen i config.json som sier `algo: null` og endre den til `algo: "rx/0"`. XMRig forventer som standard at poolen forteller den hvilken hashing-algoritme som skal benyttes.
+
+### Store sider 0 %
+
+#### Å tillate store sider på Windows
+
+Tatt fra [MSDN](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/enable-the-lock-pages-in-memory-option-windows?view=sql-server-ver15):
+
+1. Gå til Start-menyen og trykk «Kjør». Tast inn `gpedit.msc` i den åpne boksen.
+2. I redigeringskonsollen for lokale grupperetningslinjer, må du utvide datakonfigurasjonen og deretter utvide Windows-instillingene.
+3. Utvid sikkerhetsinstillingene og utvid deretter lokale retningslinjer.
+4. Velg den tildelte mappen for brukerrettigheter.
+5. Retningslinjene vil vises i detaljruta.
+6. I ruten dobbeltklikker du på «Lock pages in Memory» (Lås sider i minnet).
+7. I den lokale sikkerhetsinnstillingen «Lås sider i minnet»-dialogboksen, trykker du på «Legg til bruker eller gruppe.»
+8. Legg til en konto under «Velg brukere»-, «Tjenestekontoer»- eller «Gruppedialog»-boksen som du vil kjøre utvinneren på.
+9. Start på nytt for at endringene skal tre i kraft.
+
+Du må også kanskje starte utvinneren som administrator.
+
+#### Å tillate store sider på Linux
+
+Til å begynne med, kan du stoppe utvinneren (hvis den er i gang), kjøre følgende kommandoer for å muliggjøre store sider, og deretter starte utvinneren som root:
+
+	sudo sysctl -w vm.nr_hugepages=1168
+	sudo ./xmrig
+
+Du må kanskje øke til 1168, avhengig av hvor mange NUMA-noder CPU-en(e) din har.
+
+#### Å tillate store sider på macOS
+
+Store sider støttes ikke på macOS.
+
+### Saldoen øker ikke
+
+De fleste pools er <abbr title="Pay Per Last N Shares">PPLNS</abbr> (Betal per siste N andeler)-pools, som betyr at du kun får betalt når en utvinner i poolen finner en blokk. Hvis poolen du utvinner på er liten, kan dette ta noen dager til uker.
+
+Eventuelle blokker som blir funnet må i tillegg modnes før de kan utbetales. Dette tar 60 blokker (omlag to timer).
+
+## Å få hjelp
+
+Det finnes et aktivt samfunn for Monero-utvinning på Reddit som du finner i underforumet [/r/MoneroSupport](https://www.reddit.com/r/MoneroSupport/). Du kan også bli med i [#monero-pools på
+freenode](https://webchat.freenode.net/?channel=#monero-pools).
+
+## Å gå mer i dybden
+
+* Vurder å bruke en underadresse kun for utvinning for å hindre at adressen din blir lenket til forskjellige tjenester.
+* [Vurder å bruke Tor til å koble til poolen](https://xmrig.com/docs/miner/tor) (eller til en skjult tjenestepool som HashVault, RespectXMR og MoneroOcean). Dette skjuler utvinningaktiviten fra ISP-en din og hindrer at poolen får kjennskap til hvem du er.

--- a/_i18n/nb-no/resources/user-guides/mine-to-pool.md
+++ b/_i18n/nb-no/resources/user-guides/mine-to-pool.md
@@ -128,7 +128,7 @@ Etter disse endringene har blitt gjort, bør konfigurasjonen din se ut noe som d
 
 ## Å starte utvinneren
 
-Windows-brukere kan dobbeltklikke på xmrig.exe. Brukere til andre operativsystemer bør bruke `cd`-kommandoen til de kommer i mappeen som inneholder XMRig, og deretter taste inn `./xmrig` etterfulgt av enter.
+Windows-brukere kan dobbeltklikke på xmrig.exe. Brukere til andre operativsystemer bør bruke `cd`-kommandoen til de ender opp i mappen som inneholder XMRig, og deretter taste inn `./xmrig` etterfulgt av enter.
 
 Hvis du ser grønne meldinger som sier at andelene har blitt godkjent – gratulerer, alt funker!
 
@@ -154,7 +154,7 @@ Tatt fra [MSDN](https://docs.microsoft.com/en-us/sql/database-engine/configure-w
 
 1. Gå til Start-menyen og trykk «Kjør». Tast inn `gpedit.msc` i den åpne boksen.
 2. I redigeringskonsollen for lokale grupperetningslinjer, må du utvide datakonfigurasjonen og deretter utvide Windows-instillingene.
-3. Utvid sikkerhetsinstillingene og utvid deretter lokale retningslinjer.
+3. Utvid sikkerhetsinnstillingene og utvid deretter lokale retningslinjer.
 4. Velg den tildelte mappen for brukerrettigheter.
 5. Retningslinjene vil vises i detaljruta.
 6. I ruten dobbeltklikker du på «Lock pages in Memory» (Lås sider i minnet).

--- a/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
@@ -1,7 +1,5 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-# monero-wallet-cli
-
 `monero-wallet-cli` er lommebokprogramvaren som kommer sammen med Monero tree. Det er et konsollprogram og administrerer en konto. Mens en bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero disse: `monerod` håndterer blokkjeden, og `monero-wallet-cli` håndterer kontoen.
 
 Denne veiledningen viser deg hvordan man utfører ulike operasjoner fra `monero-wallet-cli`-UI-en. Veiledningen antar at du bruker den siste versjonen av Monero og allerede har opprettet en konto i henhold til de andre veiledningene.

--- a/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
@@ -44,7 +44,7 @@ Betalings-ID-en inngår i dette tilfellet i den integrerte adressen.
 Bytt ut `RINGSIZE` med antallet utdata du vil bruke. **Hvis dette ikke angis, velges 11 som standard.** Det er en god idé å bruke standarden, men du kan øke antallet dersom du vil inkludere flere utdata. Jo høyere antallet, jo større er transaksjonen, og jo høyere gebyr trengs for transaksjonen.
 
 
-## Receiving monero
+## Å motta monero
 
 Hvis du har din egen Monero-adresse, trenger du bare å gi din standardadresse til noen.
 

--- a/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
@@ -1,0 +1,116 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+# monero-wallet-cli
+
+`monero-wallet-cli` er lommebokprogramvaren som kommer sammen med Monero tree. Det er et konsollprogram og administrerer en konto. Mens en bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero disse: `monerod` håndterer blokkjeden, og `monero-wallet-cli` håndterer kontoen.
+
+Denne veiledningen viser deg hvordan man utfører ulike operasjoner fra `monero-wallet-cli`-UI-en. Veiledningen antar at du bruker den siste versjonen av Monero og allerede har opprettet en konto i henhold til de andre veiledningene.
+
+
+## Å sjekke saldoen din
+
+Fordi håndteringen av blokkjeden og lommeboken er separate programmer, må mye av bruken av `monero-wallet-cli` skje med @daemon. Dette omfatter å se etter innkommende transaksjoner til adressen din.
+Når du kjører både `monero-wallet-cli` og `monerod`, kan du taste inn `balance.`
+
+Eksempel:
+
+Dette vil trekke blokker fra daemon som lommeboken enda ikke har sett og oppdatere saldoen slik at den samsvarer. Denne prosessen gjøres normalt i bakgrunnen, omtrent hvert minutt. For å se se saldoen uten å oppdatere:
+
+    balance
+    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+
+I dette eksempelet er `Balance` din totale saldo. `unlocked balance` er beløpet som for øyeblikket er disponibelt. Nylig mottatte transaksjoner trenger 10 bekreftelser på blokkjeden før de låses opp. `unlocked dust` viser til veldig små beløp av ubrukte utdata som kan ha samlet seg opp på kontoen din.
+
+## Å sende monero
+
+Du vil trenge standardadressen som du vil sende til (en lang streng som begynner med '4'), muligens en betalings-ID, dersom mottakeren ber om det. I det siste tilfellet kan mottakeren i stedet gi deg en integrert adresse, der begge disse er pakket inn i én enkel adresse.
+
+### Å sende til en standard adresse:
+
+    transfer ADDRESS AMOUNT PAYMENTID
+
+Bytt ut `ADDRESS` med adressen du vil sende til, `AMOUNT` med hvor mange monero du vil sende, og `PAYMENTID` med betalings-ID-en du ble gitt. Betalings-ID-er er valgfrie. Hvis mottakeren ikke trenger en, kan du bare sløyfe det.
+
+### Å sende til en integrert adresse:
+
+    transfer ADDRESS AMOUNT
+
+Betalings-ID-en inngår i dette tilfellet i den integrerte adressen.
+
+### Spesifiser antallet utdata for en transaksjon:
+
+    transfer RINGSIZE ADDRESS AMOUNT
+
+Bytt ut `RINGSIZE` med antallet utdata du vil bruke. **Hvis dette ikke angis, velges 11 som standard.** Det er en god idé å bruke standarden, men du kan øke antallet dersom du vil inkludere flere utdata. Jo høyere antallet, jo større er transaksjonen, og jo høyere gebyr trengs for transaksjonen.
+
+
+## Receiving monero
+
+Hvis du har din egen Monero-adresse, trenger du bare å gi din standardadresse til noen.
+
+Du kan finne ut hva adressen din er med kommandoen:
+
+    address
+
+I og med at Monero er anonymt, vil du ikke se avsenders adresse som midlene du mottok kom fra. Hvis du vil vite det, for eksempel for å kreditere en spesifikk kunde, må du be senderen om å bruke en betalings-ID, som er en vilkårlig og valgfri merkelapp som festes til en transaksjon. For å gjøre livet enklere, kan du generere en adresse som allerede inkluderer en tilfeldig betalings-ID:
+
+    integrated_address
+
+Dette vil generere en tilfeldig betalings-ID og gi deg adressen som inkluderer din egen konto og den betalings-ID-en. Hvis du vil velge en spesiell betalings-ID, kan du også gjøre det:
+
+    integrated_address 12346780abcdef00
+
+Betalinger som gjøres til en integrert adresse som er generert fra kontoen din, går til din konto der den spesifikke betalings-ID-en festes slik at du kan skille betalinger fra hverandre.
+
+
+## Å bevise til en tredjepart at du har betalt noen
+
+Hvis du betaler en forhandler og forhandleren påstår å ikke ha mottatt midlene, må du kunne bevise for en tredjepart at du har sendt midlene – eller til og med til forhandleren, dersom det er en ærlig feil. Monero er privat, så du kan ikke bare vise til transaksjonen din i blokkjeden, i og med at man ikke kan fastslå hvem som har sendt det, og hvem som mottok det. Ved å forsyne parten med en «per-transaction»-privat nøkkel, kan den parten si hvorvidt den transaksjonen sendte monero til den bestemte adressen eller ikke. Merk at å lagre disse «per-transaction»-nøklene er deaktivert som standard, så du må aktivere det før du sender hvis du tror du kan få bruk for det:
+
+    set store-tx-info 1
+
+Du kan finne igjen tx-nøkkelen fra en tidligere transaksjon slik:
+
+    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+
+Legg inn transaksjons-ID-en som du ønsker nøkkelen for. Husk at en betaling må splittes inn i mer enn én transaksjon, så du trenger kanskje flere nøkler. Du kan deretter sende den nøkkelen eller disse nøklene til hvem nå enn du vil sende bevis på transaksjonen din til sammen med transaksjons-ID-en og adressen du sendte til. Merk at denne tredjeparten også vil kunne se hvor mye veksel som ble sendt tilbake til deg dersom vedkommende kjenner til din adresse.
+
+Hvis du er tredjeparten (altså om noen vil bevise til deg at de har sendt monero til en adresse), kan du sjekke det slik:
+
+    check_tx_key TXID TXKEY ADDRESS
+
+Bytt ut `TXID`, `TXKEY` og `ADDRESS` med henholdsvis transaksjons-ID-en, per-transaction-nøkkel og mottakeradressen som ble gitt til deg. monero-wallet-cli vil sjekke den transaksjonen og gi deg beskjed om hvor mye monero denne transaksjonen utbetalte til den oppgitte adressen.
+
+
+## Mulighet til å bekrefte/avbryte betalinger
+
+Hvis du vil få en siste bekreftelse når du sender en betaling:
+
+    set always-confirm-transfers 1
+
+
+## Hvordan å finne en betaling som skal til deg
+
+Hvis du har mottatt en betaling ved bruk av en bestemt betalings-ID, kan du slå den opp: 
+
+    payments PAYMENTID
+
+Du kan også gi dem mer enn én betalings-ID.
+
+Mer generelt kan du gjennomgå innkommende og utgående betalinger:
+
+    show_transfers
+
+Du kan gi en valgfri høyde for å kun liste opp nylige transaksjoner og kun be om innkommende eller utgående transaksjoner.
+
+    show_transfers in 650000
+
+vil for eksempel kun vise innkommende overføringer etter blokk 650 000. Du kan også gi et høydeintervall.
+
+Hvis du vil utvinne, kan du gjøre det fra lommeboken:
+
+    start_mining 2
+
+Dette setter i gang utvinning på daemonen ved bruk at to tråder. Merk at dette er solo-utvinning, så det kan ta litt tid før du finner en blokk. For å stanse utvinningen:
+
+    stop_mining

--- a/_i18n/nb-no/resources/user-guides/monero_tools.md
+++ b/_i18n/nb-no/resources/user-guides/monero_tools.md
@@ -1,0 +1,17 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Disse verktøyene kan brukes til å få informasjon om Monero-nettverket eller transaksjonsdataene dine i blokkjeden.
+
+### [Kontroller at en mottaker har mottatt midlene dine](http://xmrtests.llcoins.net/checktx.html)
+
+### [Verktøy for monero-adressegenerering](https://xmr.llcoins.net/)
+
+### [Monero-nodetelling](http://moneronodes.i2p.xyz/)
+
+### [Monero-nodekart](https://monerohash.com/nodes-distribution.html)
+
+### [Frakoblet Monero-lommebokgenerator](http://moneroaddress.org/)
+
+### [Monero-nettverksstatistikk](http://moneroblocks.info/stats)
+
+### [Monero.how-statistikk](https://www.monero.how/)

--- a/_i18n/nb-no/resources/user-guides/node-i2p-zero.md
+++ b/_i18n/nb-no/resources/user-guides/node-i2p-zero.md
@@ -7,15 +7,15 @@
 4. (valgfritt) Finn din tilfeldig tildelte I2P-port ved å taste inn: `router/bin/tunnel-control.sh router.externalPort`. Av personvernhensyn avdekker vi ikke dette portnummeret til andre personer. Få brannmuren din til å videreføre trafikk gjennom denne porten slik at I2P-noden din er offentlig tilgjengelig. Hvis du ikke har mulighet til å tillate innkommende transaksjoner, vil alt fremdeles fungere, men I2P-noden din vil ikke hjelpe I2P-nettverket like mye som det hadde kunnet.
 5. Opprett en socks-tunnel for utgående I2P-tilkoblinger ved å taste inn: `router/bin/tunnel-control.sh socks.create 8060`
 6. Opprett en server-tunnel for innkommende I2P-tilkoblinger ved å taste inn: `router/bin/tunnel-control.sh server.create 127.0.0.1 8061`.
-7. Komandoen over vil resultere i en I2P-adresse som skrives ut til kommandolinjen, som ender med `.b32.i2p`. Dette er din nye I2P-adresse.
-8. Kjør monerod ved å taste inn følgende og erstatt `XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p` med din egen I2P-adresse som ble skrevet ut fra steg 6: `monerod --tx-proxy i2p,127.0.0.1:8060 --add-peer core5hzivg4v5ttxbor4a3haja6dssksqsmiootlptnsrfsgwqqa.b32.i2p --add-peer dsc7fyzzultm7y6pmx2avu6tze3usc7d27nkbzs5qwuujplxcmzq.b32.i2p --add-peer sel36x6fibfzujwvt4hf5gxolz6kd3jpvbjqg6o3ud2xtionyl2q.b32.i2p --add-peer yht4tm2slhyue42zy5p2dn3sft2ffjjrpuy7oc2lpbhifcidml4q.b32.i2p --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach`
+7. Kommandoen over vil resultere i en I2P-adresse som skrives ut til kommandolinjen, som ender med `.b32.i2p`. Dette er din nye I2P-adresse.
+8. Kjør monerod ved å taste inn følgende kommando, og erstatt `XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p` med din egen I2P-adresse som ble skrevet ut i steg 6: `monerod --tx-proxy i2p,127.0.0.1:8060 --add-peer core5hzivg4v5ttxbor4a3haja6dssksqsmiootlptnsrfsgwqqa.b32.i2p --add-peer dsc7fyzzultm7y6pmx2avu6tze3usc7d27nkbzs5qwuujplxcmzq.b32.i2p --add-peer sel36x6fibfzujwvt4hf5gxolz6kd3jpvbjqg6o3ud2xtionyl2q.b32.i2p --add-peer yht4tm2slhyue42zy5p2dn3sft2ffjjrpuy7oc2lpbhifcidml4q.b32.i2p --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach`
 
 Det var alt! Ikke bytt ut dsc****.b32.i2p-adressen med din egen, bare bytt ut XXXXXXX.b32.i2p. dsc****.b32.i2p-en er en frønode som hjelper deg med å oppdage andre I2P-tilgjengelige Monero-noder.
 
 ## Oppsett av Linux-tjenester slik at monerod og I2P-zero startes automatisk
 Hvis du kjører Linux, er det nyttig å sette opp dette til å kjøre automatisk dersom maskinen noen gang startes på nytt. Du kan gjøre dette ved å opprette systemd-servicefiler:
 
-Merk: sørg for å bytte ut versjonummerne i filene under med versjonnummerne til monero og i2p-zero som du laster ned. Bytt også ut `<username>` og `<usergroup>` med din Linux-bruker og gruppenavn (bruk `whoami`- og `groups`-kommandoene hvis du ikke kjenner til dem).
+Merk: sørg for å bytte ut versjonnumrene i filene under med versjonnumrene til monero og i2p-zero som du laster ned. Bytt også ut `<username>` og `<usergroup>` med din Linux-bruker og gruppenavn (bruk `whoami`- og `groups`-kommandoene hvis du ikke kjenner til dem).
 
 ### /etc/systemd/system/i2pzero.service
 ````                                                

--- a/_i18n/nb-no/resources/user-guides/node-i2p-zero.md
+++ b/_i18n/nb-no/resources/user-guides/node-i2p-zero.md
@@ -1,0 +1,65 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+## Steg:
+1. Last ned [Monero CLI]({{  site.baseurl }}/downloads/#cli).
+2. Last ned og pakk ut den siste (ikke-GUI)-versjonen av I2P-zero: https://github.com/i2p-zero/i2p-zero/releases
+3. Kjør I2P-zero ved å taste inn den i2p-zero-utpakkede katalogen og tast inn: `router/bin/i2p-zero`
+4. (valgfritt) Finn din tilfeldig tildelte I2P-port ved å taste inn: `router/bin/tunnel-control.sh router.externalPort`. Av personvernhensyn avdekker vi ikke dette portnummeret til andre personer. Få brannmuren din til å videreføre trafikk gjennom denne porten slik at I2P-noden din er offentlig tilgjengelig. Hvis du ikke har mulighet til å tillate innkommende transaksjoner, vil alt fremdeles fungere, men I2P-noden din vil ikke hjelpe I2P-nettverket like mye som det hadde kunnet.
+5. Opprett en socks-tunnel for utgående I2P-tilkoblinger ved å taste inn: `router/bin/tunnel-control.sh socks.create 8060`
+6. Opprett en server-tunnel for innkommende I2P-tilkoblinger ved å taste inn: `router/bin/tunnel-control.sh server.create 127.0.0.1 8061`.
+7. Komandoen over vil resultere i en I2P-adresse som skrives ut til kommandolinjen, som ender med `.b32.i2p`. Dette er din nye I2P-adresse.
+8. Kjør monerod ved å taste inn følgende og erstatt `XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p` med din egen I2P-adresse som ble skrevet ut fra steg 6: `monerod --tx-proxy i2p,127.0.0.1:8060 --add-peer core5hzivg4v5ttxbor4a3haja6dssksqsmiootlptnsrfsgwqqa.b32.i2p --add-peer dsc7fyzzultm7y6pmx2avu6tze3usc7d27nkbzs5qwuujplxcmzq.b32.i2p --add-peer sel36x6fibfzujwvt4hf5gxolz6kd3jpvbjqg6o3ud2xtionyl2q.b32.i2p --add-peer yht4tm2slhyue42zy5p2dn3sft2ffjjrpuy7oc2lpbhifcidml4q.b32.i2p --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach`
+
+Det var alt! Ikke bytt ut dsc****.b32.i2p-adressen med din egen, bare bytt ut XXXXXXX.b32.i2p. dsc****.b32.i2p-en er en frønode som hjelper deg med å oppdage andre I2P-tilgjengelige Monero-noder.
+
+## Oppsett av Linux-tjenester slik at monerod og I2P-zero startes automatisk
+Hvis du kjører Linux, er det nyttig å sette opp dette til å kjøre automatisk dersom maskinen noen gang startes på nytt. Du kan gjøre dette ved å opprette systemd-servicefiler:
+
+Merk: sørg for å bytte ut versjonummerne i filene under med versjonnummerne til monero og i2p-zero som du laster ned. Bytt også ut `<username>` og `<usergroup>` med din Linux-bruker og gruppenavn (bruk `whoami`- og `groups`-kommandoene hvis du ikke kjenner til dem).
+
+### /etc/systemd/system/i2pzero.service
+````                                                
+[Unit]
+Description=i2pzero
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/<username>/i2p-zero-linux.v1.17/router/bin/i2p-zero
+User=<username>
+Group=<usergroup>
+
+[Install]
+WantedBy=multi-user.target
+````
+
+### /etc/systemd/system/monerod.service
+````
+[Unit]
+Description=monerod
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/home/<username>/monerod.pid
+ExecStart=/home/<username>/monero-x86_64-linux-gnu-v0.16.0.0/monerod --tx-proxy i2p,127.0.0.1:8060 --add-peer core5hzivg4v5ttxbor4a3haja6dssksqsmiootlptnsrfsgwqqa.b32.i2p --add-peer dsc7fyzzultm7y6pmx2avu6tze3usc7d27nkbzs5qwuujplxcmzq.b32.i2p --add-peer sel36x6fibfzujwvt4hf5gxolz6kd3jpvbjqg6o3ud2xtionyl2q.b32.i2p --add-peer yht4tm2slhyue42zy5p2dn3sft2ffjjrpuy7oc2lpbhifcidml4q.b32.i2p --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach --pidfile /home/<username>/monerod.pid
+User=<username>
+Group=<usergroup>
+
+[Install]
+WantedBy=multi-user.target
+````
+
+Etter disse to filene er opprettet, eksekverer du:
+````
+systemctl daemon-reload
+service i2pzero start
+service monerod start
+````
+
+For å se utdataene til disse tjenestene, kan du bruke `journalctl -u i2pzero` og `journalctl -u monerod`
+
+## Å kjøre din egen frønode (mipseed)
+Hvis du vil kjøre din egen frønode (kjent som en 'mipseed') for å hjelpe andre med å oppdage I2P-tilgjengelige Monero-noder, kan du følge instruksjonene i [i2p-zero-arkivet](https://github.com/i2p-zero/i2p-zero/blob/master/mipseed.md).
+
+*Den opprinnelige versjonen av denne guiden ble opprinnelig lastet opp i [i2p-zero-arkivet](https://github.com/i2p-zero/i2p-zero/blob/master/monerod-with-i2p-zero.md).*

--- a/_i18n/nb-no/resources/user-guides/prove-payment.md
+++ b/_i18n/nb-no/resources/user-guides/prove-payment.md
@@ -1,0 +1,81 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+### Bevis betalinger
+
+Når du sender penger til en part som omdiskuterer at betalingen har blitt gjort, må du kunne bevise at betalingen har skjedd.
+
+Med bitcoin gjøres dette som regel ved å slå opp transaksjons-ID-en, der den opprinnelige adressen og sluttadressen vises sammen med transaksjonsbeløpet.
+
+Monero er imidlertid privat. Disse opplysningene er ikke offentlig tilgjengelig på blokkjeden. Trinnene er derfor litt mer innviklet.
+
+For å bevise til Charlie at hun har gjennomført en betaling til Bob, må Alive forsyne Charlie med tre opplysninger:
+
+- Transaksjons-ID-en (som i bitcoin)
+- Bobs adresse (som i bitcoin)
+- Transaksjonsnøkkelen, noe som er nytt med Monero og andre CryptoNote-valutaer
+
+Når Alice har gjennomført transaksjonen, ble en éngangsnøkkel automatisk generert for akkurat den ene transaksjonen.
+
+#### CLI
+
+Alice kan altså forespørre den i sin monero-wallet-cli (nytt navn for den gamle simplewallet):
+
+> get_tx_key TXID
+
+Alice må legge inn sin faktiske transaksjons-ID i stedet for denne TXID-plassholderen. Hvis alt går som det skal, vises éngangstransaksjonsnøkkelen.
+
+Merk at dette kun vil fungere dersom monero-wallet-cli er satt opp til å lagre transaksjonsnøkler. For å dobbeltsjekke:
+
+> set
+
+Hvis den er satt til 0, setter du den til 1:
+
+> set store-tx-info 1
+
+#### GUI
+
+Alice kan åpne sin monero-wallet-gui og gå til historikksiden for å se transaksjonsdetaljene sine:
+
+![History](/img/resources/user-guides/en/prove-payment/history.png)
+
+Her kan hun kopiere transaksjons-ID-en og Bobs adresse ved å trykke på hver av dem.
+Deretter kan hun trykke på `P` for å få et betalingsbevis (transaksjonsnøkkel):
+
+![Payment proof](/img/resources/user-guides/en/prove-payment/payment-proof.png)
+
+
+---
+
+Alice kan nå sende Charlie transaksjonsnøkkelen i tillegg til transaksjons-ID-en og Bobs adresse.
+
+Merk: Hvis flere transaksjoner har blitt gjort, må dette gjentas for hver transaksjon.
+
+### Sjekk betalinger
+
+Charlie har nå mottatt de tre opplysningene og vil sikre at Alice forteller sannheten. På en oppdatert blokkjede, 
+
+#### CLI
+
+taster Charlie inn i monero-wallet-cli:
+
+> check_tx_key TXID TXKEY ADDRESS
+
+Opplysningene som Alice har oppgitt innsettes på en ryddig måte istedenfor plassholderne. monero-wallet-cli-en vil bruke transaksjonsnøkkelen til å avkode transaksjonen og viser hvor mye akkurat denne transaksjonen har sendt til denne adressen. Charlie ønsker åpenbart å dobbeltsjekke med Bob at adressen virkelig er hans – på samme måte som med bitcoin.
+
+
+#### GUI
+
+Charlie vil åpne sin monero-wallet-gui og gå til Avansert > Bevis/Sjekk-siden for å fylle inn Sjekk-seksjonen med opplysningene som Alice har oppgitt:
+
+![Check payment](/img/resources/user-guides/en/prove-payment/check-payment.png)
+
+Å trykke på Sjekk vil deretter fortelle Charlie hvor mye akkurat denne transaksjonen har sendt til denne adressen og hvor mange bekreftelser transaksjonen hadde:
+
+![Payment checked](/img/resources/user-guides/en/prove-payment/payment-checked.png)
+
+
+---
+
+Charlie ønsker åpenbart å dobbeltsjekke med Bob at adressen virkelig er hans – på samme måte som med bitcoin.
+
+Merk: Hvis flere transaksjoner har blitt gjort, må dette repeteres for hver slik transaksjon.

--- a/_i18n/nb-no/resources/user-guides/prove-payment.md
+++ b/_i18n/nb-no/resources/user-guides/prove-payment.md
@@ -8,7 +8,7 @@ Med bitcoin gjøres dette som regel ved å slå opp transaksjons-ID-en, der den 
 
 Monero er imidlertid privat. Disse opplysningene er ikke offentlig tilgjengelig på blokkjeden. Trinnene er derfor litt mer innviklet.
 
-For å bevise til Charlie at hun har gjennomført en betaling til Bob, må Alive forsyne Charlie med tre opplysninger:
+For å bevise til Charlie at hun har gjennomført en betaling til Bob, må Alice forsyne Charlie med tre opplysninger:
 
 - Transaksjons-ID-en (som i bitcoin)
 - Bobs adresse (som i bitcoin)

--- a/_i18n/nb-no/resources/user-guides/remote_node_gui.md
+++ b/_i18n/nb-no/resources/user-guides/remote_node_gui.md
@@ -1,0 +1,43 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+## Sjekk om lommeboken din er i avansert modus
+For å bruke en tilpasset ekstern node, må lommeboken din være i avansert modus. Enkel modus og Enkel modus (oppstartmodus) støtter ikke denne funksjonen.
+
+For å sjekke om lommeboken din er i avansert modus, kan du gå til `Innstillinger` > `Informasjon` og se `Lommebokmodus`. 
+
+Hvis lommeboken din ikke er i avansert modus, må du endre den til avansert modus (se neste steg).
+
+Hvis lommeboken din allerede er i avansert modus, kan du hoppe over neste steg.
+
+![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+
+## Endre lommeboken din til avansert modus
+Hvis lommeboken din er åpen, må du først lukke den. Gå til `Innstillinger` > `Lommebok` > `Lukk denne lommeboken`
+
+![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+
+Hovedmenyen (`Velkommen til Monero`-skjermen) vil åpnes. Nederst til venstre kan du trykke på `Endre lommebokmodus`-knappen, og på neste side velge `Avansert modus`. Etter det åpner du lommebokfilen din igjen.
+
+![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+
+![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+
+## Å finne en offentlig, ekstern node
+Først må du finne en offentlig, ekstern node å koble til. Nettsiden [moneroworld.com](https://moneroworld.com/#nodes) har noen flotte ressurser for å finne noder. Én av de letteste metodene er å bruke offentlige noder som kjøres av moneroworld, men de har også et verktøy for å finne tilfeldige noder.
+
+## Å konfigurere lommeboken din til å koble til en tilpasset, offentlig ekstern node
+Når du åpner lommeboken din, dukker en popup opp med alternativet `Bruk tilpassede innstillinger`. Trykk på den, så blir du videresendt til siden `Innstilliger` > `Node`. 
+
+Hvis du ikke ser denne popupen, kan du gå til siden `Innstillinger` > `Node`.
+
+![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+
+På denne siden velger du `Ekstern node`.
+
+Under `Adresse` bør du fylle inn adressen til den eksterne noden som du vil koble til. Denne adressen ser kanskje ut som `node.moneroworld.com` eller så ser den ut som en hvilken som helst IP-adresse. 
+
+Under `Port` bør du fylle inn porten til den eksterne noden. Hvis en ekstern node er oppført som `node.moneroworld.com:18089`, er adressen `node.moneroworld.com` og porten er `18089`. Standardporten er `18081`, men den kan variere avhengig av noden du er koblet til.
+
+Hvis din eksterne node krever autentisering, kan du legge inn et brukernavn i `Daemon-brukernavn` og et passord i `Daemon-passord`.
+
+Avslutningsvis kan du trykke på `Koble til`-knappen og vente på at lommeboken din kobler seg til.

--- a/_i18n/nb-no/resources/user-guides/restore_account.md
+++ b/_i18n/nb-no/resources/user-guides/restore_account.md
@@ -1,0 +1,53 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+## Operativsystemer:  Windows, Linux, Mac
+
+- Hent frem ditt @mnemoniske frø på 25 ord som du lagret da du opprettet din gamle Monero-@lommebok
+
+### Kontoprogramvare:  monero-wallet-cli
+
+- Åpne en ledetekst og naviger til disken og katalogen som inneholder monero-wallet-cli
+
+- I ledeteksten taster du inn:  `monero-wallet-cli --restore-deterministic-wallet`
+
+- Når du trykker på enter, blir du bedt om et lommebokfilnavn. Gi lommeboken ditt et navn – et hvilket som helst navn holder
+
+- Trykk på enter igjen, så blir du bedt om et passord. Gi lommeboken din et nytt og langt passord
+
+- Trykk på enter igjen, så blir du bedt om å gjenta passordet
+
+- Trykk på enter igjen, så blir du bedt om å legge inn det mnemoniske electrum-frøet på 25 ord som du fant fram tidligere
+
+-  Du blir deretter tilskyndet med «Gjenopprett fra en spesifikk blokkjedehøyde (valgfritt, standard 0):» Standard-valget starter gjenopprettingsprosessen fra begynnelsen av Monero-blokkjeden. Hvis du ikke kjenner til den spesifikke blokkjedehøyden, trykker du bare på enter. (Å spesifisere en spesifikk blokkkjedehøyde starter gjenopprettingsprosessen fra den spesifikke høyden. Hvis du vet ved hvilken blokkjedehøyde midlene dine har gjennomgått en transaksjon, sparer dette litt tid hva gjelder skanning.)
+
+Etter du har tastet inn det mnemoniske frøet på 25 ord og har spesifisert blokkjedehøyden din, vil monero-wallet-cli generere den samme offentlige adressen og visningsnøkkelen som din gamle lommebok og begynne oppdateringsprosessen automatisk. (Vennligst vær tålmodig i og med at oppdateringsprosessen kan ta en stund.)
+
+### Kontoprogramvare:  monero-wallet-gui
+
+Start `monero-wallet-gui`. Hvis dette er første gang du har startet den, kan du gå til neste trinn. Ellers kan du trykke på `Avbryt`:
+
+![cancel opening](/img/resources/user-guides/en/restore_account/cancel-opening.png)
+
+Velg språket ditt (`Norsk`):
+
+![choose language](/img/resources/user-guides/en/restore_account/choose-language.png)
+
+Trykk på `Gjenopprett lommeboken fra nøkler eller mnemoniske frø`:
+
+![choose restore](/img/resources/user-guides/en/restore_account/choose-restore.png)
+
+Huk av `Gjenopprett fra nøkler`, gi lommeboken din et navn og lagringssted, og fullfør `Skriv inn ditt mnemoniske frø på 25 (eller 24) ord`. Alternativt kan du angi en `Gjenopprettingshøyde (valgfritt)` for å unngå skanning av de eldste blokkene. Deretter trykker du på `Høyre`-piltasten:
+
+![restore wallet](/img/resources/user-guides/en/restore_account/restore-wallet.png)
+
+På neste side kan du gi lommeboken din et sterkt passord og bekrefte det før du trykker på `Høyre`-piltasten:
+
+![wallet password](/img/resources/user-guides/en/restore_account/wallet-password.png)
+
+Spesifiser dine @daemon-innstillinger og trykk på `Høyre`-piltasten:
+
+![daemon settings](/img/resources/user-guides/en/restore_account/daemon-settings.png)
+
+Trykk på `BRUK MONERO` for å glede deg over din gjenopprettede lommebok:
+
+![all set up](/img/resources/user-guides/en/restore_account/all-set-up.png)

--- a/_i18n/nb-no/resources/user-guides/restore_account.md
+++ b/_i18n/nb-no/resources/user-guides/restore_account.md
@@ -8,7 +8,7 @@
 
 - Åpne en ledetekst og naviger til disken og katalogen som inneholder monero-wallet-cli
 
-- I ledeteksten taster du inn:  `monero-wallet-cli --restore-deterministic-wallet`
+- I ledeteksten taster du inn: `monero-wallet-cli --restore-deterministic-wallet`
 
 - Når du trykker på enter, blir du bedt om et lommebokfilnavn. Gi lommeboken ditt et navn – et hvilket som helst navn holder
 
@@ -18,7 +18,7 @@
 
 - Trykk på enter igjen, så blir du bedt om å legge inn det mnemoniske electrum-frøet på 25 ord som du fant fram tidligere
 
--  Du blir deretter tilskyndet med «Gjenopprett fra en spesifikk blokkjedehøyde (valgfritt, standard 0):» Standard-valget starter gjenopprettingsprosessen fra begynnelsen av Monero-blokkjeden. Hvis du ikke kjenner til den spesifikke blokkjedehøyden, trykker du bare på enter. (Å spesifisere en spesifikk blokkkjedehøyde starter gjenopprettingsprosessen fra den spesifikke høyden. Hvis du vet ved hvilken blokkjedehøyde midlene dine har gjennomgått en transaksjon, sparer dette litt tid hva gjelder skanning.)
+-  Du blir deretter tilskyndet med «Gjenopprett fra en spesifikk blokkjedehøyde (valgfritt, standard 0):» Standard-valget starter gjenopprettingsprosessen fra begynnelsen av Monero-blokkjeden. Hvis du ikke kjenner til den spesifikke blokkjedehøyden, trykker du bare på enter. (Å spesifisere en spesifikk blokkjedehøyde starter gjenopprettingsprosessen fra den spesifikke høyden. Hvis du vet ved hvilken blokkjedehøyde midlene dine har gjennomgått en transaksjon, sparer dette litt tid hva gjelder skanning.)
 
 Etter du har tastet inn det mnemoniske frøet på 25 ord og har spesifisert blokkjedehøyden din, vil monero-wallet-cli generere den samme offentlige adressen og visningsnøkkelen som din gamle lommebok og begynne oppdateringsprosessen automatisk. (Vennligst vær tålmodig i og med at oppdateringsprosessen kan ta en stund.)
 

--- a/_i18n/nb-no/resources/user-guides/restore_from_keys.md
+++ b/_i18n/nb-no/resources/user-guides/restore_from_keys.md
@@ -1,0 +1,52 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Å gjenopprette en lommebok fra pivate nøkler er ganske enkelt. Hvis du har den nødvendige informasjonen, kan du med denne guiden gjenopprette lommeboken din fullstendig. Merk: du trenger IKKE passordet ditt for å gjenopprette fra nøkler.
+
+Du trenger tre stykker data fra lommeboken din eller din .keys-fil som bevarer denne informasjonen og passordet for å avkryptere det. De tre lommebokkomponentene du trenger er:
+
+1. **Adresse**
+2. **Hemmelig forbruksnøkkel**
+3. **Hemmelig visningsnøkkel**
+
+
+#### CLI
+
+Kjør deretter lommebokkommandoen:
+
+`./monero-wallet-cli --generate-from-keys New_Wallet_Name.abc`
+
+Etter det blir du spurt om adressen, forbruksnøkkelen, visningsnøkkelen og til slutt det nye passordet for den regenererte lommeboken.
+
+Å kjøre denne kommandoen med de riktige parameterne vil generere lommebokfilene dine på nytt for deg og la deg sette et nytt passord.
+
+Hvis du møter på problemer, vil kommandoen `./monero-wallet-cli --help` vise deg dine tilgjengelige valge ved oppstart av lommeboken. Når du er inni lommeboken din, kan du kjøre `help`-kommandoen som vil gi deg en liste over de tilgjengelige hjelpekommandoene i lommeboken din.
+
+#### GUI
+
+Start `monero-wallet-gui`. Hvis dette er første gang du har startet den, kan du gå til neste trinn. Ellers kan du trykke på `Avbryt`:
+
+![cancel opening](/img/resources/user-guides/en/restore_from_keys/cancel-opening.png)
+
+Velg språket ditt (`Norsk`):
+
+![choose language](/img/resources/user-guides/en/restore_from_keys/choose-language.png)
+
+Trykk på `Gjenopprett lommeboken fra nøkler eller mnemoniske frø`:
+
+![choose restore](/img/resources/user-guides/en/restore_from_keys/choose-restore.png)
+
+Velg `Gjenopprett fra nøkler`, gi lommeboken din et navn og lagringssted, og fullfør `Kontoadresse (offentlig)`, `Visningsnøkkel (privat)` og `Forbruksnøkkel (privat)`. Alternativt kan du angi en `Gjenopprettingshøyde (valgfritt)` for å unngå skanning av de eldste blokkene. Deretter trykker du på `Høyre`-piltasten:
+
+![restore wallet](/img/resources/user-guides/en/restore_from_keys/restore-wallet.png)
+
+På neste side kan du gi lommeboken din et sterkt passord og bekrefte det før du trykker på `Høyre`-piltasten:
+
+![wallet password](/img/resources/user-guides/en/restore_from_keys/wallet-password.png)
+
+Spesifiser dine daemon-innstillinger og trykk på `Høyre`-piltasten:
+
+![daemon settings](/img/resources/user-guides/en/restore_from_keys/daemon-settings.png)
+
+Trykk på `BRUK MONERO` for å glede deg over din gjenopprettede lommebok:
+
+![all set up](/img/resources/user-guides/en/restore_from_keys/all-set-up.png)

--- a/_i18n/nb-no/resources/user-guides/restore_from_keys.md
+++ b/_i18n/nb-no/resources/user-guides/restore_from_keys.md
@@ -2,7 +2,7 @@
 
 Å gjenopprette en lommebok fra pivate nøkler er ganske enkelt. Hvis du har den nødvendige informasjonen, kan du med denne guiden gjenopprette lommeboken din fullstendig. Merk: du trenger IKKE passordet ditt for å gjenopprette fra nøkler.
 
-Du trenger tre stykker data fra lommeboken din eller din .keys-fil som bevarer denne informasjonen og passordet for å avkryptere det. De tre lommebokkomponentene du trenger er:
+Du trenger tre stykker data fra lommeboken din eller din .keys-fil som bevarer denne informasjonen og passordet for å avkode det. De tre lommebokkomponentene du trenger er:
 
 1. **Adresse**
 2. **Hemmelig forbruksnøkkel**

--- a/_i18n/nb-no/resources/user-guides/securely_purchase.md
+++ b/_i18n/nb-no/resources/user-guides/securely_purchase.md
@@ -5,7 +5,7 @@ Det er flere måter å oppdrive Monero på. Du kan utvinne det, veksle varer ell
 
 Det finnes flere børser som støtter Monero. Noen er sentraliserte, som vanligvis har mye likviditet og rask service, men som krever at du sender inn personlige opplysninger (KYC) før du kan begynne å handle der. Andre er desentraliserte og krever ikke identifikasjon, men har vanligvis mindre volum og kan være vanskeligere å bruke. Det finnes også tjenester som lar mennesker møte og handle uten at en tredjepart er involvert.
 
-En ufullstendig liste over børser som støtter Monero finnes på vår [Forhandler-side ]({{ site.baseurl }}/community/merchants/#exchanges).
+En ufullstendig liste over børser som støtter Monero finnes på vår [Forhandler-side]({{ site.baseurl }}/community/merchants/#exchanges).
 
 ## Steg 2: Last ned og opprett en papirlommebok på en sikker PC som ikke er koblet til internett.
 Last ned @papirlommebokgeneratoren på: [moneroaddress.org](https://moneroaddress.org) og kopier den til en USB-minnepinne (direktelenke: [https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip](https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip)).
@@ -16,7 +16,7 @@ Papirlommeboken din vil inneholde fire viktige elementer:
 
 - Offentlig Monero-@adresse: Den offentlige adressen brukes til å motta midler til @lommeboken. Du gir denne til de som vil sende midler til lommeboken din.
 
-- @Mnemonisk Monero-frø: Det mnemoniske frøet er en metode å lagre hele lommeboken på som er enkelt gjenkjenbart for mennesker. Dette er alt du trenger for å gjenopprette lommeboken din senere.
+- @Mnemonisk Monero-frø: Det mnemoniske frøet er en metode å lagre hele lommeboken på som er enkelt gjenkjennelig for mennesker. Dette er alt du trenger for å gjenopprette lommeboken din senere.
 
 - Monero-@forbruksnøkkel: Den private forbruksnøkkelen brukes til å sende midler fra lommebøkene.
 
@@ -30,7 +30,7 @@ Uansett hvilken metode du velger, må du sørge for at det ikke finnes en kopi a
 
 #### Sidemerknad
 Mulighet for å kryptere et XMR-mnemonisk frø: https://xmr.llcoins.net/
-Last ned html-siden og sett den på PC-en din som ikke er koblet til internett. Se delen om «Kryptering/avkryptering av mnemonisk frø» og sørg for at du bruker «CN Add» med et godt passord. Takk til manicminer5.
+Last ned html-siden og sett den på PC-en din som ikke er koblet til internett. Se delen om «Kryptering/avkoding av mnemoniske frø» og sørg for at du bruker «CN Add» med et godt passord. Takk til manicminer5.
 
 ## Steg 3: Send dine Moneroj til papirlommeboken
 Nå som du har alt du trenger, er du klar til å sende dine XMR til papirlommeboken din. Bare send myntene til lommebok-adressen du skrev ned tidligere. Sørg for at adressen er riktig, selv om du har kopiert og limt den! Husk at hvis du sender myntene til en feil adresse, er det ingen måte å få dem tilbake på!

--- a/_i18n/nb-no/resources/user-guides/securely_purchase.md
+++ b/_i18n/nb-no/resources/user-guides/securely_purchase.md
@@ -1,0 +1,43 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+## Steg 1: Å oppdrive Monero
+Det er flere måter å oppdrive Monero på. Du kan utvinne det, veksle varer eller tjenester for det, eller du kan veksle andre kryptovalutaer og fiat-penger til XMR. Hvis du velger det siste, er den enkleste måten å gjøre det på å bruke en børs.
+
+Det finnes flere børser som støtter Monero. Noen er sentraliserte, som vanligvis har mye likviditet og rask service, men som krever at du sender inn personlige opplysninger (KYC) før du kan begynne å handle der. Andre er desentraliserte og krever ikke identifikasjon, men har vanligvis mindre volum og kan være vanskeligere å bruke. Det finnes også tjenester som lar mennesker møte og handle uten at en tredjepart er involvert.
+
+En ufullstendig liste over børser som støtter Monero finnes på vår [Forhandler-side ]({{ site.baseurl }}/community/merchants/#exchanges).
+
+## Steg 2: Last ned og opprett en papirlommebok på en sikker PC som ikke er koblet til internett.
+Last ned @papirlommebokgeneratoren på: [moneroaddress.org](https://moneroaddress.org) og kopier den til en USB-minnepinne (direktelenke: [https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip](https://github.com/moneromooo-monero/monero-wallet-generator/archive/master.zip)).
+
+Pakk opp og åpne papirlommebokgeneratoren (monero-wallet-generator.html) i en nettleser på en (@airgap)-PC som ikke er koblet til internett som ikke tidligere har blitt brukt eller som har en ren installasjon av operativsystemet.
+
+Papirlommeboken din vil inneholde fire viktige elementer:
+
+- Offentlig Monero-@adresse: Den offentlige adressen brukes til å motta midler til @lommeboken. Du gir denne til de som vil sende midler til lommeboken din.
+
+- @Mnemonisk Monero-frø: Det mnemoniske frøet er en metode å lagre hele lommeboken på som er enkelt gjenkjenbart for mennesker. Dette er alt du trenger for å gjenopprette lommeboken din senere.
+
+- Monero-@forbruksnøkkel: Den private forbruksnøkkelen brukes til å sende midler fra lommebøkene.
+
+- Monero-@visningsnøkkel: Den private visningsnøkkelen brukes til å se transaksjoner som går inn i lommeboken. Den brukes vanligvis til å sette opp en visningslommebok som kan se innkommende transaksjoner på blokkjeden i sanntid mens de sendes til en kald lommebok.
+
+På dette stadiet har du mange valg. Du kan skrive ut lommeboken på papir, lagre den som PDF eller tekst på en USB-minnepinne, brenne den til CD/DVD osv. Du vil sannsynligvis ha minst to eller tre kopier som lagres sikkert på ulike steder. Hvis det lagres digitalt, bør alt krypteres med et sterkt passord. Hvis det lagres på papir, må lommeboken ikke vises til noen andre som kan lære seg de 25 ordene utenat eller ta bilde av lommeboken uten din tillatelse. Å sende noen et bilde av lommeboken er det samme som å gi bort alle pengene dine.
+
+Uansett hvilken metode du velger, må du sørge for at det ikke finnes en kopi av Monero-lommeboken din på enheten du har brukt. Du må kanskje slette Monero-lommeboken på en trygg måte hvis du lagret den til en disk eller sørge for at printeren din ikke lagrer kopier av utskrifter.
+
+*Hvis du mister tilgangen til Monero-papirlommeboken din, vil ikke Moneroene bli tilgjengelig for deg eller noen andre. Du vil ikke kunne gjenvinne dem!*
+
+#### Sidemerknad
+Mulighet for å kryptere et XMR-mnemonisk frø: https://xmr.llcoins.net/
+Last ned html-siden og sett den på PC-en din som ikke er koblet til internett. Se delen om «Kryptering/avkryptering av mnemonisk frø» og sørg for at du bruker «CN Add» med et godt passord. Takk til manicminer5.
+
+## Steg 3: Send dine Moneroj til papirlommeboken
+Nå som du har alt du trenger, er du klar til å sende dine XMR til papirlommeboken din. Bare send myntene til lommebok-adressen du skrev ned tidligere. Sørg for at adressen er riktig, selv om du har kopiert og limt den! Husk at hvis du sender myntene til en feil adresse, er det ingen måte å få dem tilbake på!
+
+#### Merknader og hvordan å verifisere midler
+Fordi Monero-blokkjeden er privat og usporbar, vil du ikke kunne sjekke din offentlige Monero-adresse og bekrefte at midlene har ankommet slik som med bitcoin. Dette er bra for personvern, men uheldig med tanke på bekvemmelighet.
+
+For å sikkert verifisere midlene i lommeboken din, må du sette opp en visningslommebok. Dette er hvor visningsnøkkelen kommer inn i spill. For å opprette en visningslommebok, kan du se oppføringen: [Visningslommebok]({{site.baseurl}}/resources/user-guides/view_only.html)
+
+For å verifisere at midlene *fremdeles* er i lommeboken din og ikke har blitt brukt, må du opprette en kald lommebok med den mnemoniske nøkkelen din (alle midlene dine) på en PC som ikke er koblet til internett og som har en oppdatert kopi av Monero-blokkjeden. Når du er ferdig, må du på en sikker måte slette lommeboken eller koble den til internett, og da blir det en «varm» lommebok.

--- a/_i18n/nb-no/resources/user-guides/solo_mine_GUI.md
+++ b/_i18n/nb-no/resources/user-guides/solo_mine_GUI.md
@@ -1,0 +1,17 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Det er veldig enkelt å solo-utvinne med den offisielle GUI-en. Hvis du ikke allerede har gjort det, kan du gå til <a href="{{site.baseurl}}/downloads/">Monero-nedlastingssiden</a> og laste ned denne offisielle GUI-en for operativsystemet ditt. Deretter kan du kjøre oppsettet og smøre deg med tålmodighet mens Monero synkroniseres med nettverket. Du bør se at den viser «Tilkoblet» nederst til venstre.
+
+<img src="/img/resources/user-guides/en/solo_mine_GUI/01.PNG" style="width: 600px;"/>
+
+Trykk på «Avansert»-fanen. Du bør se at flere andre valg dukker opp. Trykk deretter på underfanen som heter «Utvinning».
+
+<img src="/img/resources/user-guides/en/solo_mine_GUI/02.PNG" style="width: 600px;"/>
+
+Nå bør du ha valget om å begynne å utvinne. Du kan som alternativ endre antallet tråder å utvinne med. For optimal effektivitet, bør du utvinne med cachen til CPU-en din, delt på 2. Du må slå opp CPU-spesifikasjonene dine på produsentens nettside. Hvis du er usikker, kan du la antallet tråder stå som 1. Trykk på «Start utvinning»-knappen.
+
+<img src="/img/resources/user-guides/en/solo_mine_GUI/03.PNG" style="width: 600px;"/>
+
+Du utvinner nå med nettverket, som du også kan se nederst på bildet. I dette eksempelet bidrar PC-en med 23 H/s til Monero-nettverket. Utvinning hjelper med å holde nettverket sikkert, og du kan bli heldig og motta en belønning for å beskytte nettverket.
+
+For å avslutte utvinningen, trykker du på «Stopp utvinning»-knappen.

--- a/_i18n/nb-no/resources/user-guides/tor_wallet.md
+++ b/_i18n/nb-no/resources/user-guides/tor_wallet.md
@@ -1,0 +1,85 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Under viser vi deg et eksempel på konfigurasjon som lar deg kjøre en Monero @daemon (f.eks. på en hjemmeserver eller VPS) som du kan koble til fra en annen PC som kjører lommeboken din. Vi gjør dette over Tor-nettverket for å gjenfinne informasjon om transaksjoner som lommeboken din trenger. Fordelene ved denne tilnærmingen er at daemon (`monerod`) kan være på hele tiden mens blokker sendes/mottas mens lommeboken kan kobles til ved behov og få tilgang til hele blokkjeden. [Monerujo](https://www.monerujo.io/) bør også fungere via [Orbot](https://guardianproject.info/apps/org.torproject.android/).  Fordi Tor-nettverket gir kryptering og autentisering, kan du være sikker på at RPC-akkreditivene dine ikke lekkes. Tor løser også ofte problemer som man kan se på hjemmeservere tilknyttet port-videresending, endring av IP-adresser osv. – det bare virker. Dette oppsettet vil også tilsløre det faktum at du kobler deg til en ekstern Monero-node. Det er testet med Monero `v0.15.0.1`, der en lommebok fra en bærbar MAC kobles til en ekstern Linux-node (Ubuntu 18.04.2).
+
+## Å opprette et Tor-nettverk for RPC
+
+Sørg for at [Tor er installert](https://community.torproject.org/relay/setup/bridge/debian-ubuntu/) og kjører på riktig måte før du fortsetter.
+
+Vi trenger kun å konfigurere RPC-tjenesten til å kjøre som en skjult tjeneste her på `18081`.
+
+Fil: `/etc/torrc`
+
+```
+HiddenServiceDir /var/lib/tor/monero-service/
+HiddenServicePort 18081 127.0.0.1:18081
+```
+Start Tor på nytt:
+```
+sudo systemctl restart tor@default
+```
+
+Sørg for at Tor har startet opp riktig:
+```
+sudo systemctl status tor@default.service
+```
+
+Hvis alt ser bra ut, kan du lage et notat av navnet på den skjulte tjenesten (onion-adressen):
+```
+sudo cat /var/lib/tor/monero-service/hostname
+```
+Den vil være noe 4dcj312uxag2r6ye.onion -- bruk denne for `HIDDEN_SERVICE` under.
+
+### Å konfigurere Daemon til å tillate RPC
+
+I dette eksempelet bruker vi ikke Tor til å samhandle med p2p-nettverket, men kun for å koble til en Monero-node, så det er kun RPC-skjulte tjenester som trengs.
+
+Fil: `~/.bitmonero/bitmonero.conf` (i hjemkatalogen til Monero-brukeren)
+
+```
+no-igd=1
+restricted-rpc=1
+rpc-login=USERNAME:PASSWORD
+```
+(Finn på et brukernavn (USERNAME) og passord (PASSWORD) som brukes med RPC-en)
+
+Start daemon på nytt: `monerod stop_daemon; sleep 10; monerod --detach`
+
+Sørg for at daemon startet ordentlig:
+```
+tail -f ~/.bitmonero/bitmonero.log
+```
+
+## Å koble til en node fra en lokal lommebok
+
+Sørg for at du har Tor som kjører lokalt slik at du kan koble til Tor-nettverket. En enkel måte på Macen er å bare starte Tor-nettleseren og bruke Tor dens daemon.
+
+Deretter kan du teste en enkel RPC-kommando, f.eks.:
+```
+curl --socks5-hostname 127.0.0.1:9150 -u USERNAME:PASSWORD --digest -X POST http://HIDDEN_SERVICE.onion:18081/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json'
+```
+Bytt ut `USERNAME`, `PASSWORD`, og `HIDDEN_SERVICE` med verdiene over. Endre `9150` til en annen port hvis det trengs av din lokale Tor daemon.
+
+Når du utfører kommandoen, bør du få litt informasjon om den eksterne daemonen hvis alt fungerer som det skal. Hvis ikke, kan du legge til en ` -v ` i begynnelsen og prøve å feilsøke hvorfor den ikke kobler seg til. Sjekk brannmurer, passord osv.
+
+Når den fungerer, kan du koble til ved å bruke CLI-lommeboken din:
+```
+./monero-wallet-cli --proxy 127.0.0.1:9150 --daemon-host HIDDEN_SERVICE.onion --trusted-daemon --daemon-login USERNAME:PASSWORD --wallet-file ~/PATH/TO/YOUR/WALLET
+```
+Bytt ut verdiene over etter behov.
+
+## GUI
+
+Hvis du er interessert i å eksperimentere med GUI-en over Tor, kan du prøve `torsocks` (merk at denne kan lekke informasjon -- ikke stol på den hvis livet ditt avhenger av å opprettholde anonymitet).  Her er et eksempel på MacOS. Juster verdiene etter behov for Linux GUI-en:
+```
+torsocks --port 9150 /Applications/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui
+```
+
+Dette lar GUI-en kommunisere med Tor-nettverket. Når GUI-en er åpen og lommeboken lastet inn, må du konfigurere den til å koble til Tor-nettverket ditt ved å legge til onion-adressen din i:  "Innstillinger > Node > Ekstern node > Adresse".
+
+I fremtidige versjoner av GUI-en forventer vi å legge til direkte støtte for Tor/I2P slik at `torsocks` + kommandolinjen ikke trengs.
+
+# Flere ressurser
+
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [Hvordan bruke Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/nb-no/resources/user-guides/tor_wallet.md
+++ b/_i18n/nb-no/resources/user-guides/tor_wallet.md
@@ -28,7 +28,7 @@ Hvis alt ser bra ut, kan du lage et notat av navnet på den skjulte tjenesten (o
 ```
 sudo cat /var/lib/tor/monero-service/hostname
 ```
-Den vil være noe 4dcj312uxag2r6ye.onion -- bruk denne for `HIDDEN_SERVICE` under.
+Den vil se ut som dette: 4dcj312uxag2r6ye.onion -- bruk denne for `HIDDEN_SERVICE` under.
 
 ### Å konfigurere Daemon til å tillate RPC
 
@@ -75,7 +75,7 @@ Hvis du er interessert i å eksperimentere med GUI-en over Tor, kan du prøve `t
 torsocks --port 9150 /Applications/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui
 ```
 
-Dette lar GUI-en kommunisere med Tor-nettverket. Når GUI-en er åpen og lommeboken lastet inn, må du konfigurere den til å koble til Tor-nettverket ditt ved å legge til onion-adressen din i:  "Innstillinger > Node > Ekstern node > Adresse".
+Dette lar GUI-en kommunisere med Tor-nettverket. Når GUI-en er åpen og lommeboken lastet inn, må du konfigurere den til å koble til Tor-nettverket ditt ved å legge til onion-adressen din i: "Innstillinger > Node > Ekstern node > Adresse".
 
 I fremtidige versjoner av GUI-en forventer vi å legge til direkte støtte for Tor/I2P slik at `torsocks` + kommandolinjen ikke trengs.
 

--- a/_i18n/nb-no/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/nb-no/resources/user-guides/verification-allos-advanced.md
@@ -1,0 +1,180 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Verifisering av Monero-binærfilene bør gjøres i forkant av utpakking, installering eller bruk av Monero-programvaren. Dette er den eneste måten å sikre at du bruker den offisielle Monero-programvaren. Hvis du mottar en falsk Monero-binærfil (f.eks. phishing, MITM osv.), vil denne veiledningen hindre deg fra å bli lurt til å bruke den.
+
+For å beskytte integriteten til binærfilene, gir Monero-teamet en kryptografisk signert liste over alle [SHA256](https://en.wikipedia.org/wiki/SHA-2)-hashene. Hvis din nedlastede binærfil har blitt tuklet med, produserer den en [forskjellig hash](https://en.wikipedia.org/wiki/File_verification) enn den i filen.
+
+Dette er en avansert veiledning for Linux, Mac, eller Windows som gjør bruk at kommandolinjen. Den leder deg gjennom prosessen av å installere den nødvendige programvaren, importering av signaturnøkkelen, nedlasting av de nødvendig filene, og til slutt verifisering av at binærfilene dine er autentiske.
+
+## Innholdsfortegnelse:
+
+### [1. Installering av GnuPG](#1-installing-gnupg)
+### [2. Verifisering og import av signaturnøkkel](#2-verify-and-import-signing-key)
+  + [2.1. Å få tak i signaturnøkkel](#21-get-signing-key)
+  + [2.2. Verifisering av signaturnøkkel](#22-verify-signing-key)
+  + [2.3. Import av signaturnøkkel](#23-import-signing-key)
+### [3. Nedlasting og verifisering av hash-fil](#3-download-and-verify-hash-file)
+  + [3.1. Å få tak i hashfilen](#31-get-hash-file)
+  + [3.2. Verifisering av hashfil](#32-verify-hash-file)
+### [4. Nedlasting og verifisering av binærfiler](#4-download-and-verify-binary)
+  + [4.1. Å få tak i Monero-binærfiler](#41-get-monero-binary)
+  + [4.2. Verifisering av binærfiler på Linux or Mac](#42-binary-verification-on-linux-or-mac)
+  + [4.3. Verifisering av binærfiler på Windows](#43-binary-verification-on-windows)
+
+## 1. Installering av GnuPG
+
++ På Windows, gå til [Gpg4win-nedlastingssiden](https://gpg4win.org/download.html) og følg anvisningene for installasjon.
+
++ På Mac, gå til [Gpgtools-nedlastingssiden](https://gpgtools.org/) og følg anvisningene for installasjon.
+
++ GnuPG installert som standard på Linux.
+
+## 2. Verifisering og import av signaturnøkkel
+
+Denne delen tar for seg hvordan man får tak i Monero-signaturnøkkelen, hvordan man sikrer at den er riktig og hvordan man importerer nøkkelen til GnuPG.
+
+### 2.1. Å få tak i signaturnøkkelen
+
+På Windows eller Mac, gå til [binaryFates GPG key](https://raw.githubusercontent.com/monero-project/monero/master/utils/gpg_keys/binaryfate.asc), som han bruker til å signere Monero-binærfilene, og lagre siden som `binaryfate.asc` til hjemkatalogen din.
+
+På Linux kan du laste ned binaryFates signaturnøkkel ved å eksekvere følgende kommando:
+
+```
+wget -O binaryfate.asc https://raw.githubusercontent.com/monero-project/monero/master/utils/gpg_keys/binaryfate.asc
+```
+
+### 2.2. Verifsering av signaturnøkkel
+
+På alle operativsystemer, kan du sjekke fingeravtrykket til `binaryfate.asc` ved å eksekvere følgende kommando i en terminal:
+
+```
+gpg --keyid-format long --with-fingerprint binaryfate.asc
+```
+
+
+Verifiser fingeravtrykkene:
+
+```
+pub   rsa4096/F0AF4D462A0BDF92 2019-12-12 [SCEA]
+      Key fingerprint = 81AC 591F E9C4 B65C 5806  AFC3 F0AF 4D46 2A0B DF92
+uid                           binaryFate <binaryfate@getmonero.org>
+```
+
+Dersom fingeravtrykket **MATCHER**, kan du fortsette.
+
+Dersom fingeravtrykket **IKKE MATCHER**, **IKKE FORTSETT.** Slett istedenfor `binaryfate.asc`-filen og gå tilbake til [seksjon 2.1](#21-get-signing-key).
+
+### 2.3. Import av signaturnøkkel
+
+Fra en terminal, importer signaturnøkkel:
+
+```
+gpg --import binaryfate.asc
+```
+
+Hvis dette er første gang du har importert nøkkelen, vil utdataen se ut noe som dette:
+
+```
+gpg: key F0AF4D462A0BDF92: 2 signatures not checked due to missing keys
+gpg: key F0AF4D462A0BDF92: public key "binaryFate <binaryfate@getmonero.org>" imported
+gpg: Total number processed: 1
+gpg:               imported: 1
+gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+```
+
+Hvis du tidligere har importert nøkkelen, vil utdataen se slik ut:
+
+```
+gpg: key F0AF4D462A0BDF92: "binaryFate <binaryfate@getmonero.org>" not changed
+gpg: Total number processed: 1
+gpg:              unchanged: 1
+```
+
+## 3. Nedlasting og verifisering av hashfil
+
+Denne delen tar for seg nedlasting av hash-filen og å verifisere at den er autentisk.
+
+### 3.1. Å få ta i hashfilen
+
+På Windows eller Mac, gå til [hashes-filen på getmonero.org]({{ site.baseurl_root }}/downloads/hashes.txt) og lagre siden som `hashes.txt` til hjemkatalogen.
+
+På Linux kan du laste ned filen med de signerte hashene ved å eksekvere følgende kommando:
+
+```
+wget -O hashes.txt https://www.getmonero.org/downloads/hashes.txt
+```
+
+### 3.2. Verifsering av hashfilen
+
+Hashfilen signeres med nøkkelen `81AC 591F E9C4 B65C 5806  AFC3 F0AF 4D46 2A0B DF92`, som det framgår i utdataen under.
+
+På alle operativsystemer kan du verifisere signaturen av hash-filen ved å eksekvere følgende kommando i en terminal:
+
+```
+gpg --verify hashes.txt
+```
+
+Hvis filen er autentisk, vil utdataen se slik ut:
+
+```
+gpg:                using RSA key 81AC591FE9C4B65C5806AFC3F0AF4D462A0BDF92
+gpg: Good signature from "binaryFate <binaryfate@getmonero.org>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 81AC 591F E9C4 B65C 5806  AFC3 F0AF 4D46 2A0B DF92
+```
+
+Dersom utdataen viser **Good signature**, som i eksempelet, kan du fortsette.
+
+Dersom du ser **BAD signature** i utdataen, **IKKE FORTSETT.** Slett istedenfor `hashes.txt`-filen og gå tilbake til [seksjon 3.1](#31-get-hash-file).
+
+## 4. Nedlasting og verifisering av binærfiler
+
+Denne delen tar for seg nedlasting av Monero-binærfilen for operativsystemet ditt, å få `SHA256`-hashen til nedlastingen din, og å verifisere at den er autentisk.
+
+### 4.1. Å få tak i Monero-binærfilene
+
+På Windows eller Mac, gå til [getmonero.org]({{ site.baseurl_root }}/downloads/) og last ned den riktige filen for operativsystemet ditt. Lagre filen til hjemkatalogen din. **Ikke pakk ut filene enda.**
+
+På Linux kan du laste ned kommandolinjeverktøyene ved å eksekvere følgende kommando:
+
+```
+wget -O monero-linux-x64-v0.15.0.1.tar.bz2 https://downloads.getmonero.org/cli/linux64
+```
+
+### 4.2. Verifisering av binærfiler på Linux eller Mac
+
+Trinnene for både Linux og Mac er de samme. Fra en terminal, få `SHA256`-hashen til den nedlastede Monero-binærfilen din. Som et eksempel vil denne veiledningen bruke `Linux, 64bit`-GUI-binærfilen. Bytt ut `monero-gui-linux-x64-v0.15.0.1.tar.bz2` med navnet på binærfilen som du lastet ned i [seksjon 4.1](#41-get-monero-binary).
+
+```
+shasum -a 256 monero-linux-x64-v0.15.0.1.tar.bz2
+```
+
+Utdataen vil se slik ut, men den vil være forskjellige for hver binærfil. Din `SHA256`-hash bør matche den som er oppført i `hashes.txt`-filen for din binærfil.
+
+```
+8d61f992a7e2dbc3d753470b4928b5bb9134ea14cf6f2973ba11d1600c0ce9ad  monero-linux-x64-v0.15.0.1.tar.bz2
+```
+
+Dersom hashen din **MATCHER**, er du ferdig med veiledningen! Du kan pakke ut filene og installere.
+
+Dersom hashen din **IKKE MATCHER**, **IKKE FORTSETT.** Slett i stedet binærfilen du lastet ned og gå tilbake til [seksjon 4.1](#41-get-monero-binary).
+
+### 4.3. Verifisering av binærfiler på Windows
+
+Åpne en terminal og få `SHA256`-hash til din nedlastede Monero-binærfil. Som et eksempel, vil denne veiledningen bruke `Windows, 64bit`-GUI-binærfilen. Bytt ut `monero-gui-win-x64-v0.15.0.1.zip` med navnet på binæren som du lastet ned i [seksjon 4.1](#41-get-monero-binary).
+
+```
+certUtil -hashfile monero-gui-win-x64-v0.15.0.1.zip SHA256
+```
+Utdataen vil se slik ut, men den vil være forskjellige for hver binærfil. Din `SHA256`-hash bør matche den som er oppført i `hashes.txt`-filen for din binærfil.
+
+```
+SHA256 hash of file monero-gui-win-x64-v0.12.0.0.zip:
+4b 9f 31 68 6e ca ad 97 cd b1 75 e6 57 4b f3 07 f8 d1 c4 10 42 78 25 f4 30 4c 21 da 8a ac 18 64
+CertUtil: -hashfile command completed successfully.
+```
+
+Dersom hashen din **MATCHER**, er du ferdig med veiledningen! Du kan pakke ut filene og installere.
+
+Dersom hashen din **IKKE MATCHER**, **IKKE FORTSETT.** Slett i stedet binærfilen du lastet ned og gå tilbake til [seksjon 4.1](#41-get-monero-binary).

--- a/_i18n/nb-no/resources/user-guides/verification-allos-advanced.md
+++ b/_i18n/nb-no/resources/user-guides/verification-allos-advanced.md
@@ -4,7 +4,7 @@ Verifisering av Monero-binærfilene bør gjøres i forkant av utpakking, install
 
 For å beskytte integriteten til binærfilene, gir Monero-teamet en kryptografisk signert liste over alle [SHA256](https://en.wikipedia.org/wiki/SHA-2)-hashene. Hvis din nedlastede binærfil har blitt tuklet med, produserer den en [forskjellig hash](https://en.wikipedia.org/wiki/File_verification) enn den i filen.
 
-Dette er en avansert veiledning for Linux, Mac, eller Windows som gjør bruk at kommandolinjen. Den leder deg gjennom prosessen av å installere den nødvendige programvaren, importering av signaturnøkkelen, nedlasting av de nødvendig filene, og til slutt verifisering av at binærfilene dine er autentiske.
+Dette er en avansert veiledning for Linux, Mac, eller Windows som gjør bruk at kommandolinjen. Den leder deg gjennom prosessen av å installere den nødvendige programvaren, importering av signaturnøkkelen, nedlasting av de nødvendige filene, og til slutt verifisering av at binærfilene dine er autentiske.
 
 ## Innholdsfortegnelse:
 
@@ -18,7 +18,7 @@ Dette er en avansert veiledning for Linux, Mac, eller Windows som gjør bruk at 
   + [3.2. Verifisering av hashfil](#32-verify-hash-file)
 ### [4. Nedlasting og verifisering av binærfiler](#4-download-and-verify-binary)
   + [4.1. Å få tak i Monero-binærfiler](#41-get-monero-binary)
-  + [4.2. Verifisering av binærfiler på Linux or Mac](#42-binary-verification-on-linux-or-mac)
+  + [4.2. Verifisering av binærfiler på Linux eller Mac](#42-binary-verification-on-linux-or-mac)
   + [4.3. Verifisering av binærfiler på Windows](#43-binary-verification-on-windows)
 
 ## 1. Installering av GnuPG
@@ -43,7 +43,7 @@ På Linux kan du laste ned binaryFates signaturnøkkel ved å eksekvere følgend
 wget -O binaryfate.asc https://raw.githubusercontent.com/monero-project/monero/master/utils/gpg_keys/binaryfate.asc
 ```
 
-### 2.2. Verifsering av signaturnøkkel
+### 2.2. Verifisering av signaturnøkkel
 
 På alle operativsystemer, kan du sjekke fingeravtrykket til `binaryfate.asc` ved å eksekvere følgende kommando i en terminal:
 

--- a/_i18n/nb-no/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/nb-no/resources/user-guides/verification-windows-beginner.md
@@ -92,7 +92,7 @@ Trykk på `Ferdig`.
 
 ## 2. Monero-signeringsnøkkel
 
-Denne seksjonen tar for seg nedlasting av Monero-signeringsnøkkelen, verifisering av at nøkkelen er riktig, og deretter import av nøkkelen til nøkkelringen din. Hash-filen som brukes til å verifisere binærfilene dine er kryptografisk signert med Monero-signeringsnøkkelen. For å kontrollere gyldigheten av denne filen, trenger du den offentlig versjonen av signeringsnøkkelen.
+Denne seksjonen tar for seg nedlasting av Monero-signeringsnøkkelen, verifisering av at nøkkelen er riktig, og deretter import av nøkkelen til nøkkelringen din. Hash-filen som brukes til å verifisere binærfilene dine er kryptografisk signert med Monero-signeringsnøkkelen. For å kontrollere gyldigheten av denne filen, trenger du den offentlige versjonen av signeringsnøkkelen.
 
 ### 2.1. Nedlasting av signeringsnøkkel
 

--- a/_i18n/nb-no/resources/user-guides/verification-windows-beginner.md
+++ b/_i18n/nb-no/resources/user-guides/verification-windows-beginner.md
@@ -1,0 +1,247 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+Verifisering av Monero-binærfilene bør gjøres i forkant av utpakking av filer, installering eller bruk av Monero-programvaren. Dette er den eneste måten å sikre at du bruker den offisielle Monero-binærfilen. Hvis du mottar en falsk binærfil (f.eks. ved phishing, MITM osv.), vil denne guiden beskytte deg fra å bli lurt til å bruke den.
+
+For å beskytte integriteten til binærene, gir Monero-teamet en kryptografisk signert liste over alle [SHA256](https://en.wikipedia.org/wiki/SHA-2)-hashene. Hvis dine nedlastede binærfiler har blitt tuklet med, vil den produsere en [forskjellig hash](https://en.wikipedia.org/wiki/File_verification) fra den i filen.
+
+Dette er en nybegynnerguide for Windows-operativsystemene og gjør nesten utelukkende bruk av GUI-er. Den leder deg gjennom prosessen av å installere den nødvendige programvaren, importere signeringsnøkkelen, nedlasting av de nødvendige filene og avslutningsvis å verifisere at binærfilene dine er autentiske.
+
+## Innholdsfortegnelse
+
+### [1. Bruk av Gpg4win-installatøren](#1-using-gpg4win-installer)
+  - [1.1. Hvordan få tak i Gpg4win-installatøren](#11-getting-gpg4win-installer)
+    + [1.1.1. Nedlasting av Gpg4win](#111-download-gpg4win)
+    + [1.1.2. Oppstart av Gpg4win](#112-launch-gpg4win)
+  - [1.2. Bruk av Gpg4win-installatøren](#12-use-gpg4win-installer)
+### [2. Import av signeringsnøkkel](#2-monero-signing-key)
+  - [2.1. Nedlasting av signeringsnøkkel](#21-download-signing-key)
+  - [2.2. Initialisering av Kleopatra](#22-initialize-kleopatra)
+    + [2.2.1. Import av signeringsnøkkel](#221-import-signing-key)
+    + [2.2.2. Oppretting av nøkkelpar](#222-create-key-pair)
+  - [2.3. Verifisering av signeringsnøkkel](#23-verify-signing-key)
+### [3. Verifisering av hash-fil](#3-hash-file-verification)
+  - [3.1. Nedlasting av hash-fil](#31-download-hash-file)
+  - [3.2. Verifisering av hash-fil](#32-verify-hash-file)
+### [4. Verifisering av binærfil](#4-binary-file-verification)
+  - [4.1. Nedlasting av binærfiler](#41-download-binary)
+  - [4.2. Verifisering av binærfiler](#42-verify-binary)
+
+## 1. Bruk av Gpg4win-installatøren
+
+Denne seksjonen tar for seg installasjon av den kryptografiske programvaren. Windows kommer ikke med de nødvendige verktøyene for å verifisere binærene dine. Du kan bruke Gpg4win-installatøren for å installere disse verktøyene.
+
+### 1.1. Hvordan få tak i Gpg4win-installatøren
+
+#### 1.1.1. Nedlasting av Gpg4win
+
+Gå til [gpg4win.org](https://gpg4win.org) i nettleseren og last ned installatøren ved å trykke på den grønne knappen.
+
+![gpg4win download button](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-site-downloadbutton.png)
+
+Du vil tas til en donasjonsside. Hvis du ikke ønsker å donere, velger du `$0`, og deretter vil du kunne trykke på `Download` (Last ned).
+
+![gpg4win donation site](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-site-donation.png)
+
+Trykk på `Lagre filen`.
+
+![gpg4win site save file](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-site-savefile.png)
+
+Velg et sted å laste ned filen til og trykk på `Lagre`.
+
+![gpg4win site download site](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-site-savefile-location.png)
+
+#### 1.1.2. Oppstart av Gpg4win
+
+Når nedlastingen er ferdig, kan du åpne mappen som filen ligger i.
+
+![gpg4win site open folder](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-site-savefile-openfolder.png)
+
+Dobbeltklikk på den nedlastede, eksekverbare gpg4win-filen for å starte den.
+
+![gpg4win launch](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-launch.png)
+
+### 1.2. Bruk av Gpg4win-installatøren
+
+Du vil bli fremlagt en sikkerhetsverifiseringsskjerm. Trykk på `Kjør`.
+
+![gpg4win install security](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-install-security.png)
+
+Velg språket ditt og trykk på `OK`.
+
+![gpg4win install language](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-install-language.png)
+
+En velkomstskjerm vil dukke opp. Trykk på `Neste`.
+
+![gpg4win install welcome](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-install-welcome.png)
+
+Nå vil du se skjermen med komponentutvalg. Du må minst huke av `Kleopatra` for denne guiden. Angi valgene dine og trykk på `Neste`.
+
+![gpg4win install components](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-components.png)
+
+Det er best å la det standard installasjonsstedet være som det er, med mindre du vet hva du gjør. Angi valgene dine og trykk deretter på `Installer`.
+
+![gpg4win install location](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-install.png)
+
+Installasjonen er fullført. Trykk på `Neste`.
+
+![gpg4win install completed](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-install-complete.png)
+
+Trykk på `Ferdig`.
+
+![gpg4win install completed](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_gpg4win-install-finish.png)
+
+## 2. Monero-signeringsnøkkel
+
+Denne seksjonen tar for seg nedlasting av Monero-signeringsnøkkelen, verifisering av at nøkkelen er riktig, og deretter import av nøkkelen til nøkkelringen din. Hash-filen som brukes til å verifisere binærfilene dine er kryptografisk signert med Monero-signeringsnøkkelen. For å kontrollere gyldigheten av denne filen, trenger du den offentlig versjonen av signeringsnøkkelen.
+
+### 2.1. Nedlasting av signeringsnøkkel
+
+Åpne nettleseren og gå til [binaryFates GPG key](https://raw.githubusercontent.com/monero-project/monero/master/utils/gpg_keys/binaryfate.asc), som han bruker for å signere Monero-binærer. Høyreklikk på siden og velg `Lagre side som`.
+
+![getkey right click](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_getkey-rightclick.png)
+
+La standardplasseringen være som den er og trykk på `Lagre`.
+
+![getkey save file](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_getkey-savefilename.png)
+
+### 2.2. Initialisering av Kleopatra
+
+Hvis dette er første gang du bruker Kleopatra, må du opprette et nøkkelpar for deg selv.
+
+Start Kleopatra.
+
+![kleo launch](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-launch.png)
+
+#### 2.2.1. Import av signeringsnøkkel
+
+Trykk på `Import`.
+
+![kleo firstrun import](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-importkey.png)
+
+Gå inn i `Nedlastinger`-katalogen, velg `binaryfate`, og trykk på `Åpne`.
+
+![kleo firstrun key location](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-import-location.png)
+
+Start prosessen av å sertifisere nøkkelen ved å trykke på `Ja`.
+
+![kleo firstrun start process](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-startverifyprocess.png)
+
+#### 2.2.2. Oppretting av nøkkelpar
+
+Start prosessen av nøkkelopprettelsen ved å trykke på `Ja`.
+
+![kleo firstrun start key creation](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-createkeysnow.png)
+
+Legg inn noen detaljer under `Navn` og `E-post`, og trykk på `Neste`.
+
+![kleo firstrun key details](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-createkeydetails.png)
+
+Verifiser detaljene og trykk på `Opprett`.
+
+![Verifisering av nøkkeldetaljer for kleo firstrun](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-verifykeydetails.png)
+
+Angi et passord og trykk på `OK`.
+
+![kleo firstrun set key pass](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-createkeys-pinentry.png)
+
+Trykk på `Ferdig`.
+
+![kleo firstrun finish create key](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-firstrun-keycreate-success.png)
+
+### 2.3. Verifisering av signeringsnøkkel
+
+Sjekk visuelt at fingeravtrykket til nøkkelen som tilhører binaryFate er `81AC591FE9C4B65C5806AFC3F0AF4D462A0BDF92`.
+
+![kleo certify fingerprint](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-certify-fingerprint.png)
+
+Hvis fingeravtrykket **MATCHER**, trykk på `Sertifiser`.
+
+Dersom fingeravtrykket til denne nøkkelen **IKKE MATCHER**, **IKKE FORTSETT**. Slett i stedet `binaryfate`-filen fra `Nedlastinger`-katalogen og gå tilbake til [seksjon 2.1](#21-download-signing-key).
+
+Skriv inn passordet ditt og trykk på `OK`.
+
+![kleo certify pass](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_kleopatra-certify-pinentry.png)
+
+Trykk på `Ferdig`.
+
+## 3. Verifisering av hash-fil
+
+Denne seksjonen tar for seg nedlasting av den signerte filen med et kjent antall gode hasher og verifisering av dens autentisitet.
+
+### 3.1. Nedlasting av hash-fil
+
+Åpne en nettleser og gå til [hash-siden til getmonero.org]({{ site.baseurl_root }}/downloads/hashes.txt). Høyreklikk på siden og velg `Lagre siden som`.
+
+![hashes right click](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_hashes-getmonero-rightclick.png)
+
+La standardplasseringen være som den er, og trykk på `Lagre`.
+
+![hashes save file](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_hashes-getmonero-savename.png)
+
+### 3.2. Verifisering av hash-fil
+
+Trykk på `Decrypt/Verify`-knappen i Kleopatra.
+
+![hashes kleo verify button](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_hashes-kleo-verify-button.png)
+
+Naviger til `Nedlastinger`-katalogen. Velg `hashes`-filen, og trykk på `Åpne`.
+
+![hashes kleo open file](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_hashes-kleo-verify-button-filename.png)
+
+Kleopatra vil informere deg hvorvidt filsignaturen er gyldig.
+
+Hvis signaturen er **GYLDIG**, vil du se dette:
+
+![hashes kleo goodsig](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_hashes-kleo-goodsig.png)
+
+Hvis signaturen er **UGYLDIG**, vil du se dette:
+
+![hashes kleo badsig](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_hashes-kleo-badsig.png)
+
+Hvis du mottar en **GYLDIG** signatur, trykk på `Forkast` og gå videre.
+
+Hvis du mottar en **UGYLDIG** signatur, **IKKE FORTSETT.** Slett i stedet `hashes`-filen fra `Nedlastinger`-katalogen og gå tilbake til [seksjon 3.1](#31-download-hash-file).
+
+## 4. Verifisering av binærfil
+
+Denne seksjonen tar for seg nedlasting av Monero-binærfilene og verifisering av dens autentisitet.
+
+### 4.1. Nedlasting av binærfiler
+
+Åpne nettleseren og gå til [nedlastingssiden på getmonero.org]({{ site.baseurl_root }}/downloads/#windows). Velg den riktige binærfilen for systemet ditt.
+
+![binary getmonero](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-getmonero-windowsfiles.png)
+
+La `Lagre fil` være huket av og trykk på `OK`.
+
+![binary getmonero save](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-getmonero-save-file.png)
+
+La standardplasseringen være som den er og trykk på `Lagre`.
+
+![binary getmonero save location](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-getmonero-save-location.png)
+
+### 4.2. Verifisering av binærfiler
+
+I en filbehandler kan du navigere til `Nedlastinger`-katalogen. Åpne `hashes`-filen med et tekstbehandlingsprogram.
+
+![binary open hashes.txt](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-word-hashfile.png)
+
+Åpne en terminal (`cmd.exe`).
+
+![binary launch term](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-cmd-launch.png)
+
+Endre stien til `Nedlastinger`-katalogen med kommandoen: `cd Nedlastinger`.
+
+![binary cmd cd](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-cmd-cd.png)
+
+Beregn hashen til Monero-binærfilen med kommandoen: `certUtil -hashfile monero-gui-win-x64-v0.16.0.2.zip SHA256` (dersom du lastet ned en «kun kommandolinje»-versjon, bytt ut `monero-gui-win-x64-v0.16.0.2.zip` deretter).
+
+![binary cmd certutil](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-cmd-certutil.png)
+
+Sammenlikn hashen fra terminalen med den i hash-filen. De bør være like (du kan se bort fra mellomrom).
+
+![binary compare hashes](/img/resources/user-guides/en/verify_binary_windows_beginner/verify-win_binary-word-cmd-compare.png)
+
+Dersom hashen din **MATCHER**, er du ferdig med verifiseringen! Du kan være sikker på at Monero-filene du har er autentiske. Du kan pakke dem ut og installere/bruke filene som normalt.
+
+Dersom hashen din **IKKE MATCHER**, **IKKE FORTSETT.** Slett i stedet Monero-binærfilen fra `Nedlastinger`-katalogen og gå tilbake til [seksjon 4.1](#41-download-binary).

--- a/_i18n/nb-no/resources/user-guides/view_only.md
+++ b/_i18n/nb-no/resources/user-guides/view_only.md
@@ -1,0 +1,53 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+En visningslommebok er en spesiell type lommebok som kun kan se innkommende transaksjoner. Siden den ikke holder på det mnemoniske frøet og private forbruksnøkkelen din, kan den ikke signere transaksjoner, og den kan ikke se utgående transaksjoner. Dette gjør dem spesielt interessante for
+
+* å validere innkommende transaksjoner til kalde lommebøker eller maskinvarelommebøker
+* å overvåke innkommende donasjoner til en innsamlingsaksjon
+* utviklere som skriver programvarebibliotek for å validere betalinger
+
+Visningslommebøker kan ikke signere transaksjoner, og de kan derfor ikke forbruke en saldo i seg selv. De kan imidlertid brukes som del av en frakoblet signering av en transaksjon ved å opprette usignerte transaksjoner som skal signeres i frakoblet tilstand i en kald enhet, og senere ved å sende den signerte transaksjonen til nettverket.
+
+Hvis lommeboken din har utgående transaksjoner, vil den viste saldoen ikke være riktig. For å få en riktig saldo i en visningslommebok, må du importere de medfølgende nøkkelbildene til hver av lommebokens utdata.
+
+Du kan også opprette en visningslommebok til en maskinvarelommebok, men denne typen visningslommebok støtter imidlertid ikke frakoblet signering av transaksjoner og import av nøkkelbilder.
+
+For å opprette en visningslommebok, må du enten ha tilgang til en lommebok eller kjenne til hovedadressen og den private visningsnøkkelen fra en lommebok.
+
+### CLI: Å opprette en visningslommebok fra en private visningsnøkkel
+
+Åpne en eksisterende lommebok og tast inn kommandoene `address` og `viewkey` for å vise lommebokens adresse og dens private (hemmelige) visningsnøkkel. Tast inn `exit` for å lukke lommeboken.
+
+Etterpå kan du opprette en visningslommebok ved å taste inn `monero-wallet-cli --generate-from-view-key wallet-name`. Det siste argumentet blir filnavnet på den nye lommeboken din. Du vil bli bedt om `Standard address` og `View key` av lommeboken. Lim inn den opprinnelige adressen og private (hemmelige) visningsnøkkelen til lommeboken din. Etter det trykker du på enter og bekrefter et passord for den nye lommeboken din.
+
+### GUI: Å opprette en visningslommebok fra en eksisterende lommebokfil
+Hvis du har tilgang til den eksisterende lommeboken, kan du åpne lommeboken din og gå til `Innstillinger` > `Lommebok` > `Opprett en visningslommebok`:
+
+![Settings](/img/resources/user-guides/en/view-only/settings.png)
+
+Visningslommebokfilen vil opprettes i den samme katalogen, og bruker ditt gjeldende passord.
+
+Alternativt kan du dobbeltklikke på `Vellykket`-vinduet for å kopiere meldingen, og deretter trykke på `OK` for å lukke det:
+
+![Success](/img/resources/user-guides/en/view-only/Success.png)
+
+### GUI: Å opprette en visningslommebok fra en privat visningsnøkkel
+Hvis du ikke har tilgang til den eksisterende lommeboken, kan du opprette en visningslommebok ved å vite lommebokens hovedadresse og private visningsnøkkel.
+
+For å gjøre dette, kan du gå til hovedmenyen og trykke på `Gjenopprett lommebok fra nøkler eller mnemonisk frø`:
+
+![restore-view-only](/img/resources/user-guides/en/view-only/restore-view-only.png)
+
+Legg inn et navn for visningslommebokfilen din. Alternativt kan du endre filplasseringen.
+
+Velg `Gjenopprett fra nøkler`.
+
+I feltet `Kontoadresse (offentlig)` legger du inn lommebokens hovedadresse som starter med en 4.
+
+I feltet `Visningsnøkkel (privat)` legger du inn lommebokens private visningsnøkkel.
+
+La `Forbruksnøkkel (privat)`-feltet være blankt.
+
+Legg inn en `Dato for opprettelse av lommebok` eller `Gjenopprettingshøyde` hvis du har en (valgfritt).
+
+Trykk på `Neste` for å opprette visningslommebokfilen din.

--- a/_i18n/nb-no/resources/user-guides/view_only.md
+++ b/_i18n/nb-no/resources/user-guides/view_only.md
@@ -14,7 +14,7 @@ Du kan også opprette en visningslommebok til en maskinvarelommebok, men denne t
 
 For å opprette en visningslommebok, må du enten ha tilgang til en lommebok eller kjenne til hovedadressen og den private visningsnøkkelen fra en lommebok.
 
-### CLI: Å opprette en visningslommebok fra en private visningsnøkkel
+### CLI: Å opprette en visningslommebok fra en privat visningsnøkkel
 
 Åpne en eksisterende lommebok og tast inn kommandoene `address` og `viewkey` for å vise lommebokens adresse og dens private (hemmelige) visningsnøkkel. Tast inn `exit` for å lukke lommeboken.
 

--- a/_i18n/nb-no/resources/user-guides/vps_run_node.md
+++ b/_i18n/nb-no/resources/user-guides/vps_run_node.md
@@ -1,0 +1,49 @@
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
+
+# monerod
+
+`monerod` er @daemon-programvaren som kommer med Monero-treet. Den er et konsollprogram og håndterer blokkjeden. Mens en bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero disse: `monerod` håndterer blokkjeden og `monero-wallet-cli` håndterer kontoen.
+
+Denne guiden antar at du allerede har satt opp VPS-konto og at du bruker SSH til å tunnellere til serverkonsollen.
+
+## Linux, 64-bit (Ubuntu 16.04 LTS)
+
+### Sørg for at port 18080 er åpen
+`monerod` bruker denne porten til å kommunisere med andre noder i Monero-nettverket.
+
+Eksempel hvis du bruker `ufw`: `sudo ufw allow 18080`
+Eksempel hvis du bruker `iptables`: `sudo iptables -A INPUT -p tcp --dport 18080 -j ACCEPT`
+
+### Last ned de gjeldende Monero Core-binærfilene
+
+    wget https://downloads.getmonero.org/linux64
+
+### Lag en katalog og pakk ut filene.
+
+    mkdir monero
+    tar -xjvf linux64 -C monero
+
+### Start opp daemon
+
+    cd monero
+    ./monerod
+
+### Valg:
+
+For å vise en liste over alle valgene og innstillingene:
+
+    ./monerod --help
+
+For å starte opp daemon som bakgrunnsprosess:
+
+    ./monerod --detach
+
+For å overvåke utdataene til `monerod` hvis den kjører som daemon:
+
+    tail -f ~/.bitmonero/bitmonero.log
+
+Hold VPS-en sikker med autooppdateringer:
+
+https://help.ubuntu.com/community/AutomaticSecurityUpdates
+
+

--- a/_i18n/nb-no/resources/user-guides/vps_run_node.md
+++ b/_i18n/nb-no/resources/user-guides/vps_run_node.md
@@ -4,7 +4,7 @@
 
 `monerod` er @daemon-programvaren som kommer med Monero-treet. Den er et konsollprogram og håndterer blokkjeden. Mens en bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero disse: `monerod` håndterer blokkjeden og `monero-wallet-cli` håndterer kontoen.
 
-Denne guiden antar at du allerede har satt opp VPS-konto og at du bruker SSH til å tunnellere til serverkonsollen.
+Denne guiden antar at du allerede har satt opp VPS-konto og at du bruker SSH-en til å tunnelere til serverkonsollen.
 
 ## Linux, 64-bit (Ubuntu 16.04 LTS)
 


### PR DESCRIPTION
Norwegian translation of the User Guides files:

– node-i2p-zero.md
– restore_account.md
– restore_from_keys.md
– securely_purchase.md
– solo_mine_GUI.md
– tor_wallet.md
– verification-allos-advanced.md
– verification-windows-beginner.md
– view_only.md
– vps_run_node.md
– monero-wallet-cli.md
– monero_tools.md
– mine-to-pool.md
– ledger-wallet.md
– importing_blockchain.md
– howto_fix_stuck_funds.md
– cli_wallet_daemon_isolation_qubes_whonix.md
– ledger-wallet-cli.md
– Offline_Backup.md
– prove-payment.md