### PR TITLE
Sponsorships: readd link to fork networking

### DIFF
--- a/community/sponsorships/index.md
+++ b/community/sponsorships/index.md
@@ -48,7 +48,7 @@ permalink: /community/sponsorships/index.html
                 <div class="info-block">
                     <div class="row center-xs">
                         <div class="col">
-                            <img src="/img/sponsors/forked_logo.png" alt="Fork Networking logo">
+                            <a class="ext-noicon" href="https://www.forked.net" target="_blank" rel="noreferrer"><img src="/img/sponsors/forked_logo.png" alt="Fork Networking logo"></a>
                             <p>{% t sponsorships.forknetworking %}</p>
                         </div>
                     </div>


### PR DESCRIPTION
Was removed with #1351

This reverts commit 813d4fe505353742a99f42eafc533c4e1d33db9c.