### PR TITLE
Removing *Bacrypt.com* - WARNING, SCAM Website!

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -7,8 +7,6 @@
       url: https://agoradesk.com
     - name: Alfacashier
       url: https://www.alfacashier.com/
-    - name: Bacrypt.com - Fully anonymous exchange
-      url: https://bacrypt.com/
     - name: BestChange
       url: https://www.bestchange.com
     - name: Bitci (XMR/BTCI, XMR/TRY, XMR/CHFT)


### PR DESCRIPTION
We've tried to exchange 5000 USDC to 14.00667577 XMR which was equivalent to $5000 US plus fees.
Bacrypt has a timer set for every exchange you make, it's about half an hour.
The coins were were transferred to the Bacrypt's wallet about 15 minutes before the timer expiration.
Once the timer has expired, the *money was never transferred to our wallet.*

Here is the *proof of the transaction:* 0x0abc8daeccc0e57bc1fbd02ee04c59ae61c2521e3b97566447994e796822eedf
You can also view here: https://etherscan.io/tx/0x0abc8daeccc0e57bc1fbd02ee04c59ae61c2521e3b97566447994e796822eedf

Here is our conversation with the support team:
Q: "Can you confirm that you’ve received the funds?"
A: "This USDC address does not belong to our service."
Q: "It looks like one of your wallets: 0xbfe830e781d40a3aa796028f7c05666234280f2b (attached the screenshot)"
A: "As you can see in the screenshot, either the exchange is made on a phishing site, or the screenshot itself is false, because we have 20 digits in the exchange number. And in the screenshot there are 10 digits in the exchange number."