### PR TITLE
Add Android icon for MyMonero

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -251,7 +251,7 @@ permalink: /downloads/index.html
                         </tr>
                         <tr>
                             <td><img src="/img/mymonero.png" width="141" height="95" loading="lazy" alt="Mymonero logo" style="height: 15px;"><a href="https://mymonero.com/">MyMonero</a></td>
-                            <td><span class="icon-apple"></span></td>
+                            <td><span class="icon-android"></span><span class="icon-apple"></span></td>
                             <td><span title="Browser" class="icon-browser"></span><span class="icon-linux"></span><span class="icon-windows"></span><span class="icon-apple"></span></td>
                             <td><a class="ext-noicon" href="https://github.com/mymonero" aria-label="GitHub icon"><span class="icon-github"></span></a></td>
                         </tr>


### PR DESCRIPTION
MyMonero is available on Android as shown on the top banner on their website https://mymonero.com/ (plays store link here https://play.google.com/store/apps/details?id=com.mymonero.official_android_application).