### PR TITLE
add po4a.config to the root of the repo

### DIFF
--- a/po4a.config
+++ b/po4a.config
@@ -1,0 +1,27 @@
+# This config file gives a set of instructions to po4a, which will update all translations files (.pot and .po) and documents (.md) at the same time.
+# we use --keep=0 to transfer all translated content directly to the original markdown file, but would be good to switch to a more reasonable thresold
+# (maybe the standard 80%?) in the future, when the guides will be mostly translated.
+#
+# To avoid spamming unnecessary diffs, we don't add all guides managed by po4a at the same time. Guides should be added to this file
+# when the translation files and the guides itself need to be updated (so when the original document got changed and the changes need to be transferred
+# to the translation files). To add a new document to be managed by po4a:
+# Under the last '[po4a_paths]' instruction add:
+# [po4a_paths] _i18n/en/resources/user-guides/weblate/<GUIDE.pot> $lang:_i18n/$lang/resources/user-guides/weblate/<GUIDE.po>
+# At the bottom of the file, under the last '[type: markdown]' instruction, add:
+# [type: markdown] _i18n/en/resources/user-guides/<GUIDE.md> $lang:_i18n/$lang/resources/user-guides/<GUIDE.md>
+#
+# To update the language files listed here and related documents run `po4a po4a.config`
+
+[po4a_langs] es it pl fr ar ru de nl pt-br tr zh-cn zh-tw nb-no
+[po4a_paths] _i18n/en/resources/user-guides/weblate/verification-allos-advanced.pot $lang:_i18n/$lang/resources/user-guides/weblate/verification-allos-advanced.po
+
+[options] opt:"--keep=0"
+[options] opt:"--localized-charset=UTF-8"
+[options] opt:"--master-charset=UTF-8"
+[options] opt:"--master-language=en_US"
+[options] opt:"--msgmerge-opt='--no-wrap'"
+[options] opt:"--wrap-po=newlines"
+
+[po4a_alias:markdown] text opt:"--option markdown"
+
+[type: markdown] _i18n/en/resources/user-guides/verification-allos-advanced.md $lang:_i18n/$lang/resources/user-guides/verification-allos-advanced.md


### PR DESCRIPTION
From the conf file:

```
# This config file gives a set of instructions to po4a, which will update all translations files (.pot and .po) and documents (.md) at the same time.
# we use --keep=0 to transfer all translated content directly to the original markdown file, but would be good to switch to a more reasonable thresold
# (maybe the standard 80%?) in the future, when the guides will be mostly translated.
#
# To avoid spamming unnecessary diffs, we don't add all guides managed by po4a at the same time. Guides should be added to this file
# when the translation files and the guides itself need to be updated (so when the original document got changed and the changes need to be transferred
# to the translation files). To add a new document to be managed by po4a:
# Under the last '[po4a_paths]' instruction add:
# [po4a_paths] _i18n/en/resources/user-guides/weblate/<GUIDE.pot> $lang:_i18n/$lang/resources/user-guides/weblate/<GUIDE.po>
# At the bottom of the file, under the last '[type: markdown]' instruction, add:
# [type: markdown] _i18n/en/resources/user-guides/<GUIDE.md> $lang:_i18n/$lang/resources/user-guides/<GUIDE.md>
#
# To update the language files listed here and related documents run `po4a po4a.config`
```

This configuration file was used for #1639