### PR TITLE
roadmap: rearrange ongoing and upcoming tasks

### DIFF
--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -196,8 +196,7 @@ permalink: /resources/roadmap/index.html
                                 <h3 class="months">{% t roadmap.feb %}</h3>
                                     <li class="completed">{% t roadmap.onionaddress %}</li>
                                 <h3 class="months">{% t roadmap.comingsoon %}</h3>
-                                    <li class="ongoing">{% t roadmap.tryptych %}</li>
-                                    <li class="upcoming">{% t roadmap.layer2 %}</li>
+                                    <li class="ongoing">{% t roadmap.atomicswaps %}</li>
                             </ul>
                     </div>
                     <label for="tab-7" tabindex="0"></label>
@@ -207,9 +206,10 @@ permalink: /resources/roadmap/index.html
                         <h2>{% t roadmap.future %}</h2>
                             <ul>
                                 <h3 class="months">{% t roadmap.comingsoon %}</h3>
-                                    <li class="upcoming">{% t roadmap.returnaddr %}</li>
-                                    <li class="ongoing">{% t roadmap.atomicswaps %}</li>
                                     <li class="ongoing">{% t roadmap.bplus %}</li>
+                                    <li class="ongoing">{% t roadmap.tryptych %}</li>
+                                    <li class="upcoming">{% t roadmap.returnaddr %}</li>
+                                    <li class="upcoming">{% t roadmap.layer2 %}</li>
                             </ul>
                     </div>
                 </div>


### PR DESCRIPTION
- Moved Tryptich and layer 2 to 'future'
- Added atomic swaps are ongoing for 2021
- Ongoing tasks are now shown before upcoming tasks in 'future'