### PR TITLE
update ruby version in CI and netlify's settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0.x' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "jekyll build --trace --limit-posts 10"
 
 [build.environment]
-  RUBY_VERSION = "2.6"
+  RUBY_VERSION = "2.7"
 
 [build.processing]
   skip_processing = true


### PR DESCRIPTION
Requires #1617

The updates from #1617 won't work on old ruby versions.