### PR TITLE
home: properly align main button

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1674,6 +1674,7 @@ h2, .info-block h2 {
     -ms-flex: 1;
     padding: 4rem 2.5rem;
     word-wrap: break-word;
+    overflow: hidden;
 }
 
 .full>.info-block.text-adapt {
@@ -2648,11 +2649,19 @@ img.monero-logo {
     display: block;
 }
 
+.main-info #btn-primary-box {
+    display: flex;
+    justify-content: center;
+}
+
 .main-info p a.btn-auto, a.btn-primary {
     background-color: #d26e2b;
     border: 2px solid #d26e2b;
     color: #ffffff;
-    display: inline-block;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    padding: 0;
 }
 
 .main-info p a.btn-auto:hover, a.btn-primary:hover, .main-info p a.btn-auto:focus, a.btn-primary:focus, .main-info p a.btn-auto:active, a.btn-primary:active {

--- a/index.html
+++ b/index.html
@@ -26,7 +26,9 @@ permalink: index.html
                         <h1 id="main-h1">{% t global.monero %}</h1>
                         <h2 id="main-h2">{% t home.heading2 %}</h2>
                             <p id="main-text">{% t home.monero_is_cash %}</p>
-                            <p><a href="{{ site.baseurl }}/get-started/what-is-monero/" class="btn-link btn-auto btn-intro btn-primary">{% t home.whatis %}</a></p>
+                            <p id="btn-primary-box">
+                                <a href="{{ site.baseurl }}/get-started/what-is-monero/" class="btn-link btn-auto btn-intro btn-primary">{% t home.whatis %}</a>
+                            </p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Current issue:

![screen1](https://user-images.githubusercontent.com/81592644/114290684-a551eb00-9a81-11eb-8c1c-b418163a19ec.png)
![screen2](https://user-images.githubusercontent.com/81592644/114290686-a7b44500-9a81-11eb-8ea2-76576e3b81e6.png)

- the double flex causes the string to line up in the center when it no longer fits on the screen, in other words it'll show "...rn more about mo..." instead of "learn more ab...". If you prefer the other behavior, I can change it.
- `overflow: hidden;` isn't really necessary but it increases readability on very small screens.