### PR TITLE
library: remove link to masteringmonero in the description

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -814,7 +814,6 @@ library:
     <li>Details of the Monero decentralized network, peer-to-peer architecture, transaction lifecycle, and security principles.</li>
     <li>Introductions to technical foundations of Monero, intended for developers, engineers, software architects, and curious users.</li>
     <li>New developments such as Kovri, Bulletproofs, Multisignature, Hardware Wallets, etc.</li></ul>
-    See <a href="https://masteringmonero.com/">Mastering Monero</a> website for information.
   cheatsheets: Cheatsheets
   moneroaddressescheatsheet20201206: "Monero Addresses Cheatsheet"
   moneroaddressescheatsheet20201206p: >


### PR DESCRIPTION
It's pointless. The link is already in the header.