### PR TITLE
monero-wallet-cli.md: `address all` instead of `... list`

### DIFF
--- a/_i18n/en/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/en/resources/user-guides/monero-wallet-cli.md
@@ -100,7 +100,7 @@ address new
 This will generate a subaddress, which you can share to receive payment on the account it's linked to. To view all generated addresses, run:
 
 ```
-address list
+address all
 ```
 
 ## Proving to a third party you paid someone


### PR DESCRIPTION
There appears to be no such command as `address list`. When I run it I get: 
```
Error: usage: address [ new <label text with white spaces allowed> | all | <index_min> [<index_max>] | label <index> <label text with white spaces allowed> | device [<index>] | one-off <account> <subaddress>]
```