### PR TITLE
merchants: remove shapeshift

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -81,8 +81,6 @@
       url: https://poloniex.com/exchange/btc_xmr
     - name: REXI.cc
       url: https://rexi.cc
-    - name: ShapeShift (Instant)
-      url: https://shapeshift.io/
     - name: SideShift AI - A rapid coin swap that fully supports Monero
       url: https://sideshift.ai
     - name: SimpleSwap


### PR DESCRIPTION
About six and a half months ago, _The Decrypt_ [reported](https://decrypt.co/47508/shapeshift-quietly-delists-monero-privacy-coin) that ShapeShift delisted Monero (and ShapeShift [confirmed](https://decrypt.co/47823/shapeshift-confirms-regulatory-risk-led-to-privacy-coin-delistings) this):
> ShapeShift has delisted prominent privacy coin Monero from its platform, a ShapeShift spokesperson told Decrypt via Twitter.

I don't believe Monero has been added back. If this is the case, I propose we remove it from the merchants list for the time being.