### PR TITLE
merchants: remove instaex.io

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -55,8 +55,6 @@
       url: https://www.hollaex.com/
     - name: Incognito - Completely anonymous decentralized exchange
       url: https://incognito.org/
-    - name: InstaEx - Instant exchange
-      url: https://instaex.io/
     - name: Kaiserex
       url: https://www.kaiserex.com/
     - name: Karsha


### PR DESCRIPTION
The [instaex.io](https://instaex.io/) website has been for some time (I do not know precisely how long). The last activity on their [Reddit](https://www.reddit.com/user/instaex/posts/), [Medium](https://instaex.medium.com/), [Facebook](https://www.facebook.com/instaex.io) and [Twitter](https://twitter.com/search?q=%40instaex_io&src=typed_query&f=live) accounts is right around the end of November, 2020 (and their [Twitter account](https://twitter.com/instaex_io) no longer exists).

Additionally, an email I sent to the address they had [previously posted on their website](https://archive.ph/XC8va#selection-347.0-347.13) was undelivered.