### PR TITLE
blog: update nav bar media query

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -5,7 +5,7 @@ title: titles.blogbytag
 
 <div class="blog">
   <!-- Category selector: desktop -->
-  <div class="container full desktop-only">
+  <div class="container full">
     <div class="info-block blog-nav row">
       <div class="col {% if page.name == 'index.html' %}checked{% endif %}"><a href="{{ site.baseurl_root }}/blog/">{% t blog.allposts %}</a></div>
       <div class="col"><a href="{{ site.baseurl_root }}/blog/tags/urgent.html">{% t blog.urgent %}</a></div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -4063,6 +4063,10 @@ h3.months {
 }
 
 @media only screen and (max-width: 62rem) {
+.blog-nav {
+    display: none;
+}
+
 .page-numbers {
     margin-top: 1.7rem;
     margin-bottom: 1.7rem;


### PR DESCRIPTION
The navigation bar on the blog page was nonexistent whenever the width was between 62 and 75 rem.