### PR TITLE
blog: add general fund report (2020/2021)

### DIFF
--- a/_posts/2021-06-24-general-fund-2020-2021-report.md
+++ b/_posts/2021-06-24-general-fund-2020-2021-report.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title: "General Fund 2020/2021 report"
+summary: Report from the Core Team about the usage of the General Fund for the years 2020 and 2021
+tags: [community]
+author: binaryFate (Core Team)
+---
+
+First, here is the basic information of the GF wallet. This info has always been public at [https://github.com/monero-project/monero#readme](https://github.com/monero-project/monero#readme) but not everyone might know this.      
+The Monero general fund donation address is: `888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H`.  
+The view key is: `f359631075708155cc3d92a32b75a7d02a5dcf27756707b47a2b31b21c389501`. Note you need to use the base address for restoring a view-only wallet, which is: `44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A`.  
+    
+The Bitcoin general fund donation address is: `1KTexdemPdxSBcG55heUuTjDRYqbC5ZL8H`.  
+    
+**Current balance in GF wallets: 5637.585152963753 XMR, and 0.09042883 BTC.**  
+This balance has been generally increasing over the last 1.5 year.  
+    
+I exported all key images, which can be used together with a view-only wallet to see what transactions were spent, and the final balance. You can access them here: [https://downloads.getmonero.org/GF\_wallet\_key\_images\_until\_20210616](https://downloads.getmonero.org/GF\_wallet\_key\_images\_until\_20210616)  
+    
+Summary 2020  
+* Received: 2847.716692 XMR  
+* Spent: 896.4505203 XMR  
+    
+Summary 2021 (until 16/06)  
+* Received: 3161.148144 XMR  
+* Spent: 211.7867395 XMR  
+    
+You can find the full list of all transactions since 2016, as well as annotated outgoing transactions for 2020/2021 here: [https://downloads.getmonero.org/GF\_wallet\_report\_June\_2021.ods](https://downloads.getmonero.org/GF\_wallet\_report\_June\_2021.ods)  
+    
+While most donations are anonymous, I know that LocalMonero has been making some. I'll let them give info about that if and as they wish.  
+    
+Also worth noting that non-monetary donations are made by some companies who are currently paying for some of our infrastructure (see [the 'Sponsorships' page]({{ site.baseurl}}/community/sponsorships/)). Without them, the cost of resources such as our website hosting, the CDN and its associated bandwidth, etc, would probably be above 10k$/month, so it's effectively saving the general fund this amount every month.  
+    
+Historically, the GF had been used to complete some CCS proposals that were struggling to be fully funded. However, in 2020 all proposals were funded on their own and hence there was no need for that kind of intervention. In 2021 we decided to always contribute to all proposals that we deem of particular significance to the Monero project, even when it is clear that they can be fully funded anyway; at this time we expect to keep doing so. I would encourage everyone motivated to make that leap and contribute some proposals.  
+    
+A lot of questions and heated debates have been raised in the last week, including on the role of the General Fund and its purpose/administration. We (the core team) expect to post a clarification on these matters in the coming days.


### PR DESCRIPTION
This is @binaryFate's [reddit post](https://www.reddit.com/r/Monero/comments/o5jlhf/general_fund_20202021_report/) with a couple of minor changes: changed a plaintext URL into a link and changed a link from pointing to the README to pointing to our sponsorships page.