### PR TITLE
meta: wrong icon path

### DIFF
--- a/meta/manifest.json
+++ b/meta/manifest.json
@@ -2,12 +2,12 @@
     "name": "",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/meta/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/meta/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }


### PR DESCRIPTION
I'm not sure what I'm touching here, but these paths seem to be wrong.

![screen](https://user-images.githubusercontent.com/81592644/113606948-f2c8f500-9648-11eb-961e-8febae7ca2d3.png)
