### PR TITLE
remove bitqist from the list of exchanges

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -19,8 +19,6 @@
       url: https://bitexbook.com/
     - name: Bitfinex (XMRUSD, XMRBTC)
       url: https://www.bitfinex.com/
-    - name: Bitqist - Instant exchange
-      url: https://bitqist.com/
     - name: Bisq; decentralized exchange (previously Bitsquare)
       url: https://bisq.network/
     - name: ChangeHero - Instant exchange


### PR DESCRIPTION
According to Bitqist via [a tweet from 21 May 2020](https://twitter.com/bitqist/status/1263438451715854336), they have been absorbed by another exchange called Bitvavo and no longer offer services.