### PR TITLE
Add and remove merchants (8)

### DIFF
--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -3,8 +3,6 @@
   merchants:
     - name: AgoraDesk - P2P OTC trading platform, includes Monero options
       url: https://agoradesk.com
-    - name: Alfacashier
-      url: https://www.alfacashier.com/
     - name: BestChange
       url: https://www.bestchange.com
     - name: Bitci (XMR/BTCI, XMR/TRY, XMR/CHFT)
@@ -23,8 +21,6 @@
       url: https://changehero.io/
     - name: ChangeNOW
       url: https://changenow.io
-    - name: CoinCut (OTC)
-      url: https://www.coincut.com
     - name: CoinSwitch.co
       url: https://www.coinswitch.co
     - name: DV Chain (OTC) - Cryptocurrency OTC desk that offers buying and selling of Monero
@@ -51,10 +47,6 @@
       url: https://karsha.biz/
     - name: Kraken (XMRUSD, XMREUR, XMRBTC)
       url: https://www.kraken.com/
-    - name: Liberalcoins
-      url: https://liberalcoins.com/
-    - name: LocalCoin.is - LLC/XMR
-      url: https://localcoin.is/
     - name: LocalMonero (P2P exchange)
       url: https://localmonero.co/
     - name: Magnetic Exchange
@@ -81,10 +73,6 @@
       url: https://swapzone.io/
     - name: Tux Exchange
       url: https://www.tuxexchange.com/trade?coin=XMR&market=BTC
-    - name: Trovemat.com (ATM)
-      url: https://trovemat.com/
-    - name: Swaplab
-      url: https://swaplab.cc/
     - name: xChange.me - Fully anonymous cryptocurrency exchanger
       url: https://xchange.me
 - category: Payment Gateways

--- a/_data/merchants.yml
+++ b/_data/merchants.yml
@@ -27,8 +27,6 @@
       url: https://www.coincut.com
     - name: CoinSwitch.co
       url: https://www.coinswitch.co
-    - name: CRYPTODIGGERS.EU
-      url: https://cryptodiggers.eu/
     - name: DV Chain (OTC) - Cryptocurrency OTC desk that offers buying and selling of Monero
       url: https://dvchain.co
     - name: ExchangeD.I2P - Darknet exchange (I2P)
@@ -196,6 +194,8 @@
       url: https://codify.global/
     - name: Cryptostorm VPN
       url: https://cryptostorm.is/
+    - name: CRYPTODIGGERS.EU
+      url: https://cryptodiggers.eu/
     - name: cryptwerk - online directory with companies, websites, shops, services accepting cryptocurrencies
       url: https://cryptwerk.com/pay-with/xmr/
     - name: DeepWebVPN
@@ -299,6 +299,8 @@
       url: https://cryptostop.org/
     - name: Declic CBD - CBD products online shop
       url: https://declic-cbd.fr/
+    - name: De-Googled.com - De-googled phones
+      url: https://de-googled.com/
     - name: digitalgoods by ProxyStore
       url: https://digitalgoods.proxysto.re/
     - name: Direct Depot - Trucking Products And Power Inverters


### PR DESCRIPTION
- add De-Googled.com (closes #1701)
- move CRYPTODIGGERS.EU from 'echanges' to 'services' (closes #1709)

&nbsp;

- localcoin.is (closes #1711)
- remove trovemat.com (closes #1710)
- remove swaplab (closes #1708)
- remove liberalcoins (closes #1706)
- remove alfacashier (closes #1704)
- remove coincut (closes #1700)