### PR TITLE
Add right margin to the img for external links

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -993,6 +993,7 @@ a {
 a[href^="https:"]:not([href*="getmonero.org"]):not([class*="btn-link"]):not([class="chats-img"]):not([class*="ext-noicon"]):not([class*="white"]) {
   background: url(/img/external.svg) no-repeat right;
   padding-right: 0.7em;
+  margin-right: 0.3rem;
   background-size: 0.6em;
 }
 


### PR DESCRIPTION
Some text resulted a bit stacked together.

For example the contributing page:

Before
![b](https://user-images.githubusercontent.com/28106476/122924758-6506c700-d366-11eb-8e92-2a29398169ae.png)

After
![a](https://user-images.githubusercontent.com/28106476/122924759-66d08a80-d366-11eb-8797-0ca1e9f453a5.png)