### PR TITLE
user-guides: update language files of monero-wallet-cli.md

### DIFF
--- a/_i18n/ar/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/ar/resources/user-guides/monero-wallet-cli.md
@@ -1,114 +1,208 @@
 ﻿{% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-واجهه سطر الأوامر `monero-wallet-cli` هو برنامج المحفظه الذي يأتي مع مونيرو. إنه برنامج وحده تحكم ويُدير الحساب. بينما في البتكوين تُدير المحفظه كلاً من الحساب وسلسله الكُتل. يقوم مونيرو بفصلهم : الخادم `monerod` يُدير سلسله الكُتل و واجهه سطر الأوامر `monero-wallet-cli` تُدير الحساب.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-سيقوم هذا الدليل بإطلاعك علي كيفيه القيام بالعديد من العمليات من واجهه سطر الأوامر . يفترض هذا الدليل أنك تستخدم أحدث نسخه من برامج مونيرو وقمت بالفعل بإنشاء حساب كما هو موضح بالدلائل الأخري.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## التحقق من رصيدك
+You can have a list of the most important commands by running `help`:
 
-مُنذ أنه هناك برامج مختلفه لمُعالجه كلاً من سلسله الكتل والمحفظه , العديد من إستخدامات واجهه سطر الأوامر تحتاج العمل مع الخادم. من ذلك التحقق من المعاملات القادمه إلي عنوانك. بمجرد تشغيلك الخادم وواجهه سطر الأوامر إكتب `balance` لعرض رصيدك .
+```
+Important commands:
 
-مثال:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-يقوم ذلك بسحب الكتل التي لم تراها المحفظه بعد من الخادم وتحديث رصيدك, تجري هذه العمليه عاده في الخلفيه كل دقيقه او نحو ذلك . لرؤيه الرصيد بدون تحديث :
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"donate <amount>" - Donate XMR to the development team.
+```
 
-في هذا المثال, `Balance`  هو رصيدك الكلي. `unlocked balance` هو الرصيد المُتاح للإنفاق. تحتاج المعاملات الحديثه 10 تأكيدات علي سلسله الكتل قبلما تكون متاحه للإنفاق.`unlocked dust` يشير إلى كميات صغيرة جدًا من النواتج غير المنفقة التي قد تكون تراكمت في حسابك.
+## Checking your balance
 
-## إرسال مونيرو
+مُنذ أنه هناك برامج مختلفه لمُعالجه كلاً من سلسله الكتل والمحفظه , العديد من
+إستخدامات واجهه سطر الأوامر تحتاج العمل مع الخادم. من ذلك التحقق من
+المعاملات القادمه إلي عنوانك. بمجرد تشغيلك الخادم وواجهه سطر الأوامر إكتب
+`balance` لعرض رصيدك .
 
-سوف تحتاج إلي عنوان اساسي ترسل إليه ( سلسله طويله تبدأ بـ'4'), وربما تحتاج إلي هويه المعامله إذا كان المُستَلِم يتطلب واحداً, في هذه الحاله ربما يرسل لك المُستلم عنوان مُدمج وهو عباره عن العنوان الأساسي مدمج مع هويه المعامله في عنوان واحد.
+Output:
 
-### الإرسال إلي عنوان أساسي:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-إستبدل  `ADDRESS` بعنوان المُرسل إليه , و `AMOUNT`  بالكميه المراد إرسالها, و `PAYMENTID` بهويه المعامله إذا ووجدت. هويه المعامله هي إختياريه إذا لم يتطلبها المُرسل إيه قم بتجاهلها.
+## Sending monero
 
-### الإرسال إلي عنوان مُدمج:
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-    transfer ADDRESS AMOUNT
+```
+transfer ADDRESS AMOUNT
+```
 
-في هذه الحاله هويه المعامله مدمجه في العنوان الأساسي.
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-### حدد عدد المخرجات الخاصة بالمعامله:
+## Receiving monero
 
-    transfer RINGSIZE ADDRESS AMOUNT
+If you have your own Monero address, you just need to give your address to
+someone.
 
-إستبدل `RINGSIZE` بعدد المُخرجات المُراد إستخدامه ** إذا لم يتم التحدد فالعدد الإفتراضي هو 11 **. من الجيد إستخدام العدد الإفتراضي, لكن بإمكانك تزويد العدد لمزيد من المُخرجات. كلما كان العدد كبيراً كلما كان حجم المعامله اكبر وكلما زادت رسوم التحويل.
+You can find out your primary address with:
 
+```
+address
+```
 
-## إستلام مونيرو
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-إذا كان لديك عنوان مونيرو خاص بك, كل ما عليك فعله هو إعطاء هذا العنوان إلي المُرسل.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-يُمكنك إيجاد عنوانك عن طريق:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-نظراً لأن مونيرو سري لن تري عنوان المصدر الذي أتت منه الأموال. إذا كنت تريد تحديد هويه الراسل سيتحتم عليك إخبار الراسل بإستخدام هويه للمعامله, وهو عباره عن علامه عشوائيه يتم إرفاقها بالمعامله. لسهوله الإستخدام يمكنك إنشاء عنوان مع هويه للمعامله من خلال :
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-سيقوم هذا بإنشاء هويه معامله عشوائيه ويُعطيك العنوان الذي يتضمن حسابك وهويه المعامله تلك. إذا كنت تريد إستخدام هويه معامله معينه يمكنك فعل ذلك من خلال :
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-الدفعات القادمه لعنوان مدمج تم إنشائه من حسابك سيتم إضافتها إلي حسابك مربوطه بهويه المعامله تلك حتي يمكنك التفريق بين المعاملات.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## إثبات لطرف ثالث أنك قد دفعت لشخص ما
+will generate a subaddress and its label 'github_donations'.
 
-إذا دفعت لتاجر ويدّعي التاجر أنه لم يستلم الأموال ربما يجب عليك إثبات الدفع لطرف تالت - أو ربما للتاجر نفسه إذا كان خطأ غير مقصود. مونيرو خاص ولذلك لا يُمكنك الإشاره للمعامله في سلسله الكتل لأنه لا يُمكن معرفه الراسل أو المُستلم منها. مع ذلك يُمكنك توفير المفتاح الخاص بالمعامله . وبالمفتاح الخاص بالمعامله يمكن معرفه إذا تم إرسال الأموال لهذا العنوان أم لا. لاحظ أن تخزين المفاتيح الخاصه بالمعاملات غير متاح إفتراضياً ويجب عليك إتاحته قبل الإرسال إذا كنت تعتقد أنه ربما تحتاجه :
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+إذا دفعت لتاجر ويدّعي التاجر أنه لم يستلم الأموال ربما يجب عليك إثبات الدفع
+لطرف تالت - أو ربما للتاجر نفسه إذا كان خطأ غير مقصود. مونيرو خاص ولذلك لا
+يُمكنك الإشاره للمعامله في سلسله الكتل لأنه لا يُمكن معرفه الراسل أو
+المُستلم منها. مع ذلك يُمكنك توفير المفتاح الخاص بالمعامله . وبالمفتاح الخاص
+بالمعامله يمكن معرفه إذا تم إرسال الأموال لهذا العنوان أم لا. لاحظ أن تخزين
+المفاتيح الخاصه بالمعاملات غير متاح إفتراضياً ويجب عليك إتاحته قبل الإرسال
+إذا كنت تعتقد أنه ربما تحتاجه :
+
+```
+set store-tx-info 1
+```
 
 يُمكنك استرداد مفتاح معامله سابقه :
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-إدخل هويه المعامله التي تريد الحصول علي مفتاحها. تذكر أنه ربما إنقسم الدفع إلي عده معاملات وسوف تحتاج إلي عده مفاتيح. بعد ذلك يُمكن إرسال هذا المفتاح او المفاتيح مع هويه المعامله والعنوان المرسل إليه لإثبات الدفع. لاحظ أن الطرف التالت إذا كان يعلم عنوان حسابك سيتمكن من معرفه الباقي العائد إليك من هذه المعامله.
+إدخل هويه المعامله التي تريد الحصول علي مفتاحها. تذكر أنه ربما إنقسم الدفع
+إلي عده معاملات وسوف تحتاج إلي عده مفاتيح. بعد ذلك يُمكن إرسال هذا المفتاح
+او المفاتيح مع هويه المعامله والعنوان المرسل إليه لإثبات الدفع. لاحظ أن
+الطرف التالت إذا كان يعلم عنوان حسابك سيتمكن من معرفه الباقي العائد إليك من
+هذه المعامله.
 
-إذا كنت أنت الطرف التالت ( إذا كان هُناك شخص يريد إثبات لك أنه قد أرسل الأموال لحساب معين) , يمكنك التحقق من ذلك عن طريق:
+إذا كنت أنت الطرف التالت ( إذا كان هُناك شخص يريد إثبات لك أنه قد أرسل
+الأموال لحساب معين) , يمكنك التحقق من ذلك عن طريق:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-قم بتبديل `TXID`و `TXKEY` و `ADDRESS` بهويه المعامله و مفتاح المعامله و عنوان حساب المُستلِم. ستقوم واجهه سطر الأوامر بالبحث عن المعامله وإخبارك كم تم دفعه إلي ذلك الحساب.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
-
-## الحصول على فرصة لتأكيد / إلغاء المدفوعات
-
-إذا كنت ترغب في الحصول على فرصة تأكيد أخيرة عند إرسال دفعة:
-
-    set always-confirm-transfers 1
-
-
-## كيفية العثور على دفعة لك
+## How to find a payment to you
 
 إذا تلقيت دفعة باستخدام هويه معامله محدده ، فيمكنك البحث عنها:
 
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 يُمكنك تحديد أكثر من هويه معامله واحده.
 
 بشكل عام ، يمكنك مراجعة المدفوعات الواردة والصادرة:
 
-    show_transfers
+```
+show_transfers
+```
 
-يُمكنك تحديد طول معين لسرد المعاملات وطلب المعاملات الصادره أو الوارده فقط , مثال:
+يُمكنك تحديد طول معين لسرد المعاملات وطلب المعاملات الصادره أو الوارده فقط ,
+مثال:
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-سوف يعرض فقط الدفعات الوارده بعد الكتله 650000 . يمكنك أيضاً تحديد نطاق للكتل.
+سوف يعرض فقط الدفعات الوارده بعد الكتله 650000 . يمكنك أيضاً تحديد نطاق
+للكتل.
 
 إذا كنت ترغب في التعدين يمكنك القيام بذلك من المحفظة:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-سيقوم ذلك ببدأ التعدين في الخادم . لاحظ أن هذا تعدين فردي وربما يأخذ وقت طويلاً لإيجاد كتله, لإيقاف التعدين:
+سيقوم ذلك ببدأ التعدين في الخادم . لاحظ أن هذا تعدين فردي وربما يأخذ وقت
+طويلاً لإيجاد كتله, لإيقاف التعدين:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/ar/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/ar/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:19+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,410 +22,402 @@ msgstr "﻿{% include disclaimer.html translated=\"yes\" translationOutdated=\"n
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"واجهه سطر الأوامر `monero-wallet-cli` هو برنامج المحفظه الذي يأتي مع "
-"مونيرو. إنه برنامج وحده تحكم ويُدير الحساب. بينما في البتكوين تُدير المحفظه "
-"كلاً من الحساب وسلسله الكُتل. يقوم مونيرو بفصلهم : الخادم `monerod` يُدير "
-"سلسله الكُتل و واجهه سطر الأوامر `monero-wallet-cli` تُدير الحساب."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "واجهه سطر الأوامر `monero-wallet-cli` هو برنامج المحفظه الذي يأتي مع مونيرو. إنه برنامج وحده تحكم ويُدير الحساب. بينما في البتكوين تُدير المحفظه كلاً من الحساب وسلسله الكُتل. يقوم مونيرو بفصلهم : الخادم `monerod` يُدير سلسله الكُتل و واجهه سطر الأوامر `monero-wallet-cli` تُدير الحساب."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "سيقوم هذا الدليل بإطلاعك علي كيفيه القيام بالعديد من العمليات من واجهه سطر الأوامر . يفترض هذا الدليل أنك تستخدم أحدث نسخه من برامج مونيرو وقمت بالفعل بإنشاء حساب كما هو موضح بالدلائل الأخري."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"سيقوم هذا الدليل بإطلاعك علي كيفيه القيام بالعديد من العمليات من واجهه سطر "
-"الأوامر . يفترض هذا الدليل أنك تستخدم أحدث نسخه من برامج مونيرو وقمت بالفعل "
-"بإنشاء حساب كما هو موضح بالدلائل الأخري."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## التحقق من رصيدك"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"مُنذ أنه هناك برامج مختلفه لمُعالجه كلاً من سلسله الكتل والمحفظه , العديد من "
-"إستخدامات واجهه سطر الأوامر تحتاج العمل مع الخادم. من ذلك التحقق من "
-"المعاملات القادمه إلي عنوانك. بمجرد تشغيلك الخادم وواجهه سطر الأوامر إكتب "
-"`balance` لعرض رصيدك ."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "مثال:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"يقوم ذلك بسحب الكتل التي لم تراها المحفظه بعد من الخادم وتحديث رصيدك, تجري "
-"هذه العمليه عاده في الخلفيه كل دقيقه او نحو ذلك . لرؤيه الرصيد بدون تحديث :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"في هذا المثال, `Balance` هو رصيدك الكلي. `unlocked balance` هو الرصيد "
-"المُتاح للإنفاق. تحتاج المعاملات الحديثه 10 تأكيدات علي سلسله الكتل قبلما "
-"تكون متاحه للإنفاق.`unlocked dust` يشير إلى كميات صغيرة جدًا من النواتج غير "
-"المنفقة التي قد تكون تراكمت في حسابك."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## إرسال مونيرو"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"سوف تحتاج إلي عنوان اساسي ترسل إليه ( سلسله طويله تبدأ بـ'4'), وربما تحتاج "
-"إلي هويه المعامله إذا كان المُستَلِم يتطلب واحداً, في هذه الحاله ربما يرسل "
-"لك المُستلم عنوان مُدمج وهو عباره عن العنوان الأساسي مدمج مع هويه المعامله "
-"في عنوان واحد."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### الإرسال إلي عنوان أساسي:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"إستبدل `ADDRESS` بعنوان المُرسل إليه , و `AMOUNT` بالكميه المراد إرسالها, و "
-"`PAYMENTID` بهويه المعامله إذا ووجدت. هويه المعامله هي إختياريه إذا لم "
-"يتطلبها المُرسل إيه قم بتجاهلها."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### الإرسال إلي عنوان مُدمج:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "مُنذ أنه هناك برامج مختلفه لمُعالجه كلاً من سلسله الكتل والمحفظه , العديد من إستخدامات واجهه سطر الأوامر تحتاج العمل مع الخادم. من ذلك التحقق من المعاملات القادمه إلي عنوانك. بمجرد تشغيلك الخادم وواجهه سطر الأوامر إكتب `balance` لعرض رصيدك ."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADDRESS AMOUNT\n"
+msgid "Output:"
+msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr "في هذه الحاله هويه المعامله مدمجه في العنوان الأساسي."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### حدد عدد المخرجات الخاصة بالمعامله:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"إستبدل `RINGSIZE` بعدد المُخرجات المُراد إستخدامه ** إذا لم يتم التحدد "
-"فالعدد الإفتراضي هو 11 **. من الجيد إستخدام العدد الإفتراضي, لكن بإمكانك "
-"تزويد العدد لمزيد من المُخرجات. كلما كان العدد كبيراً كلما كان حجم المعامله "
-"اكبر وكلما زادت رسوم التحويل."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "في هذا المثال, `Balance` هو رصيدك الكلي. `unlocked balance` هو الرصيد المُتاح للإنفاق. تحتاج المعاملات الحديثه 10 تأكيدات علي سلسله الكتل قبلما تكون متاحه للإنفاق.`unlocked dust` يشير إلى كميات صغيرة جدًا من النواتج غير المنفقة التي قد تكون تراكمت في حسابك."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## إرسال مونيرو"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADDRESS AMOUNT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## إستلام مونيرو"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"إذا كان لديك عنوان مونيرو خاص بك, كل ما عليك فعله هو إعطاء هذا العنوان إلي "
-"المُرسل."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "يُمكنك إيجاد عنوانك عن طريق:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"نظراً لأن مونيرو سري لن تري عنوان المصدر الذي أتت منه الأموال. إذا كنت تريد "
-"تحديد هويه الراسل سيتحتم عليك إخبار الراسل بإستخدام هويه للمعامله, وهو عباره "
-"عن علامه عشوائيه يتم إرفاقها بالمعامله. لسهوله الإستخدام يمكنك إنشاء عنوان "
-"مع هويه للمعامله من خلال :"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "إذا كان لديك عنوان مونيرو خاص بك, كل ما عليك فعله هو إعطاء هذا العنوان إلي المُرسل."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "يُمكنك إيجاد عنوانك عن طريق:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"سيقوم هذا بإنشاء هويه معامله عشوائيه ويُعطيك العنوان الذي يتضمن حسابك وهويه "
-"المعامله تلك. إذا كنت تريد إستخدام هويه معامله معينه يمكنك فعل ذلك من خلال :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "نظراً لأن مونيرو سري لن تري عنوان المصدر الذي أتت منه الأموال. إذا كنت تريد تحديد هويه الراسل سيتحتم عليك إخبار الراسل بإستخدام هويه للمعامله, وهو عباره عن علامه عشوائيه يتم إرفاقها بالمعامله. لسهوله الإستخدام يمكنك إنشاء عنوان مع هويه للمعامله من خلال :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"الدفعات القادمه لعنوان مدمج تم إنشائه من حسابك سيتم إضافتها إلي حسابك مربوطه "
-"بهويه المعامله تلك حتي يمكنك التفريق بين المعاملات."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## إثبات لطرف ثالث أنك قد دفعت لشخص ما"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "سيقوم هذا بإنشاء هويه معامله عشوائيه ويُعطيك العنوان الذي يتضمن حسابك وهويه المعامله تلك. إذا كنت تريد إستخدام هويه معامله معينه يمكنك فعل ذلك من خلال :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"إذا دفعت لتاجر ويدّعي التاجر أنه لم يستلم الأموال ربما يجب عليك إثبات الدفع "
-"لطرف تالت - أو ربما للتاجر نفسه إذا كان خطأ غير مقصود. مونيرو خاص ولذلك لا "
-"يُمكنك الإشاره للمعامله في سلسله الكتل لأنه لا يُمكن معرفه الراسل أو "
-"المُستلم منها. مع ذلك يُمكنك توفير المفتاح الخاص بالمعامله . وبالمفتاح الخاص "
-"بالمعامله يمكن معرفه إذا تم إرسال الأموال لهذا العنوان أم لا. لاحظ أن تخزين "
-"المفاتيح الخاصه بالمعاملات غير متاح إفتراضياً ويجب عليك إتاحته قبل الإرسال "
-"إذا كنت تعتقد أنه ربما تحتاجه :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "يُمكنك استرداد مفتاح معامله سابقه :"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "الدفعات القادمه لعنوان مدمج تم إنشائه من حسابك سيتم إضافتها إلي حسابك مربوطه بهويه المعامله تلك حتي يمكنك التفريق بين المعاملات."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"إدخل هويه المعامله التي تريد الحصول علي مفتاحها. تذكر أنه ربما إنقسم الدفع "
-"إلي عده معاملات وسوف تحتاج إلي عده مفاتيح. بعد ذلك يُمكن إرسال هذا المفتاح "
-"او المفاتيح مع هويه المعامله والعنوان المرسل إليه لإثبات الدفع. لاحظ أن "
-"الطرف التالت إذا كان يعلم عنوان حسابك سيتمكن من معرفه الباقي العائد إليك من "
-"هذه المعامله."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"إذا كنت أنت الطرف التالت ( إذا كان هُناك شخص يريد إثبات لك أنه قد أرسل "
-"الأموال لحساب معين) , يمكنك التحقق من ذلك عن طريق:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"قم بتبديل `TXID`و `TXKEY` و `ADDRESS` بهويه المعامله و مفتاح المعامله و "
-"عنوان حساب المُستلِم. ستقوم واجهه سطر الأوامر بالبحث عن المعامله وإخبارك كم "
-"تم دفعه إلي ذلك الحساب."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## الحصول على فرصة لتأكيد / إلغاء المدفوعات"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr "إذا كنت ترغب في الحصول على فرصة تأكيد أخيرة عند إرسال دفعة:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## كيفية العثور على دفعة لك"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr "إذا تلقيت دفعة باستخدام هويه معامله محدده ، فيمكنك البحث عنها:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## إثبات لطرف ثالث أنك قد دفعت لشخص ما"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "إذا دفعت لتاجر ويدّعي التاجر أنه لم يستلم الأموال ربما يجب عليك إثبات الدفع لطرف تالت - أو ربما للتاجر نفسه إذا كان خطأ غير مقصود. مونيرو خاص ولذلك لا يُمكنك الإشاره للمعامله في سلسله الكتل لأنه لا يُمكن معرفه الراسل أو المُستلم منها. مع ذلك يُمكنك توفير المفتاح الخاص بالمعامله . وبالمفتاح الخاص بالمعامله يمكن معرفه إذا تم إرسال الأموال لهذا العنوان أم لا. لاحظ أن تخزين المفاتيح الخاصه بالمعاملات غير متاح إفتراضياً ويجب عليك إتاحته قبل الإرسال إذا كنت تعتقد أنه ربما تحتاجه :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "يُمكنك استرداد مفتاح معامله سابقه :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "إدخل هويه المعامله التي تريد الحصول علي مفتاحها. تذكر أنه ربما إنقسم الدفع إلي عده معاملات وسوف تحتاج إلي عده مفاتيح. بعد ذلك يُمكن إرسال هذا المفتاح او المفاتيح مع هويه المعامله والعنوان المرسل إليه لإثبات الدفع. لاحظ أن الطرف التالت إذا كان يعلم عنوان حسابك سيتمكن من معرفه الباقي العائد إليك من هذه المعامله."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "إذا كنت أنت الطرف التالت ( إذا كان هُناك شخص يريد إثبات لك أنه قد أرسل الأموال لحساب معين) , يمكنك التحقق من ذلك عن طريق:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "قم بتبديل `TXID`و `TXKEY` و `ADDRESS` بهويه المعامله و مفتاح المعامله و عنوان حساب المُستلِم. ستقوم واجهه سطر الأوامر بالبحث عن المعامله وإخبارك كم تم دفعه إلي ذلك الحساب."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## كيفية العثور على دفعة لك"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "إذا تلقيت دفعة باستخدام هويه معامله محدده ، فيمكنك البحث عنها:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "يُمكنك تحديد أكثر من هويه معامله واحده."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
 msgstr "بشكل عام ، يمكنك مراجعة المدفوعات الواردة والصادرة:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"يُمكنك تحديد طول معين لسرد المعاملات وطلب المعاملات الصادره أو الوارده فقط , "
-"مثال:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "يُمكنك تحديد طول معين لسرد المعاملات وطلب المعاملات الصادره أو الوارده فقط , مثال:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"سوف يعرض فقط الدفعات الوارده بعد الكتله 650000 . يمكنك أيضاً تحديد نطاق "
-"للكتل."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "سوف يعرض فقط الدفعات الوارده بعد الكتله 650000 . يمكنك أيضاً تحديد نطاق للكتل."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "إذا كنت ترغب في التعدين يمكنك القيام بذلك من المحفظة:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"سيقوم ذلك ببدأ التعدين في الخادم . لاحظ أن هذا تعدين فردي وربما يأخذ وقت "
-"طويلاً لإيجاد كتله, لإيقاف التعدين:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "سيقوم ذلك ببدأ التعدين في الخادم . لاحظ أن هذا تعدين فردي وربما يأخذ وقت طويلاً لإيجاد كتله, لإيقاف التعدين:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "مثال:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "يقوم ذلك بسحب الكتل التي لم تراها المحفظه بعد من الخادم وتحديث رصيدك, تجري هذه العمليه عاده في الخلفيه كل دقيقه او نحو ذلك . لرؤيه الرصيد بدون تحديث :"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "سوف تحتاج إلي عنوان اساسي ترسل إليه ( سلسله طويله تبدأ بـ'4'), وربما تحتاج إلي هويه المعامله إذا كان المُستَلِم يتطلب واحداً, في هذه الحاله ربما يرسل لك المُستلم عنوان مُدمج وهو عباره عن العنوان الأساسي مدمج مع هويه المعامله في عنوان واحد."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### الإرسال إلي عنوان أساسي:"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "إستبدل `ADDRESS` بعنوان المُرسل إليه , و `AMOUNT` بالكميه المراد إرسالها, و `PAYMENTID` بهويه المعامله إذا ووجدت. هويه المعامله هي إختياريه إذا لم يتطلبها المُرسل إيه قم بتجاهلها."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### الإرسال إلي عنوان مُدمج:"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "في هذه الحاله هويه المعامله مدمجه في العنوان الأساسي."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### حدد عدد المخرجات الخاصة بالمعامله:"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "إستبدل `RINGSIZE` بعدد المُخرجات المُراد إستخدامه ** إذا لم يتم التحدد فالعدد الإفتراضي هو 11 **. من الجيد إستخدام العدد الإفتراضي, لكن بإمكانك تزويد العدد لمزيد من المُخرجات. كلما كان العدد كبيراً كلما كان حجم المعامله اكبر وكلما زادت رسوم التحويل."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## الحصول على فرصة لتأكيد / إلغاء المدفوعات"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "إذا كنت ترغب في الحصول على فرصة تأكيد أخيرة عند إرسال دفعة:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/de/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/de/resources/user-guides/monero-wallet-cli.md
@@ -1,111 +1,220 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` ist die im Monero-Baum enthaltene Wallet-Software, die als Konsolenprogramm ein Konto verwaltet. Während ein Bitcoin-Wallet sowohl das Konto als auch die Blockchain verwaltet, ist dies bei Monero getrennt: `monerod` ist für die Blockchain, `monero-wallet-cli` für das Konto zuständig.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-Wie verschiedene Vorgänge ausgehend von der Benutzeroberfläche des `monero-wallet-cli` - die Befehlszeile - gesteuert werden, wird in dieser Anleitung erklärt. Es wird angenommen, dass du die neueste Version Moneros nutzt und mithilfe anderer Anleitungen bereits ein Konto erstellt hast.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
-## Guthaben überprüfen
+## Overview
 
-Da die Zuständigkeiten für Blockchain und Wallet bei verschiedenen Programmen liegen, benötigen einige Dienste des `monero-wallet-cli` eine Verbindung mit einem Hintergrunddienst (darunter die Suche nach eingehenden Transaktionen). 
-Sobald du sowohl `monero-wallet-cli` wie auch `monerod` gestartet hast, kannst du `balance` eingeben.
+You can have a list of the most important commands by running `help`:
 
-Beispiel: 
+```
+Important commands:
 
-Dies lädt Blöcke aus dem Hintergrunddienst, welche dein Wallet vielleicht noch nicht gesehen hat, und aktualisiert dein Guthaben entsprechend. Dieser Vorgang läuft normalerweise etwa jede Minute im Hintergrund ab. Um dein Guthaben ohne Aktualisierung anzuzeigen:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-In diesem Beispiel ist `Balance` dein gesamtes Guthaben. `unlocked balance` steht für den Betrag, den du derzeit ausgeben kannst; neu eingehende Transaktionen benötigen zunächst zehn Bestätigungen innerhalb der Blockchain, bevor sie entsperrt und für dich freigegeben werden. Der `unlocked dust` sind die Kleinstbeträge nichtausgegebener Outputs, die sich auf deinem Konto angesammelt haben.
+"donate <amount>" - Donate XMR to the development team.
+```
 
-## Monero versenden
+## Checking your balance
 
-Du brauchst hierzu die Standardadresse, an die du deine Monero senden möchtest (eine lange, mit einer '4' beginnende Zeichenkette), und zudem möglicherweise eine Zahlungs-ID, falls der Empfänger eine solche benötigt. Im letzteren Fall kann dir dieser stattdessen eine integrierte Adresse zukommen lassen, die sowohl die Standardadresse als auch eine Zahlungs-ID in einer einzelnen Adresse vereint. 
+Da die Zuständigkeiten für Blockchain und Wallet bei verschiedenen
+Programmen liegen, benötigen einige Dienste des `monero-wallet-cli` eine
+Verbindung mit einem Hintergrunddienst (darunter die Suche nach eingehenden
+Transaktionen).  Sobald du sowohl `monero-wallet-cli` wie auch `monerod`
+gestartet hast, kannst du `balance` eingeben.
 
-### An eine Standardadresse senden
+Output:
 
-    transfer ADDRESS AMOUNT PAYMENTID
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-Ersetze `ADDRESS` mit der Adresse, an die du senden möchtest, `AMOUNT` mit dem Betrag der Monero, die du versenden wirst und `PAYMENTID` mit der dir bereitgestellten Zahlungs-ID. Zahlungs-IDs sind optional: Wenn der Empfänger keine benötigt, kannst du sie einfach weglassen.
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-### An eine integrierte Adresse senden
+## Sending monero
 
-    transfer ADDRESS AMOUNT
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-In diesem Fall ist die Zahlungs-ID in die integrierte Adresse inkludiert.
+```
+transfer ADDRESS AMOUNT
+```
 
-### Die Anzahl an Outputs für eine Transaktion festlegen
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-    transfer RINGSIZE ADDRESS AMOUNT
+## Receiving monero
 
-Ersetze `RINGSIZE` mit der Anzahl an Outputs, die du verwenden möchtest. **Die Standardeinstellung ist 11, wenn nichts anderes festgelegt wird.** Es ist ratsam, die voreingestellte Ringgröße zu verwenden; du kannst die Zahl aber auch erhöhen, wenn du mehr Outputs beifügen möchtest. Je größer die Zahl ist, desto größer ist auch die Transaktion und die mit ihr einhergehenden Gebühren.
+If you have your own Monero address, you just need to give your address to
+someone.
 
-## Monero empfangen
+You can find out your primary address with:
 
-Wenn du eine eigene Monero-Adresse hast, kannst du jemandem ganz einfach deine Standardadresse geben.
+```
+address
+```
 
-Diese findest du heraus mit:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-    address
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Da Monero anonym ist, wirst du die Ursprungsadresse deiner empfangenen Gelder nicht sehen können. Wenn du sie aber doch aus irgendeinem Grund (beispielsweise, um einen besonderen Kunden zu honorieren) wissen möchtest, musst du dem Sender mitteilen, dass er eine Zahlungs-ID verwenden soll. Diese ist ein willkürlicher, optionaler Tag, mit welchem die Transaktion versehen wird. Um es dir einfach zu machen, kannst du eine Adresse erstellen, die bereits eine zufällige Zahlungs-ID enthält:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    integrated_address
+```
+integrated_address 82d79055f3b27f56
+```
 
-Dies generiert eine zufällige Zahlungs-ID und gibt eine Adresse aus, welche dein eigenes Konto und zudem ebendiese Zahlungs-ID enthält. Wenn du eine bestimmte Zahlungs-ID verwenden möchtest, kannst du das folgendermaßen machen:
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address 12346780abcdef00
+### Using subaddresses
 
-An eine von deinem Konto aus generierte integrierte Adresse gesendete Zahlungen gehen mit der Zahlungs-ID markiert auf dein Konto. Auf diese Weise kannst du Zahlungen unterscheiden.
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-## Getätigte Zahlungen gegenüber Dritten nachweisen
+```
+address new [<label text with white spaces allowed>]
+```
 
-Solltest du einen Händler bezahlt haben, dieser aber bestreiten, das Geld empfangen zu haben, kann es passieren, dass du deine Zahlung gegenüber Dritten nachweisen musst - oder sogar gegenüber des Händlers, sofern es ein ehrlicher Fehler seinerseits war. Da Monero privat ist und man nicht ausmachen kann, wer Gelder empfangen oder gesendet hat, kannst du nicht einfach auf deine Transaktion in der Blockchain verweisen. Durch Bereitstellen des privaten, pro Transaktion vertraulichen Schlüssels ist es Dritten allerdings möglich, zu sehen, ob in dieser Transaktion Monero an die jeweilige Adresse gesendet wurden. Beachte, dass das Abspeichern dieser Transaktionsschlüssel standardmäßig deaktiviert ist. Wenn du denkst, du könntest diese Funktion gebrauchen, musst du sie vor dem Senden einschalten:
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
-    set store-tx-info 1
+```
+address new github_donations
+```
+
+will generate a subaddress and its label 'github_donations'.
+
+To view all generated addresses, run:
+
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Solltest du einen Händler bezahlt haben, dieser aber bestreiten, das Geld
+empfangen zu haben, kann es passieren, dass du deine Zahlung gegenüber
+Dritten nachweisen musst - oder sogar gegenüber des Händlers, sofern es ein
+ehrlicher Fehler seinerseits war. Da Monero privat ist und man nicht
+ausmachen kann, wer Gelder empfangen oder gesendet hat, kannst du nicht
+einfach auf deine Transaktion in der Blockchain verweisen. Durch
+Bereitstellen des privaten, pro Transaktion vertraulichen Schlüssels ist es
+Dritten allerdings möglich, zu sehen, ob in dieser Transaktion Monero an die
+jeweilige Adresse gesendet wurden. Beachte, dass das Abspeichern dieser
+Transaktionsschlüssel standardmäßig deaktiviert ist. Wenn du denkst, du
+könntest diese Funktion gebrauchen, musst du sie vor dem Senden einschalten:
+
+```
+set store-tx-info 1
+```
 
 Du kannst den Transaktionsschlüssel einer früheren Transaktion abrufen:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Gib die Transaktions-ID, deren Schlüssel du benötigst, ein. Vergiss nicht, dass eine Zahlung mit verschiedenen Einzeltransaktionen getätigt werden kann; es kann also sein, dass du mehrere Schlüssel brauchst. Du kannst diese(n) Schlüssel (zusammen mit der Transaktions-ID und der Empfangsadresse) anschließend an denjenigen schicken, dem du einen Nachweis über deine Transaktion erbringen möchtest. Bedenke, dass der entsprechende Dritte - sollte er deine eigene Adresse kennen - sehen kann, wie viel Wechselgeld an dich zurückgegangen ist.
+Gib die Transaktions-ID, deren Schlüssel du benötigst, ein. Vergiss nicht,
+dass eine Zahlung mit verschiedenen Einzeltransaktionen getätigt werden
+kann; es kann also sein, dass du mehrere Schlüssel brauchst. Du kannst
+diese(n) Schlüssel (zusammen mit der Transaktions-ID und der
+Empfangsadresse) anschließend an denjenigen schicken, dem du einen Nachweis
+über deine Transaktion erbringen möchtest. Bedenke, dass der entsprechende
+Dritte - sollte er deine eigene Adresse kennen - sehen kann, wie viel
+Wechselgeld an dich zurückgegangen ist.
 
-Wenn du dieser Dritte bist (weil dir jemand beweisen möchte, dass er Monero an eine Adresse gesendet hat), kannst du den Nachweis folgendermaßen überprüfen:
+Wenn du dieser Dritte bist (weil dir jemand beweisen möchte, dass er Monero
+an eine Adresse gesendet hat), kannst du den Nachweis folgendermaßen
+überprüfen:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Ersetze `TXID`, `TXKEY` und `ADDRESS` mit der dir bereitgestellten Transaktions-ID, dem jeweiligen Transaktionsschlüssel und der Zieladresse. monero-wallet-cli überprüft nun diese Transaktion und teilt dir mit, wie viele Monero in dieser Transaktion an die vorgegebene Adresse gesendet wurden.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
-## Möglichkeit des Bestätigens/Abbrechens von Zahlungen einrichten
+## How to find a payment to you
 
-Wenn du eine finale Bestätigungsmöglichkeit beim Senden einer Zahlung möchtest:
+Hast du eine Zahlung mit einer bestimmten Zahlungs-ID erhalten, kannst du
+diese folgendermaßen aufsuchen:
 
-    set always-confirm-transfers 1
-
-
-## Eine an dich gehende Zahlung finden
-
-Hast du eine Zahlung mit einer bestimmten Zahlungs-ID erhalten, kannst du diese folgendermaßen aufsuchen:
-
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 Du kannst auch mehr als eine Zahlungs-ID eingeben.
 
 Grundsätzlich kannst du ein- und ausgehende Zahlungen wie folgt prüfen:
 
-    show_transfers
+```
+show_transfers
+```
 
-Du kannst zur Anzeige jüngerer Transaktionen eine bestimmte Höhe setzen und nur eingehende oder nur ausgehende Transaktionen abfragen, zum Beispiel zeigt
+Du kannst zur Anzeige jüngerer Transaktionen eine bestimmte Höhe setzen und
+nur eingehende oder nur ausgehende Transaktionen abfragen, zum Beispiel
+zeigt
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-nur die eingegangen Transaktionen nach dem Block 650000 an. Du kannst außerdem einen Höhenbereich festlegen.
+nur die eingegangen Transaktionen nach dem Block 650000 an. Du kannst
+außerdem einen Höhenbereich festlegen.
 
 Falls du minen möchtest, kannst du dies vom Wallet aus tun:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Hierdurch startet das Mining mit dem Hintergrunddienst unter Gebrauch zweier Threads. Bedenke, dass dieses Solomining eine Weile dauern kann, bis du einen Block findest. Du beendest das Minen mit
+Hierdurch startet das Mining mit dem Hintergrunddienst unter Gebrauch zweier
+Threads. Bedenke, dass dieses Solomining eine Weile dauern kann, bis du
+einen Block findest. Du beendest das Minen mit
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/de/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/de/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:19+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,444 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` ist die im Monero-Baum enthaltene Wallet-Software, die "
-"als Konsolenprogramm ein Konto verwaltet. Während ein Bitcoin-Wallet sowohl "
-"das Konto als auch die Blockchain verwaltet, ist dies bei Monero getrennt: "
-"`monerod` ist für die Blockchain, `monero-wallet-cli` für das Konto "
-"zuständig."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` ist die im Monero-Baum enthaltene Wallet-Software, die als Konsolenprogramm ein Konto verwaltet. Während ein Bitcoin-Wallet sowohl das Konto als auch die Blockchain verwaltet, ist dies bei Monero getrennt: `monerod` ist für die Blockchain, `monero-wallet-cli` für das Konto zuständig."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "Wie verschiedene Vorgänge ausgehend von der Benutzeroberfläche des `monero-wallet-cli` - die Befehlszeile - gesteuert werden, wird in dieser Anleitung erklärt. Es wird angenommen, dass du die neueste Version Moneros nutzt und mithilfe anderer Anleitungen bereits ein Konto erstellt hast."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"Wie verschiedene Vorgänge ausgehend von der Benutzeroberfläche des "
-"`monero-wallet-cli` - die Befehlszeile - gesteuert werden, wird in dieser "
-"Anleitung erklärt. Es wird angenommen, dass du die neueste Version Moneros "
-"nutzt und mithilfe anderer Anleitungen bereits ein Konto erstellt hast."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Guthaben überprüfen"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Da die Zuständigkeiten für Blockchain und Wallet bei verschiedenen "
-"Programmen liegen, benötigen einige Dienste des `monero-wallet-cli` eine "
-"Verbindung mit einem Hintergrunddienst (darunter die Suche nach eingehenden "
-"Transaktionen).  Sobald du sowohl `monero-wallet-cli` wie auch `monerod` "
-"gestartet hast, kannst du `balance` eingeben."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Beispiel:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Dies lädt Blöcke aus dem Hintergrunddienst, welche dein Wallet vielleicht "
-"noch nicht gesehen hat, und aktualisiert dein Guthaben entsprechend. Dieser "
-"Vorgang läuft normalerweise etwa jede Minute im Hintergrund ab. Um dein "
-"Guthaben ohne Aktualisierung anzuzeigen:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"In diesem Beispiel ist `Balance` dein gesamtes Guthaben. `unlocked balance` "
-"steht für den Betrag, den du derzeit ausgeben kannst; neu eingehende "
-"Transaktionen benötigen zunächst zehn Bestätigungen innerhalb der "
-"Blockchain, bevor sie entsperrt und für dich freigegeben werden. Der "
-"`unlocked dust` sind die Kleinstbeträge nichtausgegebener Outputs, die sich "
-"auf deinem Konto angesammelt haben."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Monero versenden"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Du brauchst hierzu die Standardadresse, an die du deine Monero senden "
-"möchtest (eine lange, mit einer '4' beginnende Zeichenkette), und zudem "
-"möglicherweise eine Zahlungs-ID, falls der Empfänger eine solche "
-"benötigt. Im letzteren Fall kann dir dieser stattdessen eine integrierte "
-"Adresse zukommen lassen, die sowohl die Standardadresse als auch eine "
-"Zahlungs-ID in einer einzelnen Adresse vereint."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### An eine Standardadresse senden"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Ersetze `ADDRESS` mit der Adresse, an die du senden möchtest, `AMOUNT` mit "
-"dem Betrag der Monero, die du versenden wirst und `PAYMENTID` mit der dir "
-"bereitgestellten Zahlungs-ID. Zahlungs-IDs sind optional: Wenn der Empfänger "
-"keine benötigt, kannst du sie einfach weglassen."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### An eine integrierte Adresse senden"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Da die Zuständigkeiten für Blockchain und Wallet bei verschiedenen Programmen liegen, benötigen einige Dienste des `monero-wallet-cli` eine Verbindung mit einem Hintergrunddienst (darunter die Suche nach eingehenden Transaktionen).  Sobald du sowohl `monero-wallet-cli` wie auch `monerod` gestartet hast, kannst du `balance` eingeben."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADDRESS AMOUNT\n"
+msgid "Output:"
+msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr "In diesem Fall ist die Zahlungs-ID in die integrierte Adresse inkludiert."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Die Anzahl an Outputs für eine Transaktion festlegen"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Ersetze `RINGSIZE` mit der Anzahl an Outputs, die du verwenden "
-"möchtest. **Die Standardeinstellung ist 11, wenn nichts anderes festgelegt "
-"wird.** Es ist ratsam, die voreingestellte Ringgröße zu verwenden; du kannst "
-"die Zahl aber auch erhöhen, wenn du mehr Outputs beifügen möchtest. Je "
-"größer die Zahl ist, desto größer ist auch die Transaktion und die mit ihr "
-"einhergehenden Gebühren."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "In diesem Beispiel ist `Balance` dein gesamtes Guthaben. `unlocked balance` steht für den Betrag, den du derzeit ausgeben kannst; neu eingehende Transaktionen benötigen zunächst zehn Bestätigungen innerhalb der Blockchain, bevor sie entsperrt und für dich freigegeben werden. Der `unlocked dust` sind die Kleinstbeträge nichtausgegebener Outputs, die sich auf deinem Konto angesammelt haben."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Monero versenden"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADDRESS AMOUNT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Monero empfangen"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Wenn du eine eigene Monero-Adresse hast, kannst du jemandem ganz einfach "
-"deine Standardadresse geben."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Diese findest du heraus mit:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"Da Monero anonym ist, wirst du die Ursprungsadresse deiner empfangenen "
-"Gelder nicht sehen können. Wenn du sie aber doch aus irgendeinem Grund "
-"(beispielsweise, um einen besonderen Kunden zu honorieren) wissen möchtest, "
-"musst du dem Sender mitteilen, dass er eine Zahlungs-ID verwenden "
-"soll. Diese ist ein willkürlicher, optionaler Tag, mit welchem die "
-"Transaktion versehen wird. Um es dir einfach zu machen, kannst du eine "
-"Adresse erstellen, die bereits eine zufällige Zahlungs-ID enthält:"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Wenn du eine eigene Monero-Adresse hast, kannst du jemandem ganz einfach deine Standardadresse geben."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Diese findest du heraus mit:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Dies generiert eine zufällige Zahlungs-ID und gibt eine Adresse aus, welche "
-"dein eigenes Konto und zudem ebendiese Zahlungs-ID enthält. Wenn du eine "
-"bestimmte Zahlungs-ID verwenden möchtest, kannst du das folgendermaßen "
-"machen:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "Da Monero anonym ist, wirst du die Ursprungsadresse deiner empfangenen Gelder nicht sehen können. Wenn du sie aber doch aus irgendeinem Grund (beispielsweise, um einen besonderen Kunden zu honorieren) wissen möchtest, musst du dem Sender mitteilen, dass er eine Zahlungs-ID verwenden soll. Diese ist ein willkürlicher, optionaler Tag, mit welchem die Transaktion versehen wird. Um es dir einfach zu machen, kannst du eine Adresse erstellen, die bereits eine zufällige Zahlungs-ID enthält:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"An eine von deinem Konto aus generierte integrierte Adresse gesendete "
-"Zahlungen gehen mit der Zahlungs-ID markiert auf dein Konto. Auf diese Weise "
-"kannst du Zahlungen unterscheiden."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Getätigte Zahlungen gegenüber Dritten nachweisen"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Dies generiert eine zufällige Zahlungs-ID und gibt eine Adresse aus, welche dein eigenes Konto und zudem ebendiese Zahlungs-ID enthält. Wenn du eine bestimmte Zahlungs-ID verwenden möchtest, kannst du das folgendermaßen machen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Solltest du einen Händler bezahlt haben, dieser aber bestreiten, das Geld "
-"empfangen zu haben, kann es passieren, dass du deine Zahlung gegenüber "
-"Dritten nachweisen musst - oder sogar gegenüber des Händlers, sofern es ein "
-"ehrlicher Fehler seinerseits war. Da Monero privat ist und man nicht "
-"ausmachen kann, wer Gelder empfangen oder gesendet hat, kannst du nicht "
-"einfach auf deine Transaktion in der Blockchain verweisen. Durch "
-"Bereitstellen des privaten, pro Transaktion vertraulichen Schlüssels ist es "
-"Dritten allerdings möglich, zu sehen, ob in dieser Transaktion Monero an die "
-"jeweilige Adresse gesendet wurden. Beachte, dass das Abspeichern dieser "
-"Transaktionsschlüssel standardmäßig deaktiviert ist. Wenn du denkst, du "
-"könntest diese Funktion gebrauchen, musst du sie vor dem Senden einschalten:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Du kannst den Transaktionsschlüssel einer früheren Transaktion abrufen:"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "An eine von deinem Konto aus generierte integrierte Adresse gesendete Zahlungen gehen mit der Zahlungs-ID markiert auf dein Konto. Auf diese Weise kannst du Zahlungen unterscheiden."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Gib die Transaktions-ID, deren Schlüssel du benötigst, ein. Vergiss nicht, "
-"dass eine Zahlung mit verschiedenen Einzeltransaktionen getätigt werden "
-"kann; es kann also sein, dass du mehrere Schlüssel brauchst. Du kannst "
-"diese(n) Schlüssel (zusammen mit der Transaktions-ID und der "
-"Empfangsadresse) anschließend an denjenigen schicken, dem du einen Nachweis "
-"über deine Transaktion erbringen möchtest. Bedenke, dass der entsprechende "
-"Dritte - sollte er deine eigene Adresse kennen - sehen kann, wie viel "
-"Wechselgeld an dich zurückgegangen ist."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Wenn du dieser Dritte bist (weil dir jemand beweisen möchte, dass er Monero "
-"an eine Adresse gesendet hat), kannst du den Nachweis folgendermaßen "
-"überprüfen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Ersetze `TXID`, `TXKEY` und `ADDRESS` mit der dir bereitgestellten "
-"Transaktions-ID, dem jeweiligen Transaktionsschlüssel und der "
-"Zieladresse. monero-wallet-cli überprüft nun diese Transaktion und teilt dir "
-"mit, wie viele Monero in dieser Transaktion an die vorgegebene Adresse "
-"gesendet wurden."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Möglichkeit des Bestätigens/Abbrechens von Zahlungen einrichten"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-"Wenn du eine finale Bestätigungsmöglichkeit beim Senden einer Zahlung "
-"möchtest:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Eine an dich gehende Zahlung finden"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Hast du eine Zahlung mit einer bestimmten Zahlungs-ID erhalten, kannst du "
-"diese folgendermaßen aufsuchen:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Getätigte Zahlungen gegenüber Dritten nachweisen"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Solltest du einen Händler bezahlt haben, dieser aber bestreiten, das Geld empfangen zu haben, kann es passieren, dass du deine Zahlung gegenüber Dritten nachweisen musst - oder sogar gegenüber des Händlers, sofern es ein ehrlicher Fehler seinerseits war. Da Monero privat ist und man nicht ausmachen kann, wer Gelder empfangen oder gesendet hat, kannst du nicht einfach auf deine Transaktion in der Blockchain verweisen. Durch Bereitstellen des privaten, pro Transaktion vertraulichen Schlüssels ist es Dritten allerdings möglich, zu sehen, ob in dieser Transaktion Monero an die jeweilige Adresse gesendet wurden. Beachte, dass das Abspeichern dieser Transaktionsschlüssel standardmäßig deaktiviert ist. Wenn du denkst, du könntest diese Funktion gebrauchen, musst du sie vor dem Senden einschalten:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Du kannst den Transaktionsschlüssel einer früheren Transaktion abrufen:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Gib die Transaktions-ID, deren Schlüssel du benötigst, ein. Vergiss nicht, dass eine Zahlung mit verschiedenen Einzeltransaktionen getätigt werden kann; es kann also sein, dass du mehrere Schlüssel brauchst. Du kannst diese(n) Schlüssel (zusammen mit der Transaktions-ID und der Empfangsadresse) anschließend an denjenigen schicken, dem du einen Nachweis über deine Transaktion erbringen möchtest. Bedenke, dass der entsprechende Dritte - sollte er deine eigene Adresse kennen - sehen kann, wie viel Wechselgeld an dich zurückgegangen ist."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Wenn du dieser Dritte bist (weil dir jemand beweisen möchte, dass er Monero an eine Adresse gesendet hat), kannst du den Nachweis folgendermaßen überprüfen:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Ersetze `TXID`, `TXKEY` und `ADDRESS` mit der dir bereitgestellten Transaktions-ID, dem jeweiligen Transaktionsschlüssel und der Zieladresse. monero-wallet-cli überprüft nun diese Transaktion und teilt dir mit, wie viele Monero in dieser Transaktion an die vorgegebene Adresse gesendet wurden."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Eine an dich gehende Zahlung finden"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Hast du eine Zahlung mit einer bestimmten Zahlungs-ID erhalten, kannst du diese folgendermaßen aufsuchen:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Du kannst auch mehr als eine Zahlungs-ID eingeben."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
 msgstr "Grundsätzlich kannst du ein- und ausgehende Zahlungen wie folgt prüfen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Du kannst zur Anzeige jüngerer Transaktionen eine bestimmte Höhe setzen und "
-"nur eingehende oder nur ausgehende Transaktionen abfragen, zum Beispiel "
-"zeigt"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Du kannst zur Anzeige jüngerer Transaktionen eine bestimmte Höhe setzen und nur eingehende oder nur ausgehende Transaktionen abfragen, zum Beispiel zeigt"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"nur die eingegangen Transaktionen nach dem Block 650000 an. Du kannst "
-"außerdem einen Höhenbereich festlegen."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "nur die eingegangen Transaktionen nach dem Block 650000 an. Du kannst außerdem einen Höhenbereich festlegen."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "Falls du minen möchtest, kannst du dies vom Wallet aus tun:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Hierdurch startet das Mining mit dem Hintergrunddienst unter Gebrauch zweier "
-"Threads. Bedenke, dass dieses Solomining eine Weile dauern kann, bis du "
-"einen Block findest. Du beendest das Minen mit"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Hierdurch startet das Mining mit dem Hintergrunddienst unter Gebrauch zweier Threads. Bedenke, dass dieses Solomining eine Weile dauern kann, bis du einen Block findest. Du beendest das Minen mit"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Beispiel:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Dies lädt Blöcke aus dem Hintergrunddienst, welche dein Wallet vielleicht noch nicht gesehen hat, und aktualisiert dein Guthaben entsprechend. Dieser Vorgang läuft normalerweise etwa jede Minute im Hintergrund ab. Um dein Guthaben ohne Aktualisierung anzuzeigen:"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Du brauchst hierzu die Standardadresse, an die du deine Monero senden möchtest (eine lange, mit einer '4' beginnende Zeichenkette), und zudem möglicherweise eine Zahlungs-ID, falls der Empfänger eine solche benötigt. Im letzteren Fall kann dir dieser stattdessen eine integrierte Adresse zukommen lassen, die sowohl die Standardadresse als auch eine Zahlungs-ID in einer einzelnen Adresse vereint."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### An eine Standardadresse senden"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Ersetze `ADDRESS` mit der Adresse, an die du senden möchtest, `AMOUNT` mit dem Betrag der Monero, die du versenden wirst und `PAYMENTID` mit der dir bereitgestellten Zahlungs-ID. Zahlungs-IDs sind optional: Wenn der Empfänger keine benötigt, kannst du sie einfach weglassen."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### An eine integrierte Adresse senden"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "In diesem Fall ist die Zahlungs-ID in die integrierte Adresse inkludiert."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Die Anzahl an Outputs für eine Transaktion festlegen"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Ersetze `RINGSIZE` mit der Anzahl an Outputs, die du verwenden möchtest. **Die Standardeinstellung ist 11, wenn nichts anderes festgelegt wird.** Es ist ratsam, die voreingestellte Ringgröße zu verwenden; du kannst die Zahl aber auch erhöhen, wenn du mehr Outputs beifügen möchtest. Je größer die Zahl ist, desto größer ist auch die Transaktion und die mit ihr einhergehenden Gebühren."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Möglichkeit des Bestätigens/Abbrechens von Zahlungen einrichten"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Wenn du eine finale Bestätigungsmöglichkeit beim Senden einer Zahlung möchtest:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/en/resources/user-guides/weblate/monero-wallet-cli.pot
+++ b/_i18n/en/resources/user-guides/weblate/monero-wallet-cli.pot
@@ -3,379 +3,365 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:09+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:2
+#, markdown-text
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
+#, markdown-text
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, markdown-text
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, markdown-text, no-wrap
+msgid "Overview"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+#, markdown-text
+msgid "You can have a list of the most important commands by running `help`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
 #, no-wrap
 msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-#, no-wrap
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, markdown-text, no-wrap
+msgid "Checking your balance"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
+#, markdown-text
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
+#, markdown-text
+msgid "Output:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-#, no-wrap
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
+#, markdown-text
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, markdown-text, no-wrap
+msgid "Sending monero"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+#, markdown-text
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
 msgstr ""
 
-#. type: Plain text
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
 #, no-wrap
-msgid "    address\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+#, markdown-text
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, markdown-text, no-wrap
+msgid "Receiving monero"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
+#, markdown-text
+msgid "If you have your own Monero address, you just need to give your address to someone."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-#, no-wrap
-msgid "    integrated_address\n"
+#, markdown-text
+msgid "You can find out your primary address with:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
 #, no-wrap
-msgid "    integrated_address 12346780abcdef00\n"
+msgid "address\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
-msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+#, markdown-text
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
 #, no-wrap
-msgid "    set store-tx-info 1\n"
+msgid ""
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, markdown-text
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, no-wrap
+msgid "integrated_address 82d79055f3b27f56\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
+#, markdown-text
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr ""
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, markdown-text, no-wrap
+msgid "Using subaddresses"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+#, markdown-text
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
 #, no-wrap
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+#, markdown-text
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
 #, no-wrap
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "address new github_donations\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+#, markdown-text
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+#, markdown-text
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
+#, no-wrap
+msgid "address all\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-#, no-wrap
-msgid "    set always-confirm-transfers 1\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-#, no-wrap
-msgid "    payments PAYMENTID\n"
+#, markdown-text, no-wrap
+msgid "Proving to a third party you paid someone"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
-msgid "You can give more than one payment ID too."
+#, markdown-text
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
-msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
 #, no-wrap
-msgid "    show_transfers\n"
+msgid "set store-tx-info 1\n"
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+#, markdown-text
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
 #, no-wrap
-msgid "    show_transfers in 650000\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
-msgid "If you want to mine, you can do so from the wallet:"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-#, no-wrap
-msgid "    start_mining 2\n"
+#, markdown-text
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
+#, markdown-text
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, no-wrap
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, markdown-text
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, markdown-text, no-wrap
+msgid "How to find a payment to you"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+#, markdown-text
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
 #, no-wrap
-msgid "    stop_mining\n"
+msgid "payments PAYMENTID\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
+#, markdown-text
+msgid "You can give more than one payment ID too."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
+#, markdown-text
+msgid "More generally, you can review incoming and outgoing payments:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, no-wrap
+msgid "show_transfers\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+#, markdown-text
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, no-wrap
+msgid "show_transfers in 650000\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+#, markdown-text
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
+#, markdown-text
+msgid "If you want to mine, you can do so from the wallet:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, no-wrap
+msgid "start_mining 2\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+#, markdown-text
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, no-wrap
+msgid "stop_mining\n"
 msgstr ""

--- a/_i18n/es/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/es/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,214 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` es el software de monedero que viene con el árbol de Monero. Es un programa de consola,
-y administra una cuenta. Mientras que un monedero de Bitcoin administra ambos, cuenta y blockchain,
-Monero separa estos: `monerod` maneja la blockchain, y `monero-wallet-cli` la cuenta.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-Esta guía mostrará cómo realizar varias operaciones desde la interfaz de usuario `monero-wallet-cli`. Esta guía asume que estás versión más reciente de Monero y que ya has creado una cuenta conforme a las demás guías.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## Revisando tu balance
+You can have a list of the most important commands by running `help`:
 
-Ya que el manejo de la blockchain y del monedero son programas separados, varios usos de `monero-wallet-cli`
-necesitan trabajar con el daemon. Esto incluye buscar por transacciones de entrada a tu dirección.
-Una vez que estés ejecutando `monero-wallet-cli` y `monerod`, escribe `balance`.
+```
+Important commands:
 
-Ejemplo:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-Esto sacará bloques del daemon que el monedero aún no ve, y actualizará tu balance para
-que coincidan. Este proceso será normalmente realizado en segundo plano más o menos cada minuto. Para ver tu
-balance sin refrescar:
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"donate <amount>" - Donate XMR to the development team.
+```
 
-En este ejemplo, `Balance` es tu balance total. El `unlocked balance` es la cantidad actualmente disponible para gastar. Transacciones recientemente recibidas requieren 10 confirmaciones en la blockchain antes de ser desbloqueadas. `unlocked dust` se refiere a muy pequeñas cantidades de salidas sin gastar que se pueden haber acumulado en tu cuenta.
+## Checking your balance
 
-## Enviando Monero
+Ya que el manejo de la blockchain y del monedero son programas separados,
+varios usos de `monero-wallet-cli` necesitan trabajar con el daemon. Esto
+incluye buscar por transacciones de entrada a tu dirección.  Una vez que
+estés ejecutando `monero-wallet-cli` y `monerod`, escribe `balance`.
 
-Necesitarás la dirección estándar a la que quieres enviar (una larga cadena que comienza con '4'), y
-posiblemente un ID de pago, si el receptor requiere uno. En ese último caso, el receptor
-te debería dar una dirección integrada, que es la combinación de ambas en una dirección individual.
+Output:
 
-### Enviando a una dirección estándar:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-Reemplaza `ADDRESS` con la dirección a la que deseas enviar, `AMOUNT` con cuánto Monero quieres enviar,
-y `PAYMENTID` con el ID de pago que fuiste provisto. Los ID de pago son opcionales. Si el la parte receptora no requiere uno,
-sólo omítelo.
+## Sending monero
 
-### Enviando a una dirección integrada:
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-    transfer ADDRESS AMOUNT
+```
+transfer ADDRESS AMOUNT
+```
 
-El ID de pago está implícito en la dirección integrada en este caso.
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-### Especificar el número de salidas para una transacción:
+## Receiving monero
 
-    transfer RINGSIZE ADDRESS AMOUNT
+If you have your own Monero address, you just need to give your address to
+someone.
 
-Reemplaza `RINGSIZE` con el número de salidas que deseas utilizar. **Si no se especifica, el valor por defecto es 11.** Es una buena idea utilizar el valor por defecto, pero puedes incrementar el número si quieres incluir más salidas. Entre más alto el número, más grande es la transacción, y se requerirá más comisión.
+You can find out your primary address with:
 
+```
+address
+```
 
-## Recibiendo Monero
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-Si tienes tu propia dirección de Monero, sólo necesitas dar tu dirección estándar a alguien.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Puedes encontrar tu dirección con:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-Ya que Monero es anónimo, no podrás ver la dirección de origen de donde recibes fondos. Si
-quieres saber, por ejemplo, cómo acreditar a un cliente en particular, tendrás que decir al emisor que utilice un
-ID de pago, que es una etiqueta arbitraria opcional que se adjunta a una transacción. Para facilitar
-las cosas, puedes generar una dirección que ya incluya un ID de pago aleatorio:
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-Esto generará un ID de pago aleatorio, y te dará la dirección que incluye tu propia cuenta y el
-ID de pago. Si quieres seleccionar un ID de pago en particular, puedes hacerlo también:
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-Pagos realizados a una dirección integrada generada desde tu cuenta irán a tu cuenta,
-con el ID de pago adjunto, así podrás diferenciar pagos.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## Probando a un tercero que pagaste a alguien
+will generate a subaddress and its label 'github_donations'.
 
-Si pagas a un comerciante, y el comerciante reclama que no ha recibido el pago, puedes necesitar
-probar a un tercero que sí enviaste los fondos, o incluso al comerciante, si es que es un error
-honesto. Monero es privado, así que no puedes simplemente indicar tu transacción en la blockchain,
-tampoco puedes saber quién la envió, ni quién la recibió. No obstante, proveyendo la llave privada
-por transacción a una parte, esa parte puede saber si esa transacción envió Monero a esa
-dirección en particular. Ten en cuenta que guardar estas llaves privadas por transacción está desactivado por defecto, y
-tendrás que activarlo antes de enviar, si crees que lo puedes necesitar:
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Si pagas a un comerciante, y el comerciante reclama que no ha recibido el
+pago, puedes necesitar probar a un tercero que sí enviaste los fondos, o
+incluso al comerciante, si es que es un error honesto. Monero es privado,
+así que no puedes simplemente indicar tu transacción en la blockchain,
+tampoco puedes saber quién la envió, ni quién la recibió. No obstante,
+proveyendo la llave privada por transacción a una parte, esa parte puede
+saber si esa transacción envió Monero a esa dirección en particular. Ten en
+cuenta que guardar estas llaves privadas por transacción está desactivado
+por defecto, y tendrás que activarlo antes de enviar, si crees que lo puedes
+necesitar:
+
+```
+set store-tx-info 1
+```
 
 Puedes recuperar la llave tx de una transacción anterior:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Coloca el ID de la transacción del cual quieres la llave. Recuerda que un pago puede haber sido
-dividido en más de una transacción, así que puedes necesitar varias llaves. Puedes enviar esa llave,
-o llaves, a quien quieras proveer con pruebas de tu transacción, junto con los
-ID de transacción y la dirección a la que enviaste. Ten en cuenta que este tercero, si conoce tu
+Coloca el ID de la transacción del cual quieres la llave. Recuerda que un
+pago puede haber sido dividido en más de una transacción, así que puedes
+necesitar varias llaves. Puedes enviar esa llave, o llaves, a quien quieras
+proveer con pruebas de tu transacción, junto con los ID de transacción y la
+dirección a la que enviaste. Ten en cuenta que este tercero, si conoce tu
 dirección, será capaz de ver cuánto cambio regresó a tu cuenta también.
 
 Si tú eres el tercero (esto es, alguien quiere probarte que enviaron Monero
 a una dirección), entonces puedes revisarlo de esta forma:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Reemplaza `TXID`, `TXKEY` y `ADDRESS` con el ID de transacción, la llave por transacción y la dirección
-de destino que te fueron provistas respectivamente. monero-wallet-cli revisará esa transacción
-y te hará saber cuánto monero pagó esta transacción a la dirección dada.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
+## How to find a payment to you
 
-## Obtener una oportunidad para confirmar/cancelar pagos
+Si recibiste un pago utilizando un ID de pago en particular, puedes verlo
+con:
 
-Si deseas obtener una última oportunidad de confirmación al enviar un pago:
-
-    set always-confirm-transfers 1
-
-
-## Cómo encontrar un pago
-
-Si recibiste un pago utilizando un ID de pago en particular, puedes verlo con:
-
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 Puedes dar más de un ID de pago también.
 
 De manera más general, puedes revisar pagos de entrada y salida:
 
-    show_transfers
+```
+show_transfers
+```
 
-Puedes dar una altura opcional para listar sólo transacciones recientes, y solicitar
-solamente transacciones de entrada o salida. Por ejemplo,
+Puedes dar una altura opcional para listar sólo transacciones recientes, y
+solicitar solamente transacciones de entrada o salida. Por ejemplo,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-sólo mostrará transacciones de entrada después del block 650000. También puedes dar
-un rango de altura.
+sólo mostrará transacciones de entrada después del block 650000. También
+puedes dar un rango de altura.
 
 Si quieres minar, puedes hacerlo desde tu monedero:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Esto empezará a minar en el daemon utilizando dos subprocesos. Ten en cuenta que esto es minado en solitario,
-y puede tomar un tiempo en encontrar un bloque. Para detener el minado:
+Esto empezará a minar en el daemon utilizando dos subprocesos. Ten en cuenta
+que esto es minado en solitario, y puede tomar un tiempo en encontrar un
+bloque. Para detener el minado:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/es/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/es/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:19+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,425 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` es el software de monedero que viene con el árbol de "
-"Monero. Es un programa de consola, y administra una cuenta. Mientras que un "
-"monedero de Bitcoin administra ambos, cuenta y blockchain, Monero separa "
-"estos: `monerod` maneja la blockchain, y `monero-wallet-cli` la cuenta."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` es el software de monedero que viene con el árbol de Monero. Es un programa de consola, y administra una cuenta. Mientras que un monedero de Bitcoin administra ambos, cuenta y blockchain, Monero separa estos: `monerod` maneja la blockchain, y `monero-wallet-cli` la cuenta."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "Esta guía mostrará cómo realizar varias operaciones desde la interfaz de usuario `monero-wallet-cli`. Esta guía asume que estás versión más reciente de Monero y que ya has creado una cuenta conforme a las demás guías."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"Esta guía mostrará cómo realizar varias operaciones desde la interfaz de "
-"usuario `monero-wallet-cli`. Esta guía asume que estás versión más reciente "
-"de Monero y que ya has creado una cuenta conforme a las demás guías."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Revisando tu balance"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Ya que el manejo de la blockchain y del monedero son programas separados, "
-"varios usos de `monero-wallet-cli` necesitan trabajar con el daemon. Esto "
-"incluye buscar por transacciones de entrada a tu dirección.  Una vez que "
-"estés ejecutando `monero-wallet-cli` y `monerod`, escribe `balance`."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Ejemplo:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Esto sacará bloques del daemon que el monedero aún no ve, y actualizará tu "
-"balance para que coincidan. Este proceso será normalmente realizado en "
-"segundo plano más o menos cada minuto. Para ver tu balance sin refrescar:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"En este ejemplo, `Balance` es tu balance total. El `unlocked balance` es la "
-"cantidad actualmente disponible para gastar. Transacciones recientemente "
-"recibidas requieren 10 confirmaciones en la blockchain antes de ser "
-"desbloqueadas. `unlocked dust` se refiere a muy pequeñas cantidades de "
-"salidas sin gastar que se pueden haber acumulado en tu cuenta."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Enviando Monero"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Necesitarás la dirección estándar a la que quieres enviar (una larga cadena "
-"que comienza con '4'), y posiblemente un ID de pago, si el receptor requiere "
-"uno. En ese último caso, el receptor te debería dar una dirección integrada, "
-"que es la combinación de ambas en una dirección individual."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### Enviando a una dirección estándar:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Reemplaza `ADDRESS` con la dirección a la que deseas enviar, `AMOUNT` con "
-"cuánto Monero quieres enviar, y `PAYMENTID` con el ID de pago que fuiste "
-"provisto. Los ID de pago son opcionales. Si el la parte receptora no "
-"requiere uno, sólo omítelo."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### Enviando a una dirección integrada:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Ya que el manejo de la blockchain y del monedero son programas separados, varios usos de `monero-wallet-cli` necesitan trabajar con el daemon. Esto incluye buscar por transacciones de entrada a tu dirección.  Una vez que estés ejecutando `monero-wallet-cli` y `monerod`, escribe `balance`."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADDRESS AMOUNT\n"
+msgid "Output:"
+msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr "El ID de pago está implícito en la dirección integrada en este caso."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Especificar el número de salidas para una transacción:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Reemplaza `RINGSIZE` con el número de salidas que deseas utilizar. **Si no "
-"se especifica, el valor por defecto es 11.** Es una buena idea utilizar el "
-"valor por defecto, pero puedes incrementar el número si quieres incluir más "
-"salidas. Entre más alto el número, más grande es la transacción, y se "
-"requerirá más comisión."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "En este ejemplo, `Balance` es tu balance total. El `unlocked balance` es la cantidad actualmente disponible para gastar. Transacciones recientemente recibidas requieren 10 confirmaciones en la blockchain antes de ser desbloqueadas. `unlocked dust` se refiere a muy pequeñas cantidades de salidas sin gastar que se pueden haber acumulado en tu cuenta."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Enviando Monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADDRESS AMOUNT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Recibiendo Monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Si tienes tu propia dirección de Monero, sólo necesitas dar tu dirección "
-"estándar a alguien."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Puedes encontrar tu dirección con:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"Ya que Monero es anónimo, no podrás ver la dirección de origen de donde "
-"recibes fondos. Si quieres saber, por ejemplo, cómo acreditar a un cliente "
-"en particular, tendrás que decir al emisor que utilice un ID de pago, que es "
-"una etiqueta arbitraria opcional que se adjunta a una transacción. Para "
-"facilitar las cosas, puedes generar una dirección que ya incluya un ID de "
-"pago aleatorio:"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Si tienes tu propia dirección de Monero, sólo necesitas dar tu dirección estándar a alguien."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Puedes encontrar tu dirección con:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Esto generará un ID de pago aleatorio, y te dará la dirección que incluye tu "
-"propia cuenta y el ID de pago. Si quieres seleccionar un ID de pago en "
-"particular, puedes hacerlo también:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "Ya que Monero es anónimo, no podrás ver la dirección de origen de donde recibes fondos. Si quieres saber, por ejemplo, cómo acreditar a un cliente en particular, tendrás que decir al emisor que utilice un ID de pago, que es una etiqueta arbitraria opcional que se adjunta a una transacción. Para facilitar las cosas, puedes generar una dirección que ya incluya un ID de pago aleatorio:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"Pagos realizados a una dirección integrada generada desde tu cuenta irán a "
-"tu cuenta, con el ID de pago adjunto, así podrás diferenciar pagos."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Probando a un tercero que pagaste a alguien"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Esto generará un ID de pago aleatorio, y te dará la dirección que incluye tu propia cuenta y el ID de pago. Si quieres seleccionar un ID de pago en particular, puedes hacerlo también:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Si pagas a un comerciante, y el comerciante reclama que no ha recibido el "
-"pago, puedes necesitar probar a un tercero que sí enviaste los fondos, o "
-"incluso al comerciante, si es que es un error honesto. Monero es privado, "
-"así que no puedes simplemente indicar tu transacción en la blockchain, "
-"tampoco puedes saber quién la envió, ni quién la recibió. No obstante, "
-"proveyendo la llave privada por transacción a una parte, esa parte puede "
-"saber si esa transacción envió Monero a esa dirección en particular. Ten en "
-"cuenta que guardar estas llaves privadas por transacción está desactivado "
-"por defecto, y tendrás que activarlo antes de enviar, si crees que lo puedes "
-"necesitar:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Puedes recuperar la llave tx de una transacción anterior:"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "Pagos realizados a una dirección integrada generada desde tu cuenta irán a tu cuenta, con el ID de pago adjunto, así podrás diferenciar pagos."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Coloca el ID de la transacción del cual quieres la llave. Recuerda que un "
-"pago puede haber sido dividido en más de una transacción, así que puedes "
-"necesitar varias llaves. Puedes enviar esa llave, o llaves, a quien quieras "
-"proveer con pruebas de tu transacción, junto con los ID de transacción y la "
-"dirección a la que enviaste. Ten en cuenta que este tercero, si conoce tu "
-"dirección, será capaz de ver cuánto cambio regresó a tu cuenta también."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Si tú eres el tercero (esto es, alguien quiere probarte que enviaron Monero "
-"a una dirección), entonces puedes revisarlo de esta forma:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Reemplaza `TXID`, `TXKEY` y `ADDRESS` con el ID de transacción, la llave por "
-"transacción y la dirección de destino que te fueron provistas "
-"respectivamente. monero-wallet-cli revisará esa transacción y te hará saber "
-"cuánto monero pagó esta transacción a la dirección dada."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Obtener una oportunidad para confirmar/cancelar pagos"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr "Si deseas obtener una última oportunidad de confirmación al enviar un pago:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Cómo encontrar un pago"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Si recibiste un pago utilizando un ID de pago en particular, puedes verlo "
-"con:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Probando a un tercero que pagaste a alguien"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Si pagas a un comerciante, y el comerciante reclama que no ha recibido el pago, puedes necesitar probar a un tercero que sí enviaste los fondos, o incluso al comerciante, si es que es un error honesto. Monero es privado, así que no puedes simplemente indicar tu transacción en la blockchain, tampoco puedes saber quién la envió, ni quién la recibió. No obstante, proveyendo la llave privada por transacción a una parte, esa parte puede saber si esa transacción envió Monero a esa dirección en particular. Ten en cuenta que guardar estas llaves privadas por transacción está desactivado por defecto, y tendrás que activarlo antes de enviar, si crees que lo puedes necesitar:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Puedes recuperar la llave tx de una transacción anterior:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Coloca el ID de la transacción del cual quieres la llave. Recuerda que un pago puede haber sido dividido en más de una transacción, así que puedes necesitar varias llaves. Puedes enviar esa llave, o llaves, a quien quieras proveer con pruebas de tu transacción, junto con los ID de transacción y la dirección a la que enviaste. Ten en cuenta que este tercero, si conoce tu dirección, será capaz de ver cuánto cambio regresó a tu cuenta también."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Si tú eres el tercero (esto es, alguien quiere probarte que enviaron Monero a una dirección), entonces puedes revisarlo de esta forma:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Reemplaza `TXID`, `TXKEY` y `ADDRESS` con el ID de transacción, la llave por transacción y la dirección de destino que te fueron provistas respectivamente. monero-wallet-cli revisará esa transacción y te hará saber cuánto monero pagó esta transacción a la dirección dada."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Cómo encontrar un pago"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Si recibiste un pago utilizando un ID de pago en particular, puedes verlo con:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Puedes dar más de un ID de pago también."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
 msgstr "De manera más general, puedes revisar pagos de entrada y salida:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Puedes dar una altura opcional para listar sólo transacciones recientes, y "
-"solicitar solamente transacciones de entrada o salida. Por ejemplo,"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Puedes dar una altura opcional para listar sólo transacciones recientes, y solicitar solamente transacciones de entrada o salida. Por ejemplo,"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"sólo mostrará transacciones de entrada después del block 650000. También "
-"puedes dar un rango de altura."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "sólo mostrará transacciones de entrada después del block 650000. También puedes dar un rango de altura."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "Si quieres minar, puedes hacerlo desde tu monedero:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Esto empezará a minar en el daemon utilizando dos subprocesos. Ten en cuenta "
-"que esto es minado en solitario, y puede tomar un tiempo en encontrar un "
-"bloque. Para detener el minado:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Esto empezará a minar en el daemon utilizando dos subprocesos. Ten en cuenta que esto es minado en solitario, y puede tomar un tiempo en encontrar un bloque. Para detener el minado:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Ejemplo:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Esto sacará bloques del daemon que el monedero aún no ve, y actualizará tu balance para que coincidan. Este proceso será normalmente realizado en segundo plano más o menos cada minuto. Para ver tu balance sin refrescar:"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Necesitarás la dirección estándar a la que quieres enviar (una larga cadena que comienza con '4'), y posiblemente un ID de pago, si el receptor requiere uno. En ese último caso, el receptor te debería dar una dirección integrada, que es la combinación de ambas en una dirección individual."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### Enviando a una dirección estándar:"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Reemplaza `ADDRESS` con la dirección a la que deseas enviar, `AMOUNT` con cuánto Monero quieres enviar, y `PAYMENTID` con el ID de pago que fuiste provisto. Los ID de pago son opcionales. Si el la parte receptora no requiere uno, sólo omítelo."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### Enviando a una dirección integrada:"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "El ID de pago está implícito en la dirección integrada en este caso."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Especificar el número de salidas para una transacción:"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Reemplaza `RINGSIZE` con el número de salidas que deseas utilizar. **Si no se especifica, el valor por defecto es 11.** Es una buena idea utilizar el valor por defecto, pero puedes incrementar el número si quieres incluir más salidas. Entre más alto el número, más grande es la transacción, y se requerirá más comisión."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Obtener una oportunidad para confirmar/cancelar pagos"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Si deseas obtener una última oportunidad de confirmación al enviar un pago:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/fr/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/fr/resources/user-guides/monero-wallet-cli.md
@@ -1,154 +1,221 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` est une application de portefeuille qui est incluse dans la suite Monero. C'est un
-programme en ligne de commandes qui permet de gérer un compte. Tandis que le portefeuille Bitcoin
-gère à la fois un compte et la chaîne de bloc, Monero sépare ces deux composants : `monerod`
-s'occupe de la chaîne de blocs, et `monero-wallet-cli` gère le compte.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-Ce guide montrera comment effectuer diverses opération depuis l'interface de `monero-wallet-cli`. Ce guide suppose que vous utilisiez la version la plus récenter de Monero et que vous ayez déjà créé un compte comme exposé dans l'autre guide.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## Vérifier votre solde
+You can have a list of the most important commands by running `help`:
 
-Dans la mesure ou la gestion de la chaîne de blocs et le portefeuille sont des applications séparées,
-de nombreux usages de `monero-wallet-cli` implique de fonctionner avec le démon. Incluant la
-vérifications des transactions entrantes sur votre adresse. Une fois que `monero-wallet-cli` et
-`monerod` sont tous deux en cours d'exécution, entrez `balance`.
+```
+Important commands:
 
-Exemple :
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-Ceci récupèrera depuis le démon les blocs que le portefeuille n'a pas encore vu, et mettra à jour
-votre solde. Ce processus est normalement réalisé en tache de fond environ toutes les minutes.
-Pour voir votre balance sans rafraichir :
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"donate <amount>" - Donate XMR to the development team.
+```
 
-Dans cette exemple, `Balance` correspond à votre solde total. `unlocked balance` est le montant actuellement disponible pour être dépensé. Les nouvelles transactions reçues nécessitent 10 confirmations sur la chaîne de blocs avant d'être débloquées. `unlocked dust` corresponds à de très faible montants de sorties non dépensées qui ont pu s'accumuler sur votre compte.
+## Checking your balance
 
-## Envoyer des Moneroj
+Dans la mesure ou la gestion de la chaîne de blocs et le portefeuille sont
+des applications séparées, de nombreux usages de `monero-wallet-cli`
+implique de fonctionner avec le démon. Incluant la vérifications des
+transactions entrantes sur votre adresse. Une fois que `monero-wallet-cli`
+et `monerod` sont tous deux en cours d'exécution, entrez `balance`.
 
-Vous aurez besoin de l'adresse standard à laquelle vous comptez envoyer (une longue chaine de
-caractères commençant par '4') et potentiellement un ID de paiement, si le destinataire vous en
-demande un. Dans ce dernier cas, celui-ci pourrait vous donner une adresse intégrée, qui contient
-les deux dans une seule et même adresse.
+Output:
 
-### Envoyer à une adresse standard :
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    transfer ADRESSE MONTANT IDdePAIEMENT
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-Remplacez `ADRESSE` avec l'adresse à laquelle vous souhaitez envoyer, `MONTANT` avec le montant que vous souhaitez
-envoyer et `IDdePAIEMENT` avec l'ID de paiement qui vous a été fournit. L'ID de paiement est optionnel. Si le
-destinataire ne vous en a pas fournit, n'en indiquez pas.
+## Sending monero
 
-### Envoyer à une adresse intégrée :
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-    transfer ADRESSE MONTANT
+```
+transfer ADDRESS AMOUNT
+```
 
-Dans ce cas, l'ID de paiement est implicitement inclus dans l'adresse intégrée.
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-### Indiquer le nombre de sorties pour une transaction :
+## Receiving monero
 
-    transfer RINGSIZE ADRESSE MONTANT
+If you have your own Monero address, you just need to give your address to
+someone.
 
-Remplacez `RINGSIZE` avec le nombre de sorties que vous souhaitez utiliser. **S'il n'est pas spécifié, la valeur par défaut est 11.** C'est une bonne idée d'utiliser la valeur par défaut, mais vous pouvez augmenter celle-ci pour inclure plus de sorties. Plus grand est le nombre, plus grosse sera la transaction, nécessitant des frais plus importants.
+You can find out your primary address with:
 
+```
+address
+```
 
-## Recevoir des moneroj
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-Si vous avez votre propre adresse Monero, vous devez simplement communiquer à quelqu'un votre adresse standard.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Vous pouvez trouver votre adresse standard avec :
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-Comme Monero est anonyme, vous ne verrez pas l'adresse à partir de laquelle les fonds vous sont envoyés.
-Si vous voulez le savoir, par exemple pour créditer un client particulier, vous devrez indiquer à
-l'émetteur d'utiliser un ID de paiement, qui est une étiquette optionnelle et arbitraire qui sera
-associé à la transaction. Pour vous faciliter la vie, vous pouvez générer une adresse qui inclus déjà
-un ID de paiement aléatoire.
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-Cela va générer un ID de paiement aléatoire et vous fournir l'adresse qui inclus votre propre compte
-et cet ID de paiement. Si vous voulez sélectionner un ID de paiement particulier, vous pouvez aussi
-faire :
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-Les paiements effectués sur une adresse intégrée générée depuis votre compte iront sur votre compte,
-avec cet ID de paiement associé, vous permettant de distinguer les paiements.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## Prouver à un tiers que vous avez payé quelqu'un
+will generate a subaddress and its label 'github_donations'.
 
-Si vous payez un commerçants, et que celui-ci prétends qu'il n'a pas reçu les fonds, vous pourriez
-avoir besoin de prouver à un tiers que vous avez bien envoyé les fonds (ou même au commerçants,
-s'il s'agit d'une erreur honnête). Monero est confidentiel, de sorte que vous ne pouvez pas
-simplement indiquer votre transaction dans la chaîne de blocs, dans la mesure où vous ne pouvez ni
-dire qui l'a envoyé, ni qui l'a reçu. Cependant, en fournissant la clef privée propre à la
-transaction à un tiers, celui-ci peut dire si la transaction à envoyé des moneroj à cette adresse
-particulière. Notez que la conservation des clefs privées propres aux transactions est désactivé
-par défaut, et que vous aurez à l'activer avant l'envoie, si vous pensez que vous pourriez en avoir
-besoin :
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Si vous payez un commerçants, et que celui-ci prétends qu'il n'a pas reçu
+les fonds, vous pourriez avoir besoin de prouver à un tiers que vous avez
+bien envoyé les fonds (ou même au commerçants, s'il s'agit d'une erreur
+honnête). Monero est confidentiel, de sorte que vous ne pouvez pas
+simplement indiquer votre transaction dans la chaîne de blocs, dans la
+mesure où vous ne pouvez ni dire qui l'a envoyé, ni qui l'a reçu. Cependant,
+en fournissant la clef privée propre à la transaction à un tiers, celui-ci
+peut dire si la transaction à envoyé des moneroj à cette adresse
+particulière. Notez que la conservation des clefs privées propres aux
+transactions est désactivé par défaut, et que vous aurez à l'activer avant
+l'envoie, si vous pensez que vous pourriez en avoir besoin :
+
+```
+set store-tx-info 1
+```
 
 Vous pouvez récupérer la clef tx d'une précédente transaction :
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Indiquez l'ID de transaction dont vous voulez la clef. Souvenez vous qu'un paiement peut avoir
-été scindé en plusieurs transactions, donc vous pourriez avoir besoin de plusieurs clefs. Vous
-pourrez alors envoyer cette clef, ou ces clefs, à quiconque vous fournira la preuve de votre
-transaction, accompagné de l'ID de transaction et de l'adresse à laquelle vous avez envoyé les
-fonds. Notez que ce tiers, s'il connaît votre propre adresse, sera également en mesure de voir
-quelle quantité de monnaie vous aurait été rendue.
+Indiquez l'ID de transaction dont vous voulez la clef. Souvenez vous qu'un
+paiement peut avoir été scindé en plusieurs transactions, donc vous pourriez
+avoir besoin de plusieurs clefs. Vous pourrez alors envoyer cette clef, ou
+ces clefs, à quiconque vous fournira la preuve de votre transaction,
+accompagné de l'ID de transaction et de l'adresse à laquelle vous avez
+envoyé les fonds. Notez que ce tiers, s'il connaît votre propre adresse,
+sera également en mesure de voir quelle quantité de monnaie vous aurait été
+rendue.
 
-Si vous êtes le tiers (c'est à dire que quelqu'un veut vous prouver qu'il a effectivement envoyé
-des moneroj à une adresse), vous pouvez le vérifier comme suit :
+Si vous êtes le tiers (c'est à dire que quelqu'un veut vous prouver qu'il a
+effectivement envoyé des moneroj à une adresse), vous pouvez le vérifier
+comme suit :
 
-    check_tx_key IDTX CLEFTX ADRESSE
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Remplacez `IDTX`, `CLEFTX` et `ADRESSE` respectivement par l'ID de transaction, la clef propre
-à la transaction et l'adresse de destination qui vous ont été communiqués. monero-wallet-cli va
-vérifier cette transaction et vous indiquera combien de moneroj ont été payés à l'adresse fournie.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
+## How to find a payment to you
 
-## Pouvoir confirmer ou annuler des paiements
+Si vous recevez un paiement utilisant un ID de paiement précis, vous pouvez
+le rechercher :
 
-Si vous souhaitez devoir confirmer les paiements que vous envoyez :
-
-    set always-confirm-transfers 1
-
-
-## Comment retrouver un paiement qui vous a été fait
-
-Si vous recevez un paiement utilisant un ID de paiement précis, vous pouvez le rechercher :
-
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 Vous pouvez également fournir plus d'un ID de paiement.
 
 Plus généralement, vous pouvez examiner les paiements reçus et envoyés :
 
-    show_transfers
+```
+show_transfers
+```
 
-Vous pouvez indiquer une hauteur de bloc optionnelle pour ne lister que les transactions
-récentes, et ne demander que les transactions entrantes ou sortantes. Par exemple,
+Vous pouvez indiquer une hauteur de bloc optionnelle pour ne lister que les
+transactions récentes, et ne demander que les transactions entrantes ou
+sortantes. Par exemple,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-ne vous montrera que les transferts reçus après le block 650000. Vous pouvez également
-fournir une plage de hauteur de bloc.
+ne vous montrera que les transferts reçus après le block 650000. Vous pouvez
+également fournir une plage de hauteur de bloc.
 
 Si vous voulez miner, vous pouvez le faire depuis le portefeuille :
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Cela va démarrer l'extraction minière sur le démon en utilisant deux threads. Notez qu'il s'agit
-d'extraction minière en solo, et qu'il pourrait falloir un moment avant que vous ne trouviez un
-bloc. Pour arrêter l'extraction minière :
+Cela va démarrer l'extraction minière sur le démon en utilisant deux
+threads. Notez qu'il s'agit d'extraction minière en solo, et qu'il pourrait
+falloir un moment avant que vous ne trouviez un bloc. Pour arrêter
+l'extraction minière :
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/fr/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/fr/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:19+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,439 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` est une application de portefeuille qui est incluse dans "
-"la suite Monero. C'est un programme en ligne de commandes qui permet de "
-"gérer un compte. Tandis que le portefeuille Bitcoin gère à la fois un compte "
-"et la chaîne de bloc, Monero sépare ces deux composants : `monerod` s'occupe "
-"de la chaîne de blocs, et `monero-wallet-cli` gère le compte."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` est une application de portefeuille qui est incluse dans la suite Monero. C'est un programme en ligne de commandes qui permet de gérer un compte. Tandis que le portefeuille Bitcoin gère à la fois un compte et la chaîne de bloc, Monero sépare ces deux composants : `monerod` s'occupe de la chaîne de blocs, et `monero-wallet-cli` gère le compte."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "Ce guide montrera comment effectuer diverses opération depuis l'interface de `monero-wallet-cli`. Ce guide suppose que vous utilisiez la version la plus récenter de Monero et que vous ayez déjà créé un compte comme exposé dans l'autre guide."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"Ce guide montrera comment effectuer diverses opération depuis l'interface de "
-"`monero-wallet-cli`. Ce guide suppose que vous utilisiez la version la plus "
-"récenter de Monero et que vous ayez déjà créé un compte comme exposé dans "
-"l'autre guide."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Vérifier votre solde"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Dans la mesure ou la gestion de la chaîne de blocs et le portefeuille sont "
-"des applications séparées, de nombreux usages de `monero-wallet-cli` "
-"implique de fonctionner avec le démon. Incluant la vérifications des "
-"transactions entrantes sur votre adresse. Une fois que `monero-wallet-cli` "
-"et `monerod` sont tous deux en cours d'exécution, entrez `balance`."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Exemple :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Ceci récupèrera depuis le démon les blocs que le portefeuille n'a pas encore "
-"vu, et mettra à jour votre solde. Ce processus est normalement réalisé en "
-"tache de fond environ toutes les minutes.  Pour voir votre balance sans "
-"rafraichir :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"Dans cette exemple, `Balance` correspond à votre solde total. `unlocked "
-"balance` est le montant actuellement disponible pour être dépensé. Les "
-"nouvelles transactions reçues nécessitent 10 confirmations sur la chaîne de "
-"blocs avant d'être débloquées. `unlocked dust` corresponds à de très faible "
-"montants de sorties non dépensées qui ont pu s'accumuler sur votre compte."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Envoyer des Moneroj"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Vous aurez besoin de l'adresse standard à laquelle vous comptez envoyer (une "
-"longue chaine de caractères commençant par '4') et potentiellement un ID de "
-"paiement, si le destinataire vous en demande un. Dans ce dernier cas, "
-"celui-ci pourrait vous donner une adresse intégrée, qui contient les deux "
-"dans une seule et même adresse."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### Envoyer à une adresse standard :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADRESSE MONTANT IDdePAIEMENT\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Remplacez `ADRESSE` avec l'adresse à laquelle vous souhaitez envoyer, "
-"`MONTANT` avec le montant que vous souhaitez envoyer et `IDdePAIEMENT` avec "
-"l'ID de paiement qui vous a été fournit. L'ID de paiement est optionnel. Si "
-"le destinataire ne vous en a pas fournit, n'en indiquez pas."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### Envoyer à une adresse intégrée :"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Dans la mesure ou la gestion de la chaîne de blocs et le portefeuille sont des applications séparées, de nombreux usages de `monero-wallet-cli` implique de fonctionner avec le démon. Incluant la vérifications des transactions entrantes sur votre adresse. Une fois que `monero-wallet-cli` et `monerod` sont tous deux en cours d'exécution, entrez `balance`."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADRESSE MONTANT\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
+msgid "Output:"
 msgstr ""
-"Dans ce cas, l'ID de paiement est implicitement inclus dans l'adresse "
-"intégrée."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Indiquer le nombre de sorties pour une transaction :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADRESSE MONTANT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Remplacez `RINGSIZE` avec le nombre de sorties que vous souhaitez "
-"utiliser. **S'il n'est pas spécifié, la valeur par défaut est 11.** C'est "
-"une bonne idée d'utiliser la valeur par défaut, mais vous pouvez augmenter "
-"celle-ci pour inclure plus de sorties. Plus grand est le nombre, plus grosse "
-"sera la transaction, nécessitant des frais plus importants."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "Dans cette exemple, `Balance` correspond à votre solde total. `unlocked balance` est le montant actuellement disponible pour être dépensé. Les nouvelles transactions reçues nécessitent 10 confirmations sur la chaîne de blocs avant d'être débloquées. `unlocked dust` corresponds à de très faible montants de sorties non dépensées qui ont pu s'accumuler sur votre compte."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Envoyer des Moneroj"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADRESSE MONTANT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Recevoir des moneroj"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Si vous avez votre propre adresse Monero, vous devez simplement communiquer "
-"à quelqu'un votre adresse standard."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Vous pouvez trouver votre adresse standard avec :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"Comme Monero est anonyme, vous ne verrez pas l'adresse à partir de laquelle "
-"les fonds vous sont envoyés.  Si vous voulez le savoir, par exemple pour "
-"créditer un client particulier, vous devrez indiquer à l'émetteur d'utiliser "
-"un ID de paiement, qui est une étiquette optionnelle et arbitraire qui sera "
-"associé à la transaction. Pour vous faciliter la vie, vous pouvez générer "
-"une adresse qui inclus déjà un ID de paiement aléatoire."
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Si vous avez votre propre adresse Monero, vous devez simplement communiquer à quelqu'un votre adresse standard."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Vous pouvez trouver votre adresse standard avec :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Cela va générer un ID de paiement aléatoire et vous fournir l'adresse qui "
-"inclus votre propre compte et cet ID de paiement. Si vous voulez "
-"sélectionner un ID de paiement particulier, vous pouvez aussi faire :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "Comme Monero est anonyme, vous ne verrez pas l'adresse à partir de laquelle les fonds vous sont envoyés.  Si vous voulez le savoir, par exemple pour créditer un client particulier, vous devrez indiquer à l'émetteur d'utiliser un ID de paiement, qui est une étiquette optionnelle et arbitraire qui sera associé à la transaction. Pour vous faciliter la vie, vous pouvez générer une adresse qui inclus déjà un ID de paiement aléatoire."
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"Les paiements effectués sur une adresse intégrée générée depuis votre compte "
-"iront sur votre compte, avec cet ID de paiement associé, vous permettant de "
-"distinguer les paiements."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Prouver à un tiers que vous avez payé quelqu'un"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Cela va générer un ID de paiement aléatoire et vous fournir l'adresse qui inclus votre propre compte et cet ID de paiement. Si vous voulez sélectionner un ID de paiement particulier, vous pouvez aussi faire :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Si vous payez un commerçants, et que celui-ci prétends qu'il n'a pas reçu "
-"les fonds, vous pourriez avoir besoin de prouver à un tiers que vous avez "
-"bien envoyé les fonds (ou même au commerçants, s'il s'agit d'une erreur "
-"honnête). Monero est confidentiel, de sorte que vous ne pouvez pas "
-"simplement indiquer votre transaction dans la chaîne de blocs, dans la "
-"mesure où vous ne pouvez ni dire qui l'a envoyé, ni qui l'a reçu. Cependant, "
-"en fournissant la clef privée propre à la transaction à un tiers, celui-ci "
-"peut dire si la transaction à envoyé des moneroj à cette adresse "
-"particulière. Notez que la conservation des clefs privées propres aux "
-"transactions est désactivé par défaut, et que vous aurez à l'activer avant "
-"l'envoie, si vous pensez que vous pourriez en avoir besoin :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Vous pouvez récupérer la clef tx d'une précédente transaction :"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "Les paiements effectués sur une adresse intégrée générée depuis votre compte iront sur votre compte, avec cet ID de paiement associé, vous permettant de distinguer les paiements."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Indiquez l'ID de transaction dont vous voulez la clef. Souvenez vous qu'un "
-"paiement peut avoir été scindé en plusieurs transactions, donc vous pourriez "
-"avoir besoin de plusieurs clefs. Vous pourrez alors envoyer cette clef, ou "
-"ces clefs, à quiconque vous fournira la preuve de votre transaction, "
-"accompagné de l'ID de transaction et de l'adresse à laquelle vous avez "
-"envoyé les fonds. Notez que ce tiers, s'il connaît votre propre adresse, "
-"sera également en mesure de voir quelle quantité de monnaie vous aurait été "
-"rendue."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Si vous êtes le tiers (c'est à dire que quelqu'un veut vous prouver qu'il a "
-"effectivement envoyé des moneroj à une adresse), vous pouvez le vérifier "
-"comme suit :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key IDTX CLEFTX ADRESSE\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Remplacez `IDTX`, `CLEFTX` et `ADRESSE` respectivement par l'ID de "
-"transaction, la clef propre à la transaction et l'adresse de destination qui "
-"vous ont été communiqués. monero-wallet-cli va vérifier cette transaction et "
-"vous indiquera combien de moneroj ont été payés à l'adresse fournie."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Pouvoir confirmer ou annuler des paiements"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr "Si vous souhaitez devoir confirmer les paiements que vous envoyez :"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Comment retrouver un paiement qui vous a été fait"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Si vous recevez un paiement utilisant un ID de paiement précis, vous pouvez "
-"le rechercher :"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Prouver à un tiers que vous avez payé quelqu'un"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Si vous payez un commerçants, et que celui-ci prétends qu'il n'a pas reçu les fonds, vous pourriez avoir besoin de prouver à un tiers que vous avez bien envoyé les fonds (ou même au commerçants, s'il s'agit d'une erreur honnête). Monero est confidentiel, de sorte que vous ne pouvez pas simplement indiquer votre transaction dans la chaîne de blocs, dans la mesure où vous ne pouvez ni dire qui l'a envoyé, ni qui l'a reçu. Cependant, en fournissant la clef privée propre à la transaction à un tiers, celui-ci peut dire si la transaction à envoyé des moneroj à cette adresse particulière. Notez que la conservation des clefs privées propres aux transactions est désactivé par défaut, et que vous aurez à l'activer avant l'envoie, si vous pensez que vous pourriez en avoir besoin :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Vous pouvez récupérer la clef tx d'une précédente transaction :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Indiquez l'ID de transaction dont vous voulez la clef. Souvenez vous qu'un paiement peut avoir été scindé en plusieurs transactions, donc vous pourriez avoir besoin de plusieurs clefs. Vous pourrez alors envoyer cette clef, ou ces clefs, à quiconque vous fournira la preuve de votre transaction, accompagné de l'ID de transaction et de l'adresse à laquelle vous avez envoyé les fonds. Notez que ce tiers, s'il connaît votre propre adresse, sera également en mesure de voir quelle quantité de monnaie vous aurait été rendue."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Si vous êtes le tiers (c'est à dire que quelqu'un veut vous prouver qu'il a effectivement envoyé des moneroj à une adresse), vous pouvez le vérifier comme suit :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key IDTX CLEFTX ADRESSE\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Remplacez `IDTX`, `CLEFTX` et `ADRESSE` respectivement par l'ID de transaction, la clef propre à la transaction et l'adresse de destination qui vous ont été communiqués. monero-wallet-cli va vérifier cette transaction et vous indiquera combien de moneroj ont été payés à l'adresse fournie."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Comment retrouver un paiement qui vous a été fait"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Si vous recevez un paiement utilisant un ID de paiement précis, vous pouvez le rechercher :"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Vous pouvez également fournir plus d'un ID de paiement."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
 msgstr "Plus généralement, vous pouvez examiner les paiements reçus et envoyés :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Vous pouvez indiquer une hauteur de bloc optionnelle pour ne lister que les "
-"transactions récentes, et ne demander que les transactions entrantes ou "
-"sortantes. Par exemple,"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Vous pouvez indiquer une hauteur de bloc optionnelle pour ne lister que les transactions récentes, et ne demander que les transactions entrantes ou sortantes. Par exemple,"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"ne vous montrera que les transferts reçus après le block 650000. Vous pouvez "
-"également fournir une plage de hauteur de bloc."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "ne vous montrera que les transferts reçus après le block 650000. Vous pouvez également fournir une plage de hauteur de bloc."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "Si vous voulez miner, vous pouvez le faire depuis le portefeuille :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Cela va démarrer l'extraction minière sur le démon en utilisant deux "
-"threads. Notez qu'il s'agit d'extraction minière en solo, et qu'il pourrait "
-"falloir un moment avant que vous ne trouviez un bloc. Pour arrêter "
-"l'extraction minière :"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Cela va démarrer l'extraction minière sur le démon en utilisant deux threads. Notez qu'il s'agit d'extraction minière en solo, et qu'il pourrait falloir un moment avant que vous ne trouviez un bloc. Pour arrêter l'extraction minière :"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Exemple :"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Ceci récupèrera depuis le démon les blocs que le portefeuille n'a pas encore vu, et mettra à jour votre solde. Ce processus est normalement réalisé en tache de fond environ toutes les minutes.  Pour voir votre balance sans rafraichir :"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Vous aurez besoin de l'adresse standard à laquelle vous comptez envoyer (une longue chaine de caractères commençant par '4') et potentiellement un ID de paiement, si le destinataire vous en demande un. Dans ce dernier cas, celui-ci pourrait vous donner une adresse intégrée, qui contient les deux dans une seule et même adresse."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### Envoyer à une adresse standard :"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADRESSE MONTANT IDdePAIEMENT\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Remplacez `ADRESSE` avec l'adresse à laquelle vous souhaitez envoyer, `MONTANT` avec le montant que vous souhaitez envoyer et `IDdePAIEMENT` avec l'ID de paiement qui vous a été fournit. L'ID de paiement est optionnel. Si le destinataire ne vous en a pas fournit, n'en indiquez pas."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### Envoyer à une adresse intégrée :"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "Dans ce cas, l'ID de paiement est implicitement inclus dans l'adresse intégrée."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Indiquer le nombre de sorties pour une transaction :"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADRESSE MONTANT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Remplacez `RINGSIZE` avec le nombre de sorties que vous souhaitez utiliser. **S'il n'est pas spécifié, la valeur par défaut est 11.** C'est une bonne idée d'utiliser la valeur par défaut, mais vous pouvez augmenter celle-ci pour inclure plus de sorties. Plus grand est le nombre, plus grosse sera la transaction, nécessitant des frais plus importants."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Pouvoir confirmer ou annuler des paiements"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Si vous souhaitez devoir confirmer les paiements que vous envoyez :"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/it/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/it/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,211 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
-`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
-and manages an account. While a bitcoin wallet manages both an account and the blockchain,
-Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
+
+You can have a list of the most important commands by running `help`:
+
+```
+Important commands:
+
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
+
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
+
+"donate <amount>" - Donate XMR to the development team.
+```
 
 ## Checking your balance
 
-Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli`
-need to work with the @daemon. This includes looking for incoming transactions to your address.
-Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`.
+Since the blockchain handling and the wallet are separate programs, many
+uses of `monero-wallet-cli` need to work with the @daemon. This includes
+looking for incoming transactions to your address.  Once you are running
+both `monero-wallet-cli` and `monerod`, enter `balance`.
 
-Example:
+Output:
 
-This will pull blocks from the daemon the wallet did not yet see, and update your balance
-to match. This process will normally be done in the background every minute or so. To see the
-balance without refreshing:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-
-In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
 ## Sending monero
 
-You will need the standard address you want to send to (a long string starting with '4'), and
-possibly a payment ID, if the receiving party requires one. In that latter case, that party
-may instead give you an integrated address, which is both of these packed into a single address.
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-### Sending to a standard address:
+```
+transfer ADDRESS AMOUNT
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
-
-Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send,
-and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just
-omit it.
-
-### Sending to an integrated address:
-
-    transfer ADDRESS AMOUNT
-
-The payment ID is implicit in the integrated address in that case.
-
-### Specify the number of outputs for a transaction:
-
-    transfer RINGSIZE ADDRESS AMOUNT
-
-Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed.
-
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
 ## Receiving monero
 
-If you have your own Monero address, you just need to give your standard address to someone.
+If you have your own Monero address, you just need to give your address to
+someone.
 
-You can find out your address with:
+You can find out your primary address with:
 
-    address
+```
+address
+```
 
-Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you
-want to know, for instance to credit a particular customer, you'll have to tell the sender to use
-a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life
-easier, you can generate an address that already includes a random payment ID:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-    integrated_address
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-This will generate a random payment ID, and give you the address that includes your own account
-and that payment ID. If you want to select a particular payment ID, you can do that too:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    integrated_address 12346780abcdef00
+```
+integrated_address 82d79055f3b27f56
+```
 
-Payments made to an integrated address generated from your account will go to your account,
-with that payment id attached, so you can tell payments apart.
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
+### Using subaddresses
+
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
+
+```
+address new [<label text with white spaces allowed>]
+```
+
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
+
+```
+address new github_donations
+```
+
+will generate a subaddress and its label 'github_donations'.
+
+To view all generated addresses, run:
+
+```
+address all
+```
 
 ## Proving to a third party you paid someone
 
-If you pay a merchant, and the merchant claims to not have received the funds, you may need
-to prove to a third party you did send the funds - or even to the merchant, if it is a honest
-mistake. Monero is private, so you can't just point to your transaction in the blockchain,
-as you can't tell who sent it, and who received it. However, by supplying the per-transaction
-private key to a party, that party can tell whether that transaction sent monero to that
-particular address. Note that storing these per-transaction keys is disabled by default, and
-you will have to enable it before sending, if you think you may need it:
+If you pay a merchant, and the merchant claims to not have received the
+funds, you may need to prove to a third party you did send the funds - or
+even to the merchant, if it is a honest mistake. Monero is private, so you
+can't just point to your transaction in the blockchain, as you can't tell
+who sent it, and who received it. However, by supplying the per-transaction
+private key to a party, that party can tell whether that transaction sent
+monero to that particular address. Note that storing these per-transaction
+keys is disabled by default, and you will have to enable it before sending,
+if you think you may need it:
 
-    set store-tx-info 1
+```
+set store-tx-info 1
+```
 
 You can retrieve the tx key from an earlier transaction:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Pass in the transaction ID you want the key for. Remember that a payment might have been
-split in more than one transaction, so you may need several keys. You can then send that key,
-or these keys, to whoever you want to provide proof of your transaction, along with the
-transaction id and the address you sent to. Note that this third party, if knowing your
-own address, will be able to see how much change was returned to you as well.
+Pass in the transaction ID you want the key for. Remember that a payment
+might have been split in more than one transaction, so you may need several
+keys. You can then send that key, or these keys, to whoever you want to
+provide proof of your transaction, along with the transaction id and the
+address you sent to. Note that this third party, if knowing your own
+address, will be able to see how much change was returned to you as well.
 
-If you are the third party (that is, someone wants to prove to you that they sent monero
-to an address), then you can check this way:
+If you are the third party (that is, someone wants to prove to you that they
+sent monero to an address), then you can check this way:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination
-address which were supplied to you, respectively. monero-wallet-cli will check that transaction
-and let you know how much monero this transaction paid to the given address.
-
-
-## Getting a chance to confirm/cancel payments
-
-If you want to get a last chance confirmation when sending a payment:
-
-    set always-confirm-transfers 1
-
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
 ## How to find a payment to you
 
 If you received a payment using a particular payment ID, you can look it up:
 
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 You can give more than one payment ID too.
 
 More generally, you can review incoming and outgoing payments:
 
-    show_transfers
+```
+show_transfers
+```
 
-You can give an optional height to list only recent transactions, and request
-only incoming or outgoing transactions. For example,
+You can give an optional height to list only recent transactions, and
+request only incoming or outgoing transactions. For example,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-will only show incoming transfers after block 650000. You can also give a height
-range.
+will only show incoming transfers after block 650000. You can also give a
+height range.
 
 If you want to mine, you can do so from the wallet:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-This will start mining on the daemon usin two threads. Note that this is solo mining,
-and may take a while before you find a block. To stop mining:
+This will start mining on the daemon usin two threads. Note that this is
+solo mining, and may take a while before you find a block. To stop mining:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/it/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/it/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:12+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,360 +22,315 @@ msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
 #, no-wrap
 msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
+msgid "Checking your balance"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
+msgid "Output:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-#, no-wrap
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
 #, no-wrap
-msgid "    address\n"
+msgid "Sending monero"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, no-wrap
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, no-wrap
+msgid "Receiving monero"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
+msgid "If you have your own Monero address, you just need to give your address to someone."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-#, no-wrap
-msgid "    integrated_address\n"
+msgid "You can find out your primary address with:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
 #, no-wrap
-msgid "    integrated_address 12346780abcdef00\n"
+msgid "address\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
-msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
 #, no-wrap
-msgid "    set store-tx-info 1\n"
+msgid ""
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, no-wrap
+msgid "integrated_address 82d79055f3b27f56\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
 #, no-wrap
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "Using subaddresses"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
 #, no-wrap
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "address new github_donations\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
+#, no-wrap
+msgid "address all\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
 #, no-wrap
-msgid "    set always-confirm-transfers 1\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-#, no-wrap
-msgid "    payments PAYMENTID\n"
+msgid "Proving to a third party you paid someone"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
-msgid "You can give more than one payment ID too."
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
-msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
 #, no-wrap
-msgid "    show_transfers\n"
+msgid "set store-tx-info 1\n"
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
 #, no-wrap
-msgid "    show_transfers in 650000\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
-msgid "If you want to mine, you can do so from the wallet:"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-#, no-wrap
-msgid "    start_mining 2\n"
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, no-wrap
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
 #, no-wrap
-msgid "    stop_mining\n"
+msgid "How to find a payment to you"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, no-wrap
+msgid "payments PAYMENTID\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
+msgid "You can give more than one payment ID too."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
+msgid "More generally, you can review incoming and outgoing payments:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, no-wrap
+msgid "show_transfers\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, no-wrap
+msgid "show_transfers in 650000\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
+msgid "If you want to mine, you can do so from the wallet:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, no-wrap
+msgid "start_mining 2\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, no-wrap
+msgid "stop_mining\n"
 msgstr ""

--- a/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/nb-no/resources/user-guides/monero-wallet-cli.md
@@ -1,114 +1,215 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` er lommebokprogramvaren som kommer sammen med Monero tree. Det er et konsollprogram og administrerer en konto. Mens en bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero disse: `monerod` håndterer blokkjeden, og `monero-wallet-cli` håndterer kontoen.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-Denne veiledningen viser deg hvordan man utfører ulike operasjoner fra `monero-wallet-cli`-UI-en. Veiledningen antar at du bruker den siste versjonen av Monero og allerede har opprettet en konto i henhold til de andre veiledningene.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## Å sjekke saldoen din
+You can have a list of the most important commands by running `help`:
 
-Fordi håndteringen av blokkjeden og lommeboken er separate programmer, må mye av bruken av `monero-wallet-cli` skje med @daemon. Dette omfatter å se etter innkommende transaksjoner til adressen din.
-Når du kjører både `monero-wallet-cli` og `monerod`, kan du taste inn `balance.`
+```
+Important commands:
 
-Eksempel:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-Dette vil trekke blokker fra daemon som lommeboken enda ikke har sett og oppdatere saldoen slik at den samsvarer. Denne prosessen gjøres normalt i bakgrunnen, omtrent hvert minutt. For å se se saldoen uten å oppdatere:
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"donate <amount>" - Donate XMR to the development team.
+```
 
-I dette eksempelet er `Balance` din totale saldo. `unlocked balance` er beløpet som for øyeblikket er disponibelt. Nylig mottatte transaksjoner trenger 10 bekreftelser på blokkjeden før de låses opp. `unlocked dust` viser til veldig små beløp av ubrukte utdata som kan ha samlet seg opp på kontoen din.
+## Checking your balance
 
-## Å sende monero
+Fordi håndteringen av blokkjeden og lommeboken er separate programmer, må
+mye av bruken av `monero-wallet-cli` skje med @daemon. Dette omfatter å se
+etter innkommende transaksjoner til adressen din.  Når du kjører både
+`monero-wallet-cli` og `monerod`, kan du taste inn `balance.`
 
-Du vil trenge standardadressen som du vil sende til (en lang streng som begynner med '4'), muligens en betalings-ID, dersom mottakeren ber om det. I det siste tilfellet kan mottakeren i stedet gi deg en integrert adresse, der begge disse er pakket inn i én enkel adresse.
+Output:
 
-### Å sende til en standard adresse:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-Bytt ut `ADDRESS` med adressen du vil sende til, `AMOUNT` med hvor mange monero du vil sende, og `PAYMENTID` med betalings-ID-en du ble gitt. Betalings-ID-er er valgfrie. Hvis mottakeren ikke trenger en, kan du bare sløyfe det.
+## Sending monero
 
-### Å sende til en integrert adresse:
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-    transfer ADDRESS AMOUNT
+```
+transfer ADDRESS AMOUNT
+```
 
-Betalings-ID-en inngår i dette tilfellet i den integrerte adressen.
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-### Spesifiser antallet utdata for en transaksjon:
+## Receiving monero
 
-    transfer RINGSIZE ADDRESS AMOUNT
+If you have your own Monero address, you just need to give your address to
+someone.
 
-Bytt ut `RINGSIZE` med antallet utdata du vil bruke. **Hvis dette ikke angis, velges 11 som standard.** Det er en god idé å bruke standarden, men du kan øke antallet dersom du vil inkludere flere utdata. Jo høyere antallet, jo større er transaksjonen, og jo høyere gebyr trengs for transaksjonen.
+You can find out your primary address with:
 
+```
+address
+```
 
-## Å motta monero
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-Hvis du har din egen Monero-adresse, trenger du bare å gi din standardadresse til noen.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Du kan finne ut hva adressen din er med kommandoen:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-I og med at Monero er anonymt, vil du ikke se avsenders adresse som midlene du mottok kom fra. Hvis du vil vite det, for eksempel for å kreditere en spesifikk kunde, må du be senderen om å bruke en betalings-ID, som er en vilkårlig og valgfri merkelapp som festes til en transaksjon. For å gjøre livet enklere, kan du generere en adresse som allerede inkluderer en tilfeldig betalings-ID:
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-Dette vil generere en tilfeldig betalings-ID og gi deg adressen som inkluderer din egen konto og den betalings-ID-en. Hvis du vil velge en spesiell betalings-ID, kan du også gjøre det:
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-Betalinger som gjøres til en integrert adresse som er generert fra kontoen din, går til din konto der den spesifikke betalings-ID-en festes slik at du kan skille betalinger fra hverandre.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## Å bevise til en tredjepart at du har betalt noen
+will generate a subaddress and its label 'github_donations'.
 
-Hvis du betaler en forhandler og forhandleren påstår å ikke ha mottatt midlene, må du kunne bevise for en tredjepart at du har sendt midlene – eller til og med til forhandleren, dersom det er en ærlig feil. Monero er privat, så du kan ikke bare vise til transaksjonen din i blokkjeden, i og med at man ikke kan fastslå hvem som har sendt det, og hvem som mottok det. Ved å forsyne parten med en «per-transaction»-privat nøkkel, kan den parten si hvorvidt den transaksjonen sendte monero til den bestemte adressen eller ikke. Merk at å lagre disse «per-transaction»-nøklene er deaktivert som standard, så du må aktivere det før du sender hvis du tror du kan få bruk for det:
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Hvis du betaler en forhandler og forhandleren påstår å ikke ha mottatt
+midlene, må du kunne bevise for en tredjepart at du har sendt midlene –
+eller til og med til forhandleren, dersom det er en ærlig feil. Monero er
+privat, så du kan ikke bare vise til transaksjonen din i blokkjeden, i og
+med at man ikke kan fastslå hvem som har sendt det, og hvem som mottok
+det. Ved å forsyne parten med en «per-transaction»-privat nøkkel, kan den
+parten si hvorvidt den transaksjonen sendte monero til den bestemte adressen
+eller ikke. Merk at å lagre disse «per-transaction»-nøklene er deaktivert
+som standard, så du må aktivere det før du sender hvis du tror du kan få
+bruk for det:
+
+```
+set store-tx-info 1
+```
 
 Du kan finne igjen tx-nøkkelen fra en tidligere transaksjon slik:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Legg inn transaksjons-ID-en som du ønsker nøkkelen for. Husk at en betaling må splittes inn i mer enn én transaksjon, så du trenger kanskje flere nøkler. Du kan deretter sende den nøkkelen eller disse nøklene til hvem nå enn du vil sende bevis på transaksjonen din til sammen med transaksjons-ID-en og adressen du sendte til. Merk at denne tredjeparten også vil kunne se hvor mye veksel som ble sendt tilbake til deg dersom vedkommende kjenner til din adresse.
+Legg inn transaksjons-ID-en som du ønsker nøkkelen for. Husk at en betaling
+må splittes inn i mer enn én transaksjon, så du trenger kanskje flere
+nøkler. Du kan deretter sende den nøkkelen eller disse nøklene til hvem nå
+enn du vil sende bevis på transaksjonen din til sammen med
+transaksjons-ID-en og adressen du sendte til. Merk at denne tredjeparten
+også vil kunne se hvor mye veksel som ble sendt tilbake til deg dersom
+vedkommende kjenner til din adresse.
 
-Hvis du er tredjeparten (altså om noen vil bevise til deg at de har sendt monero til en adresse), kan du sjekke det slik:
+Hvis du er tredjeparten (altså om noen vil bevise til deg at de har sendt
+monero til en adresse), kan du sjekke det slik:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Bytt ut `TXID`, `TXKEY` og `ADDRESS` med henholdsvis transaksjons-ID-en, per-transaction-nøkkel og mottakeradressen som ble gitt til deg. monero-wallet-cli vil sjekke den transaksjonen og gi deg beskjed om hvor mye monero denne transaksjonen utbetalte til den oppgitte adressen.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
+## How to find a payment to you
 
-## Mulighet til å bekrefte/avbryte betalinger
+Hvis du har mottatt en betaling ved bruk av en bestemt betalings-ID, kan du
+slå den opp:
 
-Hvis du vil få en siste bekreftelse når du sender en betaling:
-
-    set always-confirm-transfers 1
-
-
-## Hvordan å finne en betaling som skal til deg
-
-Hvis du har mottatt en betaling ved bruk av en bestemt betalings-ID, kan du slå den opp: 
-
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 Du kan også gi dem mer enn én betalings-ID.
 
 Mer generelt kan du gjennomgå innkommende og utgående betalinger:
 
-    show_transfers
+```
+show_transfers
+```
 
-Du kan gi en valgfri høyde for å kun liste opp nylige transaksjoner og kun be om innkommende eller utgående transaksjoner.
+Du kan gi en valgfri høyde for å kun liste opp nylige transaksjoner og kun
+be om innkommende eller utgående transaksjoner.
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-vil for eksempel kun vise innkommende overføringer etter blokk 650 000. Du kan også gi et høydeintervall.
+vil for eksempel kun vise innkommende overføringer etter blokk 650 000. Du
+kan også gi et høydeintervall.
 
 Hvis du vil utvinne, kan du gjøre det fra lommeboken:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Dette setter i gang utvinning på daemonen ved bruk at to tråder. Merk at dette er solo-utvinning, så det kan ta litt tid før du finner en blokk. For å stanse utvinningen:
+Dette setter i gang utvinning på daemonen ved bruk at to tråder. Merk at
+dette er solo-utvinning, så det kan ta litt tid før du finner en blokk. For
+å stanse utvinningen:
 
-    stop_mining
+```
+stop_mining
+```

--- a/_i18n/nb-no/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/nb-no/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:18+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,429 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` er lommebokprogramvaren som kommer sammen med Monero "
-"tree. Det er et konsollprogram og administrerer en konto. Mens en "
-"bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero "
-"disse: `monerod` håndterer blokkjeden, og `monero-wallet-cli` håndterer "
-"kontoen."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` er lommebokprogramvaren som kommer sammen med Monero tree. Det er et konsollprogram og administrerer en konto. Mens en bitcoin-lommebok håndterer både en konto og blokkjeden, separerer Monero disse: `monerod` håndterer blokkjeden, og `monero-wallet-cli` håndterer kontoen."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "Denne veiledningen viser deg hvordan man utfører ulike operasjoner fra `monero-wallet-cli`-UI-en. Veiledningen antar at du bruker den siste versjonen av Monero og allerede har opprettet en konto i henhold til de andre veiledningene."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"Denne veiledningen viser deg hvordan man utfører ulike operasjoner fra "
-"`monero-wallet-cli`-UI-en. Veiledningen antar at du bruker den siste "
-"versjonen av Monero og allerede har opprettet en konto i henhold til de "
-"andre veiledningene."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Å sjekke saldoen din"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Fordi håndteringen av blokkjeden og lommeboken er separate programmer, må "
-"mye av bruken av `monero-wallet-cli` skje med @daemon. Dette omfatter å se "
-"etter innkommende transaksjoner til adressen din.  Når du kjører både "
-"`monero-wallet-cli` og `monerod`, kan du taste inn `balance.`"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Eksempel:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Dette vil trekke blokker fra daemon som lommeboken enda ikke har sett og "
-"oppdatere saldoen slik at den samsvarer. Denne prosessen gjøres normalt i "
-"bakgrunnen, omtrent hvert minutt. For å se se saldoen uten å oppdatere:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"I dette eksempelet er `Balance` din totale saldo. `unlocked balance` er "
-"beløpet som for øyeblikket er disponibelt. Nylig mottatte transaksjoner "
-"trenger 10 bekreftelser på blokkjeden før de låses opp. `unlocked dust` "
-"viser til veldig små beløp av ubrukte utdata som kan ha samlet seg opp på "
-"kontoen din."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Å sende monero"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Du vil trenge standardadressen som du vil sende til (en lang streng som "
-"begynner med '4'), muligens en betalings-ID, dersom mottakeren ber om det. I "
-"det siste tilfellet kan mottakeren i stedet gi deg en integrert adresse, der "
-"begge disse er pakket inn i én enkel adresse."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### Å sende til en standard adresse:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Bytt ut `ADDRESS` med adressen du vil sende til, `AMOUNT` med hvor mange "
-"monero du vil sende, og `PAYMENTID` med betalings-ID-en du ble "
-"gitt. Betalings-ID-er er valgfrie. Hvis mottakeren ikke trenger en, kan du "
-"bare sløyfe det."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### Å sende til en integrert adresse:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Fordi håndteringen av blokkjeden og lommeboken er separate programmer, må mye av bruken av `monero-wallet-cli` skje med @daemon. Dette omfatter å se etter innkommende transaksjoner til adressen din.  Når du kjører både `monero-wallet-cli` og `monerod`, kan du taste inn `balance.`"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADDRESS AMOUNT\n"
+msgid "Output:"
+msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr "Betalings-ID-en inngår i dette tilfellet i den integrerte adressen."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Spesifiser antallet utdata for en transaksjon:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Bytt ut `RINGSIZE` med antallet utdata du vil bruke. **Hvis dette ikke "
-"angis, velges 11 som standard.** Det er en god idé å bruke standarden, men "
-"du kan øke antallet dersom du vil inkludere flere utdata. Jo høyere "
-"antallet, jo større er transaksjonen, og jo høyere gebyr trengs for "
-"transaksjonen."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "I dette eksempelet er `Balance` din totale saldo. `unlocked balance` er beløpet som for øyeblikket er disponibelt. Nylig mottatte transaksjoner trenger 10 bekreftelser på blokkjeden før de låses opp. `unlocked dust` viser til veldig små beløp av ubrukte utdata som kan ha samlet seg opp på kontoen din."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Å sende monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADDRESS AMOUNT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Å motta monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Hvis du har din egen Monero-adresse, trenger du bare å gi din "
-"standardadresse til noen."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Du kan finne ut hva adressen din er med kommandoen:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"I og med at Monero er anonymt, vil du ikke se avsenders adresse som midlene "
-"du mottok kom fra. Hvis du vil vite det, for eksempel for å kreditere en "
-"spesifikk kunde, må du be senderen om å bruke en betalings-ID, som er en "
-"vilkårlig og valgfri merkelapp som festes til en transaksjon. For å gjøre "
-"livet enklere, kan du generere en adresse som allerede inkluderer en "
-"tilfeldig betalings-ID:"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Hvis du har din egen Monero-adresse, trenger du bare å gi din standardadresse til noen."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Du kan finne ut hva adressen din er med kommandoen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Dette vil generere en tilfeldig betalings-ID og gi deg adressen som "
-"inkluderer din egen konto og den betalings-ID-en. Hvis du vil velge en "
-"spesiell betalings-ID, kan du også gjøre det:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "I og med at Monero er anonymt, vil du ikke se avsenders adresse som midlene du mottok kom fra. Hvis du vil vite det, for eksempel for å kreditere en spesifikk kunde, må du be senderen om å bruke en betalings-ID, som er en vilkårlig og valgfri merkelapp som festes til en transaksjon. For å gjøre livet enklere, kan du generere en adresse som allerede inkluderer en tilfeldig betalings-ID:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"Betalinger som gjøres til en integrert adresse som er generert fra kontoen "
-"din, går til din konto der den spesifikke betalings-ID-en festes slik at du "
-"kan skille betalinger fra hverandre."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Å bevise til en tredjepart at du har betalt noen"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Dette vil generere en tilfeldig betalings-ID og gi deg adressen som inkluderer din egen konto og den betalings-ID-en. Hvis du vil velge en spesiell betalings-ID, kan du også gjøre det:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Hvis du betaler en forhandler og forhandleren påstår å ikke ha mottatt "
-"midlene, må du kunne bevise for en tredjepart at du har sendt midlene – "
-"eller til og med til forhandleren, dersom det er en ærlig feil. Monero er "
-"privat, så du kan ikke bare vise til transaksjonen din i blokkjeden, i og "
-"med at man ikke kan fastslå hvem som har sendt det, og hvem som mottok "
-"det. Ved å forsyne parten med en «per-transaction»-privat nøkkel, kan den "
-"parten si hvorvidt den transaksjonen sendte monero til den bestemte adressen "
-"eller ikke. Merk at å lagre disse «per-transaction»-nøklene er deaktivert "
-"som standard, så du må aktivere det før du sender hvis du tror du kan få "
-"bruk for det:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Du kan finne igjen tx-nøkkelen fra en tidligere transaksjon slik:"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "Betalinger som gjøres til en integrert adresse som er generert fra kontoen din, går til din konto der den spesifikke betalings-ID-en festes slik at du kan skille betalinger fra hverandre."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Legg inn transaksjons-ID-en som du ønsker nøkkelen for. Husk at en betaling "
-"må splittes inn i mer enn én transaksjon, så du trenger kanskje flere "
-"nøkler. Du kan deretter sende den nøkkelen eller disse nøklene til hvem nå "
-"enn du vil sende bevis på transaksjonen din til sammen med "
-"transaksjons-ID-en og adressen du sendte til. Merk at denne tredjeparten "
-"også vil kunne se hvor mye veksel som ble sendt tilbake til deg dersom "
-"vedkommende kjenner til din adresse."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Hvis du er tredjeparten (altså om noen vil bevise til deg at de har sendt "
-"monero til en adresse), kan du sjekke det slik:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Bytt ut `TXID`, `TXKEY` og `ADDRESS` med henholdsvis transaksjons-ID-en, "
-"per-transaction-nøkkel og mottakeradressen som ble gitt til "
-"deg. monero-wallet-cli vil sjekke den transaksjonen og gi deg beskjed om "
-"hvor mye monero denne transaksjonen utbetalte til den oppgitte adressen."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Mulighet til å bekrefte/avbryte betalinger"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr "Hvis du vil få en siste bekreftelse når du sender en betaling:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Hvordan å finne en betaling som skal til deg"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Hvis du har mottatt en betaling ved bruk av en bestemt betalings-ID, kan du "
-"slå den opp:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Å bevise til en tredjepart at du har betalt noen"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Hvis du betaler en forhandler og forhandleren påstår å ikke ha mottatt midlene, må du kunne bevise for en tredjepart at du har sendt midlene – eller til og med til forhandleren, dersom det er en ærlig feil. Monero er privat, så du kan ikke bare vise til transaksjonen din i blokkjeden, i og med at man ikke kan fastslå hvem som har sendt det, og hvem som mottok det. Ved å forsyne parten med en «per-transaction»-privat nøkkel, kan den parten si hvorvidt den transaksjonen sendte monero til den bestemte adressen eller ikke. Merk at å lagre disse «per-transaction»-nøklene er deaktivert som standard, så du må aktivere det før du sender hvis du tror du kan få bruk for det:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Du kan finne igjen tx-nøkkelen fra en tidligere transaksjon slik:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Legg inn transaksjons-ID-en som du ønsker nøkkelen for. Husk at en betaling må splittes inn i mer enn én transaksjon, så du trenger kanskje flere nøkler. Du kan deretter sende den nøkkelen eller disse nøklene til hvem nå enn du vil sende bevis på transaksjonen din til sammen med transaksjons-ID-en og adressen du sendte til. Merk at denne tredjeparten også vil kunne se hvor mye veksel som ble sendt tilbake til deg dersom vedkommende kjenner til din adresse."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Hvis du er tredjeparten (altså om noen vil bevise til deg at de har sendt monero til en adresse), kan du sjekke det slik:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Bytt ut `TXID`, `TXKEY` og `ADDRESS` med henholdsvis transaksjons-ID-en, per-transaction-nøkkel og mottakeradressen som ble gitt til deg. monero-wallet-cli vil sjekke den transaksjonen og gi deg beskjed om hvor mye monero denne transaksjonen utbetalte til den oppgitte adressen."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Hvordan å finne en betaling som skal til deg"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Hvis du har mottatt en betaling ved bruk av en bestemt betalings-ID, kan du slå den opp:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Du kan også gi dem mer enn én betalings-ID."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
 msgstr "Mer generelt kan du gjennomgå innkommende og utgående betalinger:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Du kan gi en valgfri høyde for å kun liste opp nylige transaksjoner og kun "
-"be om innkommende eller utgående transaksjoner."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Du kan gi en valgfri høyde for å kun liste opp nylige transaksjoner og kun be om innkommende eller utgående transaksjoner."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"vil for eksempel kun vise innkommende overføringer etter blokk 650 000. Du "
-"kan også gi et høydeintervall."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "vil for eksempel kun vise innkommende overføringer etter blokk 650 000. Du kan også gi et høydeintervall."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "Hvis du vil utvinne, kan du gjøre det fra lommeboken:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Dette setter i gang utvinning på daemonen ved bruk at to tråder. Merk at "
-"dette er solo-utvinning, så det kan ta litt tid før du finner en blokk. For "
-"å stanse utvinningen:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Dette setter i gang utvinning på daemonen ved bruk at to tråder. Merk at dette er solo-utvinning, så det kan ta litt tid før du finner en blokk. For å stanse utvinningen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Eksempel:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Dette vil trekke blokker fra daemon som lommeboken enda ikke har sett og oppdatere saldoen slik at den samsvarer. Denne prosessen gjøres normalt i bakgrunnen, omtrent hvert minutt. For å se se saldoen uten å oppdatere:"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Du vil trenge standardadressen som du vil sende til (en lang streng som begynner med '4'), muligens en betalings-ID, dersom mottakeren ber om det. I det siste tilfellet kan mottakeren i stedet gi deg en integrert adresse, der begge disse er pakket inn i én enkel adresse."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### Å sende til en standard adresse:"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Bytt ut `ADDRESS` med adressen du vil sende til, `AMOUNT` med hvor mange monero du vil sende, og `PAYMENTID` med betalings-ID-en du ble gitt. Betalings-ID-er er valgfrie. Hvis mottakeren ikke trenger en, kan du bare sløyfe det."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### Å sende til en integrert adresse:"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "Betalings-ID-en inngår i dette tilfellet i den integrerte adressen."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Spesifiser antallet utdata for en transaksjon:"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Bytt ut `RINGSIZE` med antallet utdata du vil bruke. **Hvis dette ikke angis, velges 11 som standard.** Det er en god idé å bruke standarden, men du kan øke antallet dersom du vil inkludere flere utdata. Jo høyere antallet, jo større er transaksjonen, og jo høyere gebyr trengs for transaksjonen."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Mulighet til å bekrefte/avbryte betalinger"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Hvis du vil få en siste bekreftelse når du sender en betaling:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/nl/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/nl/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,219 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` is de portemonnee-software die onderdeel uitmaakt van de Monero-code. Het is een consoleprogramma
-waarmee je een account beheert. Terwijl een Bitcoin-portemonnee zowel een account als de blockchain beheert,
-worden deze functies in Monero gescheiden: `monerod` beheert de blockchain en `monero-wallet-cli` beheert het account.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-In deze handleiding wordt uitgelegd hoe je verschillende bewerking uitvoert met de interface van `monero-wallet-cli`. We nemen aan dat je de nieuwste versie van Monero gebruikt en al een account hebt gemaakt met behulp van andere handleidingen.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## Je saldo bekijken
+You can have a list of the most important commands by running `help`:
 
-Omdat we een ander programma dan de portemonnee gebruiken om met de blockchain te werken, moet `monero-wallet-cli` voor veel toepassingen
-samenwerken met de node. Dit is bijvoorbeeld nodig om binnenkomende transacties voor je adres op te zoeken.
-Wanneer `monero-wallet-cli` en `monerod` beide worden uitgevoerd, voer je `balance` in.
+```
+Important commands:
 
-Voorbeeld:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-Hiermee worden blokken uit de node opgehaald die de portemonnee nog niet gezien heeft, en wordt je saldo navenant
-bijgewerkt. Dit proces wordt normaal ongeveer één keer per minuut in de achtergrond uitgevoerd. Zo geef je het saldo weer
-zonder te vernieuwen:
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"donate <amount>" - Donate XMR to the development team.
+```
 
-In dit voorbeeld is `Balance` je totale saldo. De `unlocked balance` is het bedrag dat momenteel beschikbaar is om uit te geven. Voor nieuw ontvangen transacties zijn 10 bevestigingen op de blockchain nodig om ze te ontgrendelen. Met `unlocked dust` worden minuscule hoeveelheden *unspent outputs* bedoeld die als een soort stof in je account zijn terechtgekomen.
+## Checking your balance
 
-## Monero verzenden
+Omdat we een ander programma dan de portemonnee gebruiken om met de
+blockchain te werken, moet `monero-wallet-cli` voor veel toepassingen
+samenwerken met de node. Dit is bijvoorbeeld nodig om binnenkomende
+transacties voor je adres op te zoeken.  Wanneer `monero-wallet-cli` en
+`monerod` beide worden uitgevoerd, voer je `balance` in.
 
-Wat je nodig hebt is het standaardadres waaraan je wilt betalen (een lange tekenreeks die begint met een 4), en
-eventueel een betalings-ID als de ontvangende partij daarom vraagt. In dat geval kan de begunstigde
-ook een geïntegreerd adres opgeven, waarbij het standaardadres en de betalings-ID in één adres worden verpakt.
+Output:
 
-### Verzenden naar een standaardadres:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    transfer ADRES BEDRAG BETALINGSID
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-Vervang `ADRES` door het adres waaraan je wilt betalen, `BEDRAG` door hoeveel Monero je wilt betalen
-en `BETALINGSID` door de betalings-ID die je hebt ontvangen. Betalings-ID's zijn optioneel. Als de ontvangende partij er geen nodig heeft, kun je
-de ID gewoon weglaten.
+## Sending monero
 
-### Verzenden naar een geïntegreerd adres:
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-    transfer ADRES BEDRAG
+```
+transfer ADDRESS AMOUNT
+```
 
-Hier is de betalings-ID opgenomen in het geïntegreerde adres.
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-### Het aantal outputs in een transactie opgeven:
+## Receiving monero
 
-    transfer RINGGROOTTE ADRES BEDRAG
+If you have your own Monero address, you just need to give your address to
+someone.
 
-Vervang `RINGGROOTTE` door het aantal outputs dat je wilt gebruiken. **Als je niets opgeeft is de standaardwaarde 11.** Het is beter om de standaardwaarde te gebruiken, maar je kunt eventueel een hoger aantal opgeven als ze meer outputs wilt meenemen. Hoe hoger het aantal, des te groter de transactie en des te hoger de transactiekosten.
+You can find out your primary address with:
 
+```
+address
+```
 
-## Monero ontvangen
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-Als je zelf een Monero-adres hebt, kun je gewoon je standaardadres aan iemand doorgeven.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Met de volgende opdracht krijg je je adres te zien:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-Aangezien Monero anoniem is, kun je niet zien van welk adres het geld dat je ontvangt afkomstig is. Als je
-dat wilt weten, bijvoorbeeld om een betaling aan een klant te koppelen, moet je de afzender vragen
-een betalings-ID te gebruiken. Dat is een willekeurige optionele tekenreeks dat wordt toegevoegd aan een transactie. Voor het gemak
-kun je een adres genereren dat al een willekeurige betalings-ID bevat:
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-Hierdoor wordt een willekeurige betalings-ID gegenereerd en krijg je een adres waarin je eigen account en de
-betalings-ID worden samengevat. Het is ook mogelijk om een bepaalde betalings-ID te kiezen als je dat wilt:
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-Betalingen aan een geïntegreerd adres dat jij hebt gegenereerd gaan naar jouw account
-met vermelding van die betalings-ID, zodat je betalingen kunt onderscheiden.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## Aan een derde bewijzen dat je iemand hebt betaald
+will generate a subaddress and its label 'github_donations'.
 
-Als je een verkoper betaalt, en de verkoper beweert dat hij/zij het geld niet heeft ontvangen, wil je misschien
-aan een derde bewijzen dat je het geld wel degelijk hebt verzonden - of aan de verkoper zelf, als het een eerlijke
-vergissing is. Monero is vertrouwelijk, dus je kunt niet zomaar je transactie aanwijzen op de blockchain,
-want daar is niet te zien wie een transactie heeft verzonden of ontvangen. Maar je kunt iemand wel de privésleutel van een transactie
-geven, zodat die kan zien of die transactie Monero naar dat
-adres heeft verzonden. Houd er rekening mee dat het opslaan van deze transactiesleutels standaard is uitgeschakeld.
-Je moet deze functie voor het verzenden inschakelen als je denkt dat je deze misschien nodig hebt:
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Als je een verkoper betaalt, en de verkoper beweert dat hij/zij het geld
+niet heeft ontvangen, wil je misschien aan een derde bewijzen dat je het
+geld wel degelijk hebt verzonden - of aan de verkoper zelf, als het een
+eerlijke vergissing is. Monero is vertrouwelijk, dus je kunt niet zomaar je
+transactie aanwijzen op de blockchain, want daar is niet te zien wie een
+transactie heeft verzonden of ontvangen. Maar je kunt iemand wel de
+privésleutel van een transactie geven, zodat die kan zien of die transactie
+Monero naar dat adres heeft verzonden. Houd er rekening mee dat het opslaan
+van deze transactiesleutels standaard is uitgeschakeld.  Je moet deze
+functie voor het verzenden inschakelen als je denkt dat je deze misschien
+nodig hebt:
+
+```
+set store-tx-info 1
+```
 
 Je kunt de transactiesleutel van een eerdere transactie ophalen:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Voer hierbij de ID in van de transactie waarvoor u de sleutel wilt hebben. Houd er rekening mee dat een betaling kan zijn gesplitst
-in meer dan één transactie, zodat je meerdere sleutels nodig hebt. Vervolgens kun je de sleutel
-of sleutels opsturen naar wie je het bewijs van je transactie wilt laten zien, met de
-transactie-ID en het adres van de ontvanger erbij. Opmerking: als deze partij ook je eigen
-adres kent, kan deze ook zien hoeveel wisselgeld je hebt teruggekregen.
+Voer hierbij de ID in van de transactie waarvoor u de sleutel wilt
+hebben. Houd er rekening mee dat een betaling kan zijn gesplitst in meer dan
+één transactie, zodat je meerdere sleutels nodig hebt. Vervolgens kun je de
+sleutel of sleutels opsturen naar wie je het bewijs van je transactie wilt
+laten zien, met de transactie-ID en het adres van de ontvanger
+erbij. Opmerking: als deze partij ook je eigen adres kent, kan deze ook zien
+hoeveel wisselgeld je hebt teruggekregen.
 
-Als je zelf de derde partij bent (dus als iemand aan jou wilt bewijzen dat hij/zij Monero naar een bepaald
-adres heeft verzonden), kun je dat op deze manier controleren:
+Als je zelf de derde partij bent (dus als iemand aan jou wilt bewijzen dat
+hij/zij Monero naar een bepaald adres heeft verzonden), kun je dat op deze
+manier controleren:
 
-    check_tx_key TXID SLEUTEL ADRES
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Vervang `TXID` door de transactie-ID, `SLEUTEL` door de transactiesleutel en `ADRES` door het doeladres
-dat je hebt ontvangen. Vervolgens controleert monero-wallet-cli die transactie
-en laat het weten hoeveel door deze transactie aan het opgegeven adres is betaald.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
+## How to find a payment to you
 
-## Instellen dat je betalingen kunt bevestigen/annuleren
+Als je een betaling met een bepaalde betalings-ID hebt ontvangen, kun je
+deze opzoeken:
 
-Als je een laatste kans wilt krijgen om een betaling te bevestigen of annuleren:
-
-    set always-confirm-transfers 1
-
-
-## Een betaling aan jou vinden
-
-Als je een betaling met een bepaalde betalings-ID hebt ontvangen, kun je deze opzoeken:
-
-    payments BETALINGSID
+```
+payments PAYMENTID
+```
 
 Je kunt ook meer dan één betalings-ID opgeven.
 
 In het algemeen kun je binnenkomende en uitgaande betalingen bekijken:
 
-    show_transfers
+```
+show_transfers
+```
 
-Je kunt een optionele blokhoogte opgeven om alleen recente transacties te ontvangen, en je kunt
-alleen binnenkomende of uitgaande transactie opvragen. Bijvoorbeeld:
+Je kunt een optionele blokhoogte opgeven om alleen recente transacties te
+ontvangen, en je kunt alleen binnenkomende of uitgaande transactie
+opvragen. Bijvoorbeeld:
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-levert alleen binnenkomende overboekingen na blok 650.000 op. Je kunt ook een bereik van blokhoogten
-opgeven.
+levert alleen binnenkomende overboekingen na blok 650.000 op. Je kunt ook
+een bereik van blokhoogten opgeven.
 
 Als je wilt minen, kun je dat ook vanuit de portemonnee doen:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Hiermee gebruik je twee CPU-threads om te minen via de daemon. Let op: dit is solo minen;
-het kan lang duren voordat je een blok vindt. Om te stoppen met minen:
+Hiermee gebruik je twee CPU-threads om te minen via de daemon. Let op: dit
+is solo minen; het kan lang duren voordat je een blok vindt. Om te stoppen
+met minen:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/nl/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/nl/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:18+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,437 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` is de portemonnee-software die onderdeel uitmaakt van de "
-"Monero-code. Het is een consoleprogramma waarmee je een account "
-"beheert. Terwijl een Bitcoin-portemonnee zowel een account als de blockchain "
-"beheert, worden deze functies in Monero gescheiden: `monerod` beheert de "
-"blockchain en `monero-wallet-cli` beheert het account."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` is de portemonnee-software die onderdeel uitmaakt van de Monero-code. Het is een consoleprogramma waarmee je een account beheert. Terwijl een Bitcoin-portemonnee zowel een account als de blockchain beheert, worden deze functies in Monero gescheiden: `monerod` beheert de blockchain en `monero-wallet-cli` beheert het account."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "In deze handleiding wordt uitgelegd hoe je verschillende bewerking uitvoert met de interface van `monero-wallet-cli`. We nemen aan dat je de nieuwste versie van Monero gebruikt en al een account hebt gemaakt met behulp van andere handleidingen."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"In deze handleiding wordt uitgelegd hoe je verschillende bewerking uitvoert "
-"met de interface van `monero-wallet-cli`. We nemen aan dat je de nieuwste "
-"versie van Monero gebruikt en al een account hebt gemaakt met behulp van "
-"andere handleidingen."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Je saldo bekijken"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Omdat we een ander programma dan de portemonnee gebruiken om met de "
-"blockchain te werken, moet `monero-wallet-cli` voor veel toepassingen "
-"samenwerken met de node. Dit is bijvoorbeeld nodig om binnenkomende "
-"transacties voor je adres op te zoeken.  Wanneer `monero-wallet-cli` en "
-"`monerod` beide worden uitgevoerd, voer je `balance` in."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Voorbeeld:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Hiermee worden blokken uit de node opgehaald die de portemonnee nog niet "
-"gezien heeft, en wordt je saldo navenant bijgewerkt. Dit proces wordt "
-"normaal ongeveer één keer per minuut in de achtergrond uitgevoerd. Zo geef "
-"je het saldo weer zonder te vernieuwen:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"In dit voorbeeld is `Balance` je totale saldo. De `unlocked balance` is het "
-"bedrag dat momenteel beschikbaar is om uit te geven. Voor nieuw ontvangen "
-"transacties zijn 10 bevestigingen op de blockchain nodig om ze te "
-"ontgrendelen. Met `unlocked dust` worden minuscule hoeveelheden *unspent "
-"outputs* bedoeld die als een soort stof in je account zijn terechtgekomen."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Monero verzenden"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Wat je nodig hebt is het standaardadres waaraan je wilt betalen (een lange "
-"tekenreeks die begint met een 4), en eventueel een betalings-ID als de "
-"ontvangende partij daarom vraagt. In dat geval kan de begunstigde ook een "
-"geïntegreerd adres opgeven, waarbij het standaardadres en de betalings-ID in "
-"één adres worden verpakt."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### Verzenden naar een standaardadres:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADRES BEDRAG BETALINGSID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Vervang `ADRES` door het adres waaraan je wilt betalen, `BEDRAG` door "
-"hoeveel Monero je wilt betalen en `BETALINGSID` door de betalings-ID die je "
-"hebt ontvangen. Betalings-ID's zijn optioneel. Als de ontvangende partij er "
-"geen nodig heeft, kun je de ID gewoon weglaten."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### Verzenden naar een geïntegreerd adres:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Omdat we een ander programma dan de portemonnee gebruiken om met de blockchain te werken, moet `monero-wallet-cli` voor veel toepassingen samenwerken met de node. Dit is bijvoorbeeld nodig om binnenkomende transacties voor je adres op te zoeken.  Wanneer `monero-wallet-cli` en `monerod` beide worden uitgevoerd, voer je `balance` in."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADRES BEDRAG\n"
+msgid "Output:"
+msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr "Hier is de betalings-ID opgenomen in het geïntegreerde adres."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Het aantal outputs in een transactie opgeven:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGGROOTTE ADRES BEDRAG\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Vervang `RINGGROOTTE` door het aantal outputs dat je wilt gebruiken. **Als "
-"je niets opgeeft is de standaardwaarde 11.** Het is beter om de "
-"standaardwaarde te gebruiken, maar je kunt eventueel een hoger aantal "
-"opgeven als ze meer outputs wilt meenemen. Hoe hoger het aantal, des te "
-"groter de transactie en des te hoger de transactiekosten."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "In dit voorbeeld is `Balance` je totale saldo. De `unlocked balance` is het bedrag dat momenteel beschikbaar is om uit te geven. Voor nieuw ontvangen transacties zijn 10 bevestigingen op de blockchain nodig om ze te ontgrendelen. Met `unlocked dust` worden minuscule hoeveelheden *unspent outputs* bedoeld die als een soort stof in je account zijn terechtgekomen."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Monero verzenden"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADRES BEDRAG\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Monero ontvangen"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Als je zelf een Monero-adres hebt, kun je gewoon je standaardadres aan "
-"iemand doorgeven."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Met de volgende opdracht krijg je je adres te zien:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"Aangezien Monero anoniem is, kun je niet zien van welk adres het geld dat je "
-"ontvangt afkomstig is. Als je dat wilt weten, bijvoorbeeld om een betaling "
-"aan een klant te koppelen, moet je de afzender vragen een betalings-ID te "
-"gebruiken. Dat is een willekeurige optionele tekenreeks dat wordt toegevoegd "
-"aan een transactie. Voor het gemak kun je een adres genereren dat al een "
-"willekeurige betalings-ID bevat:"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Als je zelf een Monero-adres hebt, kun je gewoon je standaardadres aan iemand doorgeven."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Met de volgende opdracht krijg je je adres te zien:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Hierdoor wordt een willekeurige betalings-ID gegenereerd en krijg je een "
-"adres waarin je eigen account en de betalings-ID worden samengevat. Het is "
-"ook mogelijk om een bepaalde betalings-ID te kiezen als je dat wilt:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "Aangezien Monero anoniem is, kun je niet zien van welk adres het geld dat je ontvangt afkomstig is. Als je dat wilt weten, bijvoorbeeld om een betaling aan een klant te koppelen, moet je de afzender vragen een betalings-ID te gebruiken. Dat is een willekeurige optionele tekenreeks dat wordt toegevoegd aan een transactie. Voor het gemak kun je een adres genereren dat al een willekeurige betalings-ID bevat:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"Betalingen aan een geïntegreerd adres dat jij hebt gegenereerd gaan naar "
-"jouw account met vermelding van die betalings-ID, zodat je betalingen kunt "
-"onderscheiden."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Aan een derde bewijzen dat je iemand hebt betaald"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Hierdoor wordt een willekeurige betalings-ID gegenereerd en krijg je een adres waarin je eigen account en de betalings-ID worden samengevat. Het is ook mogelijk om een bepaalde betalings-ID te kiezen als je dat wilt:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Als je een verkoper betaalt, en de verkoper beweert dat hij/zij het geld "
-"niet heeft ontvangen, wil je misschien aan een derde bewijzen dat je het "
-"geld wel degelijk hebt verzonden - of aan de verkoper zelf, als het een "
-"eerlijke vergissing is. Monero is vertrouwelijk, dus je kunt niet zomaar je "
-"transactie aanwijzen op de blockchain, want daar is niet te zien wie een "
-"transactie heeft verzonden of ontvangen. Maar je kunt iemand wel de "
-"privésleutel van een transactie geven, zodat die kan zien of die transactie "
-"Monero naar dat adres heeft verzonden. Houd er rekening mee dat het opslaan "
-"van deze transactiesleutels standaard is uitgeschakeld.  Je moet deze "
-"functie voor het verzenden inschakelen als je denkt dat je deze misschien "
-"nodig hebt:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Je kunt de transactiesleutel van een eerdere transactie ophalen:"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "Betalingen aan een geïntegreerd adres dat jij hebt gegenereerd gaan naar jouw account met vermelding van die betalings-ID, zodat je betalingen kunt onderscheiden."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Voer hierbij de ID in van de transactie waarvoor u de sleutel wilt "
-"hebben. Houd er rekening mee dat een betaling kan zijn gesplitst in meer dan "
-"één transactie, zodat je meerdere sleutels nodig hebt. Vervolgens kun je de "
-"sleutel of sleutels opsturen naar wie je het bewijs van je transactie wilt "
-"laten zien, met de transactie-ID en het adres van de ontvanger "
-"erbij. Opmerking: als deze partij ook je eigen adres kent, kan deze ook zien "
-"hoeveel wisselgeld je hebt teruggekregen."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Als je zelf de derde partij bent (dus als iemand aan jou wilt bewijzen dat "
-"hij/zij Monero naar een bepaald adres heeft verzonden), kun je dat op deze "
-"manier controleren:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID SLEUTEL ADRES\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Vervang `TXID` door de transactie-ID, `SLEUTEL` door de transactiesleutel en "
-"`ADRES` door het doeladres dat je hebt ontvangen. Vervolgens controleert "
-"monero-wallet-cli die transactie en laat het weten hoeveel door deze "
-"transactie aan het opgegeven adres is betaald."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Instellen dat je betalingen kunt bevestigen/annuleren"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-"Als je een laatste kans wilt krijgen om een betaling te bevestigen of "
-"annuleren:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Een betaling aan jou vinden"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Als je een betaling met een bepaalde betalings-ID hebt ontvangen, kun je "
-"deze opzoeken:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments BETALINGSID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Aan een derde bewijzen dat je iemand hebt betaald"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Als je een verkoper betaalt, en de verkoper beweert dat hij/zij het geld niet heeft ontvangen, wil je misschien aan een derde bewijzen dat je het geld wel degelijk hebt verzonden - of aan de verkoper zelf, als het een eerlijke vergissing is. Monero is vertrouwelijk, dus je kunt niet zomaar je transactie aanwijzen op de blockchain, want daar is niet te zien wie een transactie heeft verzonden of ontvangen. Maar je kunt iemand wel de privésleutel van een transactie geven, zodat die kan zien of die transactie Monero naar dat adres heeft verzonden. Houd er rekening mee dat het opslaan van deze transactiesleutels standaard is uitgeschakeld.  Je moet deze functie voor het verzenden inschakelen als je denkt dat je deze misschien nodig hebt:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Je kunt de transactiesleutel van een eerdere transactie ophalen:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Voer hierbij de ID in van de transactie waarvoor u de sleutel wilt hebben. Houd er rekening mee dat een betaling kan zijn gesplitst in meer dan één transactie, zodat je meerdere sleutels nodig hebt. Vervolgens kun je de sleutel of sleutels opsturen naar wie je het bewijs van je transactie wilt laten zien, met de transactie-ID en het adres van de ontvanger erbij. Opmerking: als deze partij ook je eigen adres kent, kan deze ook zien hoeveel wisselgeld je hebt teruggekregen."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Als je zelf de derde partij bent (dus als iemand aan jou wilt bewijzen dat hij/zij Monero naar een bepaald adres heeft verzonden), kun je dat op deze manier controleren:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID SLEUTEL ADRES\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Vervang `TXID` door de transactie-ID, `SLEUTEL` door de transactiesleutel en `ADRES` door het doeladres dat je hebt ontvangen. Vervolgens controleert monero-wallet-cli die transactie en laat het weten hoeveel door deze transactie aan het opgegeven adres is betaald."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Een betaling aan jou vinden"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Als je een betaling met een bepaalde betalings-ID hebt ontvangen, kun je deze opzoeken:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments BETALINGSID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Je kunt ook meer dan één betalings-ID opgeven."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
 msgstr "In het algemeen kun je binnenkomende en uitgaande betalingen bekijken:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Je kunt een optionele blokhoogte opgeven om alleen recente transacties te "
-"ontvangen, en je kunt alleen binnenkomende of uitgaande transactie "
-"opvragen. Bijvoorbeeld:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Je kunt een optionele blokhoogte opgeven om alleen recente transacties te ontvangen, en je kunt alleen binnenkomende of uitgaande transactie opvragen. Bijvoorbeeld:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"levert alleen binnenkomende overboekingen na blok 650.000 op. Je kunt ook "
-"een bereik van blokhoogten opgeven."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "levert alleen binnenkomende overboekingen na blok 650.000 op. Je kunt ook een bereik van blokhoogten opgeven."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "Als je wilt minen, kun je dat ook vanuit de portemonnee doen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Hiermee gebruik je twee CPU-threads om te minen via de daemon. Let op: dit "
-"is solo minen; het kan lang duren voordat je een blok vindt. Om te stoppen "
-"met minen:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Hiermee gebruik je twee CPU-threads om te minen via de daemon. Let op: dit is solo minen; het kan lang duren voordat je een blok vindt. Om te stoppen met minen:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Voorbeeld:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Hiermee worden blokken uit de node opgehaald die de portemonnee nog niet gezien heeft, en wordt je saldo navenant bijgewerkt. Dit proces wordt normaal ongeveer één keer per minuut in de achtergrond uitgevoerd. Zo geef je het saldo weer zonder te vernieuwen:"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Wat je nodig hebt is het standaardadres waaraan je wilt betalen (een lange tekenreeks die begint met een 4), en eventueel een betalings-ID als de ontvangende partij daarom vraagt. In dat geval kan de begunstigde ook een geïntegreerd adres opgeven, waarbij het standaardadres en de betalings-ID in één adres worden verpakt."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### Verzenden naar een standaardadres:"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADRES BEDRAG BETALINGSID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Vervang `ADRES` door het adres waaraan je wilt betalen, `BEDRAG` door hoeveel Monero je wilt betalen en `BETALINGSID` door de betalings-ID die je hebt ontvangen. Betalings-ID's zijn optioneel. Als de ontvangende partij er geen nodig heeft, kun je de ID gewoon weglaten."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### Verzenden naar een geïntegreerd adres:"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "Hier is de betalings-ID opgenomen in het geïntegreerde adres."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Het aantal outputs in een transactie opgeven:"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGGROOTTE ADRES BEDRAG\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Vervang `RINGGROOTTE` door het aantal outputs dat je wilt gebruiken. **Als je niets opgeeft is de standaardwaarde 11.** Het is beter om de standaardwaarde te gebruiken, maar je kunt eventueel een hoger aantal opgeven als ze meer outputs wilt meenemen. Hoe hoger het aantal, des te groter de transactie en des te hoger de transactiekosten."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Instellen dat je betalingen kunt bevestigen/annuleren"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Als je een laatste kans wilt krijgen om een betaling te bevestigen of annuleren:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/pl/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/pl/resources/user-guides/monero-wallet-cli.md
@@ -1,114 +1,217 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` jest oprogramowaniem, które współpracuje z Monero. To program konsoli zarządzający kontem. Podczas gdy portfel Bitcoina zarządza zarówno kontem, jak i łańcuchem bloków, Monero rozdzielił je, aby `monerod`operował łańcuchem, a `monero-wallet-cli` kontem.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-Ten przewodnik pokaże, jak wykonywać różne operacje w interfejsie `monero-wallet-cli`. Przewodnik zakłada, że używasz najnowszej wersji Monero i założyłeś już swoje konto zgodnie z instrukcjami.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## Sprawdzanie salda
+You can have a list of the most important commands by running `help`:
 
-Ponieważ zarządzanie łańcuchem bloków i portfelem odbywa się za pomocą różnych programów, wielokrotnie użycie `monero-wallet-cli` wymaga współpracy z daemonem. Obejmuje to również sprawdzanie płatności przychodzących na twój adres. Uruchamiając równocześnie `monero-wallet-cli` i `monerod`, wpisz `balance`.
+```
+Important commands:
 
-Przykład:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-Przyciągnie to bloki z daemona, których portfel jeszcze nie widział oraz zaktualizuje twoje saldo. Ten proces przeważnie odbywa się mniej więcej co minutę w tle. Aby zobaczyć saldo bez aktualizowania, wpisz:
+"donate <amount>" - Donate XMR to the development team.
+```
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+## Checking your balance
 
-W tym przypadku, `Balance` jest twoim saldem całkowitym. `unlocked balance` jest kwotą aktualnie dostępną do wydania. Nowe transakcje przychodzące wymagają 10 potwierdzeń zanim zostaną odblokowane. `unlocked dust` to bardzo mała liczba niewydanych wyników, które mogły się nagromadzić na twoim koncie.
+Ponieważ zarządzanie łańcuchem bloków i portfelem odbywa się za pomocą
+różnych programów, wielokrotnie użycie `monero-wallet-cli` wymaga współpracy
+z daemonem. Obejmuje to również sprawdzanie płatności przychodzących na twój
+adres. Uruchamiając równocześnie `monero-wallet-cli` i `monerod`, wpisz
+`balance`.
 
-## Wysyłanie monero
+Output:
 
-Będziesz potrzebował standardowego adresu, na który chcesz przesłać środki (długi ciąg zaczynający się na "4") oraz możliwe, że także numer identyfikacyjny odbiorcy, jeśli ten go wymaga. W takim przypadku, odbiorca może przekazać ci adres zintegrowany, który składa się z numeru identyfikacyjnego oraz adresu standardowego.
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-### Wysyłanie na adres standardowy:
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-    transfer ADDRESS AMOUNT PAYMENTID
+## Sending monero
 
-Zamień `ADDRESS` na adres, na który chcesz dokonać płatności, `AMOUNT` na kwotę w Monero, jaką chcesz przesłać oraz `PAYMENTID` na numer identyfikacyjny, który podał ci odbiorca. Podanie numeru identyfikacyjnego jest opcjonalne, jeśli odbiorca ci go nie podał, po prostu go pomiń.
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-### Wysyłanie na adres zintegrowany:
+```
+transfer ADDRESS AMOUNT
+```
 
-    transfer ADDRESS AMOUNT
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-Numer identyfikacyjny w tym przypadku jest domniemany w adresie zintegrowanym.
+## Receiving monero
 
-### Precyzowanie liczby wyników transakcji:
+If you have your own Monero address, you just need to give your address to
+someone.
 
-    transfer RINGSIZE ADDRESS AMOUNT
+You can find out your primary address with:
 
-Zamień `RINGSIZE` na numer wyników, jaki chcesz użyć. **Domyślny numer wyników, gdy niesprecyzowany, wynosi 11.** Dobrym pomysłem jest użycie numeru domyślnego, ale możesz zwiększyć go, gdy chcesz dołączyć więcej wyników. Im wyższy numer, tym większa transakcja i wyższe opłaty.
+```
+address
+```
 
-## Otrzymywanie Monero:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-Jeśli posiadasz własny adres Monero, wystarczy przekazać nadawcy twój adres standardowy.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Swój adres znajdziesz pod funkcją:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-Ponieważ Monero jest anonimowe, nie zobaczysz adresu nadawcy. Jeżeli chcesz go poznać, na przykład, żeby podziękować konkretnemu klientowi, poproś nadawcę o użycie opcjonalnego numeru identyfikacyjnego, który może zostać przypisany transakcji. Aby uprościć życie, możesz wygenerować adres zintegrowany, który już zawiera losowy numer identyfikacyjny, za pomocą funkcji:
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-Funkcja ta wygeneruje losowy numer identyfikacyjny i stworzy adres, który już zawiera twoje konto i numer identyfikacyjny tej płatności. Jeśli chcesz wybrać określony numer identyfikacyjny, użyj funkcji:
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-Płatności dokonane na adres zintegrowany wygenerowany z twojego konta przejdą na twoje konto wraz z załączonym numerem identyfikacyjnym, umożliwiając rozróżnienie transakcji.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## Udowadnianie płatności osobom trzecim:
+will generate a subaddress and its label 'github_donations'.
 
-Gdy dokonasz zapłaty, a odbiorca stwierdzi, że jej nie otrzymał, możesz udowodnić swoją płatność osobom trzecim lub samemu odbiorcy, jeśli po prostu popełnił on pomyłkę. Monero jest prywatne, a więc nie możesz po prostu wskazać na swoją transakcję w łańcuchu bloków, ponieważ nie da się rozróżnić, kto ją wysłał, a kto odebrał. Możesz jednak przekazać stronie prywatny klucz transakcji, aby strona rozpoznała, czy dokonana została płatność na dany adres. Zauważ, że zachowanie tych kluczy transakcji domyślnie jest wyłączone i musisz go włączyć przed dokonaniem płatności, jeśli uważasz, że będziesz ich potrzebował:
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Gdy dokonasz zapłaty, a odbiorca stwierdzi, że jej nie otrzymał, możesz
+udowodnić swoją płatność osobom trzecim lub samemu odbiorcy, jeśli po prostu
+popełnił on pomyłkę. Monero jest prywatne, a więc nie możesz po prostu
+wskazać na swoją transakcję w łańcuchu bloków, ponieważ nie da się
+rozróżnić, kto ją wysłał, a kto odebrał. Możesz jednak przekazać stronie
+prywatny klucz transakcji, aby strona rozpoznała, czy dokonana została
+płatność na dany adres. Zauważ, że zachowanie tych kluczy transakcji
+domyślnie jest wyłączone i musisz go włączyć przed dokonaniem płatności,
+jeśli uważasz, że będziesz ich potrzebował:
+
+```
+set store-tx-info 1
+```
 
 Możesz przywróciń klucz tx z wcześniejszej transakcji:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Wskaż numer identyfikacyjny transakcji, dla której chcesz otrzymań klucz. Pamiętaj, że płatność może zostać podzielona na więcej niż jedną transakcję, więc możesz potrzebować kilku kluczy. Następnie możesz przesłać otrzymany klucz lub klucze do osoby, której chcesz udowodnić dokonanie płatności, razem z numerem identyfikacyjnym transakcji i adresem odbiorcy. Zauważ, że strona trzecia, znając twój adres, będzie w stanie zobaczyć także, ile zwrotu otrzymałeś.
+Wskaż numer identyfikacyjny transakcji, dla której chcesz otrzymań
+klucz. Pamiętaj, że płatność może zostać podzielona na więcej niż jedną
+transakcję, więc możesz potrzebować kilku kluczy. Następnie możesz przesłać
+otrzymany klucz lub klucze do osoby, której chcesz udowodnić dokonanie
+płatności, razem z numerem identyfikacyjnym transakcji i adresem
+odbiorcy. Zauważ, że strona trzecia, znając twój adres, będzie w stanie
+zobaczyć także, ile zwrotu otrzymałeś.
 
-Jeżeli to ty jesteś stroną trzecią (to znaczy ktoś chce ci udowodnić, że przelał Monero na dany adres), sprawdź w ten sposób:
+Jeżeli to ty jesteś stroną trzecią (to znaczy ktoś chce ci udowodnić, że
+przelał Monero na dany adres), sprawdź w ten sposób:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Zamień `TXID`, `TXKEY` i `ADDRESS` na, odpowiednio, numer identyfikacyjny transakcji, klucz transakcji oraz przekazany ci adres odbiorcy. monero-wallet-cli sprawdzi tę transakcję i poinformuje cię, ile Monero zostało przesłane na dany adres.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
+## How to find a payment to you
 
-## Uzyskiwanie szansy na potwierdzenie lub anulowanie płatności:
+Jeśli otrzymałeś płatność z użyciem określonego numeru identyfikacyjnego,
+wyszukaj go, wpisując:
 
-Jeśli chcesz uzyskać ostatnią szansę na potwierdzenie płatności, użyj funkcji:
-
-    set always-confirm-transfers 1
-
-
-## Jak odnaleźć płatność przychodzącą:
-
-Jeśli otrzymałeś płatność z użyciem określonego numeru identyfikacyjnego, wyszukaj go, wpisując:
-
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 Możesz podań więcej niż jeden numer identyfikacyjny.
 
-Najczęściej możesz przeglądać swoje płatności przychodzące i wychodzące za pomocą funkcji:
+Najczęściej możesz przeglądać swoje płatności przychodzące i wychodzące za
+pomocą funkcji:
 
-    show_transfers
+```
+show_transfers
+```
 
-Dodając wysokość łańcucha bloków, znajdziesz jedynie najnowsze transakcje. Możesz także wybrać tylko transakcje przychodzące lub tylko wychodzące. Na przykład:
+Dodając wysokość łańcucha bloków, znajdziesz jedynie najnowsze
+transakcje. Możesz także wybrać tylko transakcje przychodzące lub tylko
+wychodzące. Na przykład:
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-pokaże jedynie przychodzące płatności następujące po bloku 650000. Możesz także sprecyzować zakres wysokości.
+pokaże jedynie przychodzące płatności następujące po bloku 650000. Możesz
+także sprecyzować zakres wysokości.
 
 Możesz zacząć wydobywać bezpośrednio z portfela, wpisując:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Wydobycie zacznie się za pomocą daemona i dwóch pasem. Zauważ, że jest to wydobycie samemu i może chwilę zająć znalezienie bloku. Aby zakończyć wydobycie, wpisz:
+Wydobycie zacznie się za pomocą daemona i dwóch pasem. Zauważ, że jest to
+wydobycie samemu i może chwilę zająć znalezienie bloku. Aby zakończyć
+wydobycie, wpisz:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/pl/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/pl/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:18+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,434 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` jest oprogramowaniem, które współpracuje z Monero. To "
-"program konsoli zarządzający kontem. Podczas gdy portfel Bitcoina zarządza "
-"zarówno kontem, jak i łańcuchem bloków, Monero rozdzielił je, aby "
-"`monerod`operował łańcuchem, a `monero-wallet-cli` kontem."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` jest oprogramowaniem, które współpracuje z Monero. To program konsoli zarządzający kontem. Podczas gdy portfel Bitcoina zarządza zarówno kontem, jak i łańcuchem bloków, Monero rozdzielił je, aby `monerod`operował łańcuchem, a `monero-wallet-cli` kontem."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "Ten przewodnik pokaże, jak wykonywać różne operacje w interfejsie `monero-wallet-cli`. Przewodnik zakłada, że używasz najnowszej wersji Monero i założyłeś już swoje konto zgodnie z instrukcjami."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"Ten przewodnik pokaże, jak wykonywać różne operacje w interfejsie "
-"`monero-wallet-cli`. Przewodnik zakłada, że używasz najnowszej wersji Monero "
-"i założyłeś już swoje konto zgodnie z instrukcjami."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Sprawdzanie salda"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Ponieważ zarządzanie łańcuchem bloków i portfelem odbywa się za pomocą "
-"różnych programów, wielokrotnie użycie `monero-wallet-cli` wymaga współpracy "
-"z daemonem. Obejmuje to również sprawdzanie płatności przychodzących na twój "
-"adres. Uruchamiając równocześnie `monero-wallet-cli` i `monerod`, wpisz "
-"`balance`."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Przykład:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Przyciągnie to bloki z daemona, których portfel jeszcze nie widział oraz "
-"zaktualizuje twoje saldo. Ten proces przeważnie odbywa się mniej więcej co "
-"minutę w tle. Aby zobaczyć saldo bez aktualizowania, wpisz:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"W tym przypadku, `Balance` jest twoim saldem całkowitym. `unlocked balance` "
-"jest kwotą aktualnie dostępną do wydania. Nowe transakcje przychodzące "
-"wymagają 10 potwierdzeń zanim zostaną odblokowane. `unlocked dust` to bardzo "
-"mała liczba niewydanych wyników, które mogły się nagromadzić na twoim "
-"koncie."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Wysyłanie monero"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Będziesz potrzebował standardowego adresu, na który chcesz przesłać środki "
-"(długi ciąg zaczynający się na \"4\") oraz możliwe, że także numer "
-"identyfikacyjny odbiorcy, jeśli ten go wymaga. W takim przypadku, odbiorca "
-"może przekazać ci adres zintegrowany, który składa się z numeru "
-"identyfikacyjnego oraz adresu standardowego."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### Wysyłanie na adres standardowy:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Zamień `ADDRESS` na adres, na który chcesz dokonać płatności, `AMOUNT` na "
-"kwotę w Monero, jaką chcesz przesłać oraz `PAYMENTID` na numer "
-"identyfikacyjny, który podał ci odbiorca. Podanie numeru identyfikacyjnego "
-"jest opcjonalne, jeśli odbiorca ci go nie podał, po prostu go pomiń."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### Wysyłanie na adres zintegrowany:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Ponieważ zarządzanie łańcuchem bloków i portfelem odbywa się za pomocą różnych programów, wielokrotnie użycie `monero-wallet-cli` wymaga współpracy z daemonem. Obejmuje to również sprawdzanie płatności przychodzących na twój adres. Uruchamiając równocześnie `monero-wallet-cli` i `monerod`, wpisz `balance`."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADDRESS AMOUNT\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
+msgid "Output:"
 msgstr ""
-"Numer identyfikacyjny w tym przypadku jest domniemany w adresie "
-"zintegrowanym."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Precyzowanie liczby wyników transakcji:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Zamień `RINGSIZE` na numer wyników, jaki chcesz użyć. **Domyślny numer "
-"wyników, gdy niesprecyzowany, wynosi 11.** Dobrym pomysłem jest użycie "
-"numeru domyślnego, ale możesz zwiększyć go, gdy chcesz dołączyć więcej "
-"wyników. Im wyższy numer, tym większa transakcja i wyższe opłaty."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "W tym przypadku, `Balance` jest twoim saldem całkowitym. `unlocked balance` jest kwotą aktualnie dostępną do wydania. Nowe transakcje przychodzące wymagają 10 potwierdzeń zanim zostaną odblokowane. `unlocked dust` to bardzo mała liczba niewydanych wyników, które mogły się nagromadzić na twoim koncie."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Wysyłanie monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADDRESS AMOUNT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Otrzymywanie Monero:"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Jeśli posiadasz własny adres Monero, wystarczy przekazać nadawcy twój adres "
-"standardowy."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Swój adres znajdziesz pod funkcją:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"Ponieważ Monero jest anonimowe, nie zobaczysz adresu nadawcy. Jeżeli chcesz "
-"go poznać, na przykład, żeby podziękować konkretnemu klientowi, poproś "
-"nadawcę o użycie opcjonalnego numeru identyfikacyjnego, który może zostać "
-"przypisany transakcji. Aby uprościć życie, możesz wygenerować adres "
-"zintegrowany, który już zawiera losowy numer identyfikacyjny, za pomocą "
-"funkcji:"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Jeśli posiadasz własny adres Monero, wystarczy przekazać nadawcy twój adres standardowy."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Swój adres znajdziesz pod funkcją:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Funkcja ta wygeneruje losowy numer identyfikacyjny i stworzy adres, który "
-"już zawiera twoje konto i numer identyfikacyjny tej płatności. Jeśli chcesz "
-"wybrać określony numer identyfikacyjny, użyj funkcji:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "Ponieważ Monero jest anonimowe, nie zobaczysz adresu nadawcy. Jeżeli chcesz go poznać, na przykład, żeby podziękować konkretnemu klientowi, poproś nadawcę o użycie opcjonalnego numeru identyfikacyjnego, który może zostać przypisany transakcji. Aby uprościć życie, możesz wygenerować adres zintegrowany, który już zawiera losowy numer identyfikacyjny, za pomocą funkcji:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"Płatności dokonane na adres zintegrowany wygenerowany z twojego konta "
-"przejdą na twoje konto wraz z załączonym numerem identyfikacyjnym, "
-"umożliwiając rozróżnienie transakcji."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Udowadnianie płatności osobom trzecim:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Funkcja ta wygeneruje losowy numer identyfikacyjny i stworzy adres, który już zawiera twoje konto i numer identyfikacyjny tej płatności. Jeśli chcesz wybrać określony numer identyfikacyjny, użyj funkcji:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Gdy dokonasz zapłaty, a odbiorca stwierdzi, że jej nie otrzymał, możesz "
-"udowodnić swoją płatność osobom trzecim lub samemu odbiorcy, jeśli po prostu "
-"popełnił on pomyłkę. Monero jest prywatne, a więc nie możesz po prostu "
-"wskazać na swoją transakcję w łańcuchu bloków, ponieważ nie da się "
-"rozróżnić, kto ją wysłał, a kto odebrał. Możesz jednak przekazać stronie "
-"prywatny klucz transakcji, aby strona rozpoznała, czy dokonana została "
-"płatność na dany adres. Zauważ, że zachowanie tych kluczy transakcji "
-"domyślnie jest wyłączone i musisz go włączyć przed dokonaniem płatności, "
-"jeśli uważasz, że będziesz ich potrzebował:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Możesz przywróciń klucz tx z wcześniejszej transakcji:"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "Płatności dokonane na adres zintegrowany wygenerowany z twojego konta przejdą na twoje konto wraz z załączonym numerem identyfikacyjnym, umożliwiając rozróżnienie transakcji."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Wskaż numer identyfikacyjny transakcji, dla której chcesz otrzymań "
-"klucz. Pamiętaj, że płatność może zostać podzielona na więcej niż jedną "
-"transakcję, więc możesz potrzebować kilku kluczy. Następnie możesz przesłać "
-"otrzymany klucz lub klucze do osoby, której chcesz udowodnić dokonanie "
-"płatności, razem z numerem identyfikacyjnym transakcji i adresem "
-"odbiorcy. Zauważ, że strona trzecia, znając twój adres, będzie w stanie "
-"zobaczyć także, ile zwrotu otrzymałeś."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Jeżeli to ty jesteś stroną trzecią (to znaczy ktoś chce ci udowodnić, że "
-"przelał Monero na dany adres), sprawdź w ten sposób:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Zamień `TXID`, `TXKEY` i `ADDRESS` na, odpowiednio, numer identyfikacyjny "
-"transakcji, klucz transakcji oraz przekazany ci adres "
-"odbiorcy. monero-wallet-cli sprawdzi tę transakcję i poinformuje cię, ile "
-"Monero zostało przesłane na dany adres."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Uzyskiwanie szansy na potwierdzenie lub anulowanie płatności:"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-"Jeśli chcesz uzyskać ostatnią szansę na potwierdzenie płatności, użyj "
-"funkcji:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Jak odnaleźć płatność przychodzącą:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Jeśli otrzymałeś płatność z użyciem określonego numeru identyfikacyjnego, "
-"wyszukaj go, wpisując:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Udowadnianie płatności osobom trzecim:"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Gdy dokonasz zapłaty, a odbiorca stwierdzi, że jej nie otrzymał, możesz udowodnić swoją płatność osobom trzecim lub samemu odbiorcy, jeśli po prostu popełnił on pomyłkę. Monero jest prywatne, a więc nie możesz po prostu wskazać na swoją transakcję w łańcuchu bloków, ponieważ nie da się rozróżnić, kto ją wysłał, a kto odebrał. Możesz jednak przekazać stronie prywatny klucz transakcji, aby strona rozpoznała, czy dokonana została płatność na dany adres. Zauważ, że zachowanie tych kluczy transakcji domyślnie jest wyłączone i musisz go włączyć przed dokonaniem płatności, jeśli uważasz, że będziesz ich potrzebował:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Możesz przywróciń klucz tx z wcześniejszej transakcji:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Wskaż numer identyfikacyjny transakcji, dla której chcesz otrzymań klucz. Pamiętaj, że płatność może zostać podzielona na więcej niż jedną transakcję, więc możesz potrzebować kilku kluczy. Następnie możesz przesłać otrzymany klucz lub klucze do osoby, której chcesz udowodnić dokonanie płatności, razem z numerem identyfikacyjnym transakcji i adresem odbiorcy. Zauważ, że strona trzecia, znając twój adres, będzie w stanie zobaczyć także, ile zwrotu otrzymałeś."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Jeżeli to ty jesteś stroną trzecią (to znaczy ktoś chce ci udowodnić, że przelał Monero na dany adres), sprawdź w ten sposób:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Zamień `TXID`, `TXKEY` i `ADDRESS` na, odpowiednio, numer identyfikacyjny transakcji, klucz transakcji oraz przekazany ci adres odbiorcy. monero-wallet-cli sprawdzi tę transakcję i poinformuje cię, ile Monero zostało przesłane na dany adres."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Jak odnaleźć płatność przychodzącą:"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Jeśli otrzymałeś płatność z użyciem określonego numeru identyfikacyjnego, wyszukaj go, wpisując:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Możesz podań więcej niż jeden numer identyfikacyjny."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-"Najczęściej możesz przeglądać swoje płatności przychodzące i wychodzące za "
-"pomocą funkcji:"
+msgstr "Najczęściej możesz przeglądać swoje płatności przychodzące i wychodzące za pomocą funkcji:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Dodając wysokość łańcucha bloków, znajdziesz jedynie najnowsze "
-"transakcje. Możesz także wybrać tylko transakcje przychodzące lub tylko "
-"wychodzące. Na przykład:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Dodając wysokość łańcucha bloków, znajdziesz jedynie najnowsze transakcje. Możesz także wybrać tylko transakcje przychodzące lub tylko wychodzące. Na przykład:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"pokaże jedynie przychodzące płatności następujące po bloku 650000. Możesz "
-"także sprecyzować zakres wysokości."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "pokaże jedynie przychodzące płatności następujące po bloku 650000. Możesz także sprecyzować zakres wysokości."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
 msgstr "Możesz zacząć wydobywać bezpośrednio z portfela, wpisując:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Wydobycie zacznie się za pomocą daemona i dwóch pasem. Zauważ, że jest to "
-"wydobycie samemu i może chwilę zająć znalezienie bloku. Aby zakończyć "
-"wydobycie, wpisz:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Wydobycie zacznie się za pomocą daemona i dwóch pasem. Zauważ, że jest to wydobycie samemu i może chwilę zająć znalezienie bloku. Aby zakończyć wydobycie, wpisz:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Przykład:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Przyciągnie to bloki z daemona, których portfel jeszcze nie widział oraz zaktualizuje twoje saldo. Ten proces przeważnie odbywa się mniej więcej co minutę w tle. Aby zobaczyć saldo bez aktualizowania, wpisz:"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Będziesz potrzebował standardowego adresu, na który chcesz przesłać środki (długi ciąg zaczynający się na \"4\") oraz możliwe, że także numer identyfikacyjny odbiorcy, jeśli ten go wymaga. W takim przypadku, odbiorca może przekazać ci adres zintegrowany, który składa się z numeru identyfikacyjnego oraz adresu standardowego."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### Wysyłanie na adres standardowy:"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Zamień `ADDRESS` na adres, na który chcesz dokonać płatności, `AMOUNT` na kwotę w Monero, jaką chcesz przesłać oraz `PAYMENTID` na numer identyfikacyjny, który podał ci odbiorca. Podanie numeru identyfikacyjnego jest opcjonalne, jeśli odbiorca ci go nie podał, po prostu go pomiń."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### Wysyłanie na adres zintegrowany:"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "Numer identyfikacyjny w tym przypadku jest domniemany w adresie zintegrowanym."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Precyzowanie liczby wyników transakcji:"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Zamień `RINGSIZE` na numer wyników, jaki chcesz użyć. **Domyślny numer wyników, gdy niesprecyzowany, wynosi 11.** Dobrym pomysłem jest użycie numeru domyślnego, ale możesz zwiększyć go, gdy chcesz dołączyć więcej wyników. Im wyższy numer, tym większa transakcja i wyższe opłaty."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Uzyskiwanie szansy na potwierdzenie lub anulowanie płatności:"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Jeśli chcesz uzyskać ostatnią szansę na potwierdzenie płatności, użyj funkcji:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/pt-br/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/pt-br/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,211 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
-`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
-and manages an account. While a bitcoin wallet manages both an account and the blockchain,
-Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
+
+You can have a list of the most important commands by running `help`:
+
+```
+Important commands:
+
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
+
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
+
+"donate <amount>" - Donate XMR to the development team.
+```
 
 ## Checking your balance
 
-Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli`
-need to work with the @daemon. This includes looking for incoming transactions to your address.
-Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`.
+Since the blockchain handling and the wallet are separate programs, many
+uses of `monero-wallet-cli` need to work with the @daemon. This includes
+looking for incoming transactions to your address.  Once you are running
+both `monero-wallet-cli` and `monerod`, enter `balance`.
 
-Example:
+Output:
 
-This will pull blocks from the daemon the wallet did not yet see, and update your balance
-to match. This process will normally be done in the background every minute or so. To see the
-balance without refreshing:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-
-In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
 ## Sending monero
 
-You will need the standard address you want to send to (a long string starting with '4'), and
-possibly a payment ID, if the receiving party requires one. In that latter case, that party
-may instead give you an integrated address, which is both of these packed into a single address.
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-### Sending to a standard address:
+```
+transfer ADDRESS AMOUNT
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
-
-Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send,
-and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just
-omit it.
-
-### Sending to an integrated address:
-
-    transfer ADDRESS AMOUNT
-
-The payment ID is implicit in the integrated address in that case.
-
-### Specify the number of outputs for a transaction:
-
-    transfer RINGSIZE ADDRESS AMOUNT
-
-Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed.
-
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
 ## Receiving monero
 
-If you have your own Monero address, you just need to give your standard address to someone.
+If you have your own Monero address, you just need to give your address to
+someone.
 
-You can find out your address with:
+You can find out your primary address with:
 
-    address
+```
+address
+```
 
-Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you
-want to know, for instance to credit a particular customer, you'll have to tell the sender to use
-a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life
-easier, you can generate an address that already includes a random payment ID:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-    integrated_address
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-This will generate a random payment ID, and give you the address that includes your own account
-and that payment ID. If you want to select a particular payment ID, you can do that too:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    integrated_address 12346780abcdef00
+```
+integrated_address 82d79055f3b27f56
+```
 
-Payments made to an integrated address generated from your account will go to your account,
-with that payment id attached, so you can tell payments apart.
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
+### Using subaddresses
+
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
+
+```
+address new [<label text with white spaces allowed>]
+```
+
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
+
+```
+address new github_donations
+```
+
+will generate a subaddress and its label 'github_donations'.
+
+To view all generated addresses, run:
+
+```
+address all
+```
 
 ## Proving to a third party you paid someone
 
-If you pay a merchant, and the merchant claims to not have received the funds, you may need
-to prove to a third party you did send the funds - or even to the merchant, if it is a honest
-mistake. Monero is private, so you can't just point to your transaction in the blockchain,
-as you can't tell who sent it, and who received it. However, by supplying the per-transaction
-private key to a party, that party can tell whether that transaction sent monero to that
-particular address. Note that storing these per-transaction keys is disabled by default, and
-you will have to enable it before sending, if you think you may need it:
+If you pay a merchant, and the merchant claims to not have received the
+funds, you may need to prove to a third party you did send the funds - or
+even to the merchant, if it is a honest mistake. Monero is private, so you
+can't just point to your transaction in the blockchain, as you can't tell
+who sent it, and who received it. However, by supplying the per-transaction
+private key to a party, that party can tell whether that transaction sent
+monero to that particular address. Note that storing these per-transaction
+keys is disabled by default, and you will have to enable it before sending,
+if you think you may need it:
 
-    set store-tx-info 1
+```
+set store-tx-info 1
+```
 
 You can retrieve the tx key from an earlier transaction:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Pass in the transaction ID you want the key for. Remember that a payment might have been
-split in more than one transaction, so you may need several keys. You can then send that key,
-or these keys, to whoever you want to provide proof of your transaction, along with the
-transaction id and the address you sent to. Note that this third party, if knowing your
-own address, will be able to see how much change was returned to you as well.
+Pass in the transaction ID you want the key for. Remember that a payment
+might have been split in more than one transaction, so you may need several
+keys. You can then send that key, or these keys, to whoever you want to
+provide proof of your transaction, along with the transaction id and the
+address you sent to. Note that this third party, if knowing your own
+address, will be able to see how much change was returned to you as well.
 
-If you are the third party (that is, someone wants to prove to you that they sent monero
-to an address), then you can check this way:
+If you are the third party (that is, someone wants to prove to you that they
+sent monero to an address), then you can check this way:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination
-address which were supplied to you, respectively. monero-wallet-cli will check that transaction
-and let you know how much monero this transaction paid to the given address.
-
-
-## Getting a chance to confirm/cancel payments
-
-If you want to get a last chance confirmation when sending a payment:
-
-    set always-confirm-transfers 1
-
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
 ## How to find a payment to you
 
 If you received a payment using a particular payment ID, you can look it up:
 
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 You can give more than one payment ID too.
 
 More generally, you can review incoming and outgoing payments:
 
-    show_transfers
+```
+show_transfers
+```
 
-You can give an optional height to list only recent transactions, and request
-only incoming or outgoing transactions. For example,
+You can give an optional height to list only recent transactions, and
+request only incoming or outgoing transactions. For example,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-will only show incoming transfers after block 650000. You can also give a height
-range.
+will only show incoming transfers after block 650000. You can also give a
+height range.
 
 If you want to mine, you can do so from the wallet:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-This will start mining on the daemon usin two threads. Note that this is solo mining,
-and may take a while before you find a block. To stop mining:
+This will start mining on the daemon usin two threads. Note that this is
+solo mining, and may take a while before you find a block. To stop mining:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/pt-br/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/pt-br/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:15+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,360 +22,315 @@ msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
 #, no-wrap
 msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
+msgid "Checking your balance"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
+msgid "Output:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-#, no-wrap
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
 #, no-wrap
-msgid "    address\n"
+msgid "Sending monero"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, no-wrap
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, no-wrap
+msgid "Receiving monero"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
+msgid "If you have your own Monero address, you just need to give your address to someone."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-#, no-wrap
-msgid "    integrated_address\n"
+msgid "You can find out your primary address with:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
 #, no-wrap
-msgid "    integrated_address 12346780abcdef00\n"
+msgid "address\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
-msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
 #, no-wrap
-msgid "    set store-tx-info 1\n"
+msgid ""
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, no-wrap
+msgid "integrated_address 82d79055f3b27f56\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
 #, no-wrap
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "Using subaddresses"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
 #, no-wrap
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "address new github_donations\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
+#, no-wrap
+msgid "address all\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
 #, no-wrap
-msgid "    set always-confirm-transfers 1\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-#, no-wrap
-msgid "    payments PAYMENTID\n"
+msgid "Proving to a third party you paid someone"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
-msgid "You can give more than one payment ID too."
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
-msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
 #, no-wrap
-msgid "    show_transfers\n"
+msgid "set store-tx-info 1\n"
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
 #, no-wrap
-msgid "    show_transfers in 650000\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
-msgid "If you want to mine, you can do so from the wallet:"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-#, no-wrap
-msgid "    start_mining 2\n"
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, no-wrap
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
 #, no-wrap
-msgid "    stop_mining\n"
+msgid "How to find a payment to you"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, no-wrap
+msgid "payments PAYMENTID\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
+msgid "You can give more than one payment ID too."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
+msgid "More generally, you can review incoming and outgoing payments:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, no-wrap
+msgid "show_transfers\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, no-wrap
+msgid "show_transfers in 650000\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
+msgid "If you want to mine, you can do so from the wallet:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, no-wrap
+msgid "start_mining 2\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, no-wrap
+msgid "stop_mining\n"
 msgstr ""

--- a/_i18n/ru/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/ru/resources/user-guides/monero-wallet-cli.md
@@ -1,113 +1,224 @@
 {% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-`monero-wallet-cli` - это программное обеспечение кошелька, которое поставляется вместе с Monero. Оно представляет собой консольную программу, которая управляет учетными записями пользователей Monero. В то время как кошелек Bitcoin управляет как учетными записями, так и блокчейном, в Monero эти функции разделены: `monerod` обрабатывает блокчейн, а `monero-wallet-cli` обрабатывает учетные записи пользователей.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-В этом руководстве будет показано, как выполнять различные операции из пользовательского интерфейса `monero-wallet-cli`. В руководстве предполагается, что вы используете самую последнюю версию Monero и уже создали учетную запись.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
 
-## Проверяем свой баланс
+You can have a list of the most important commands by running `help`:
 
-Поскольку обработка данных в блокчейне и учетных записей кошельков пользователей совершаются отдельными программами, многие функции `monero-wallet-cli` не будут функционировать без работающего демона. Одной из таких функций является поиск входящих транзакций на ваш адрес. Только когда вы запустите оба приложения, `monero-wallet-cli` и `monerod`, сможете увидеть входящий баланс своего кошелька. Для этого введите команду `balance`.
+```
+Important commands:
 
-Пример:
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
 
-Эта команда синхронизирует блоки из демона, которые еще не «видел» кошелек, и обновит информацию о вашем поточном балансе, чтобы он соответствовал по времени текущему состоянию блокчейна. Этот процесс обычно выполняется автоматически в фоновом режиме каждую минуту или около того. Чтобы увидеть баланс без ожидания автоматического обновления:
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
+"donate <amount>" - Donate XMR to the development team.
+```
 
-В этом примере `Balance` (Баланс) - это ваш текущий общий баланс. `Unlocked balance` (Разблокированный баланс) - это сумма, которую в настоящее время можно потратить. Недавно совершенные транзакции требуют 10 подтверждений в блокчейне перед разблокировкой. Разблокированная пыль (unlocked dust) относится к очень небольшим количествам неизрасходованных выходов, которые могут быть накоплены в процессе работы вашей учетной записи.
+## Checking your balance
 
-## Отправка Monero
+Поскольку обработка данных в блокчейне и учетных записей кошельков
+пользователей совершаются отдельными программами, многие функции
+`monero-wallet-cli` не будут функционировать без работающего демона. Одной
+из таких функций является поиск входящих транзакций на ваш адрес. Только
+когда вы запустите оба приложения, `monero-wallet-cli` и `monerod`, сможете
+увидеть входящий баланс своего кошелька. Для этого введите команду
+`balance`.
 
-Вам понадобится `standart address` (Стандартный адрес), на который вы хотите отправить средства (длинная строка, начинающаяся с «4»), и, возможно, `payment id` (Идентификатор платежа), если принимающая сторона требует этого. В последнем случае принимающая сторона может вместо этого предоставить вам `integrated address` (Интегрированный адрес), который будет содержать в себе обе строки этих данных в упакованном виде в форме одного адреса.
+Output:
 
-### Отправка на стандартный адрес:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
-Вместо `ADDRESS` укажите адрес, на который вы хотите отправить средства, вместо `AMOUNT`, какое количество Monero вы хотите отправить, и вместо `PAYMENTID` идентификатор платежа, который вы получили. Идентификаторы платежей являются необязательными. Если принимающая сторона не нуждается в них, просто не вводите ничего.
+## Sending monero
 
-### Отправка на интегрированный адрес:
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-    transfer ADDRESS AMOUNT
+```
+transfer ADDRESS AMOUNT
+```
 
-Идентификатор платежа в этом случае находится внутри интегрированного адреса.
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
-### Указываем количество выходов для транзакции (размер кольца):
+## Receiving monero
 
-    transfer RINGSIZE ADDRESS AMOUNT
+If you have your own Monero address, you just need to give your address to
+someone.
 
-Вместо `RINGSIZE` укажите количество выходов, которые вы хотите использовать. Если параметр не указан, **по умолчанию будет использоваться значение 11.** Рекомендуется использовать значение по умолчанию, но вы можете увеличить это число, если хотите добавить больше выходов. Чем выше число, тем больше по размеру транзакция и более высокие комиссии.
+You can find out your primary address with:
 
+```
+address
+```
 
-## Получение Monero
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-Если у вас есть собственный кошелек Monero, для получения средств на него вам просто нужно предоставить кому-то свой стандартный адрес.
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-Вы можете узнать свой стандартный адрес, если введете команду:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    address
+```
+integrated_address 82d79055f3b27f56
+```
 
-Поскольку Monero анонимная криптовалюта, вы не увидите адрес источника, из которого вы получили свои средства. Если вам нужно знать эти данные, например, для кредитования конкретного клиента, вам нужно будет договориться с отправителем, чтобы он использовал идентификатор платежа, который является произвольным необязательным тегом, который привязывается к транзакции. Чтобы упростить себе жизнь, вы можете создать интегрированный адрес, который уже содержит этот случайный идентификатор платежа:
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
-    integrated_address
+### Using subaddresses
 
-Это создаст случайный идентификатор платежа и предоставит вам адрес, который будет включать ваш стандартный адрес и этот идентификатор платежа. Если вы хотите выбрать конкретный идентификатор платежа, вы также можете это сделать с помощью команды:
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
 
-    integrated_address 12346780abcdef00
+```
+address new [<label text with white spaces allowed>]
+```
 
-Платежи, внесенные в интегрированный адрес, созданный в вашей учетной записи, будут отправляться вам с прикрепленным идентификатором платежа, чтобы вы могли вести их учет отдельно.
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
 
+```
+address new github_donations
+```
 
-## Как доказать третьей стороне, что вы заплатили кому-то
+will generate a subaddress and its label 'github_donations'.
 
-Если вы платите субъекту, а он заявляет, что не получил средств, вам может потребоваться доказать третьему лицу, которому вы отправляли средства, или даже самому субъекту, что платеж был действительно отправлен. Monero является конфиденциальной сетью, поэтому вы не можете просто указать на свою транзакцию в блокчейне, так как вы не можете сказать, кто ее отправил, и кто ее получил. Однако существует возможность предоставлять `tx key` (Ключ транзакций) третьей стороне, а эта сторона уже сможет определить, была ли отправлена эта транзакция Monero этому конкретному адресу. Обратите внимание, что сохранение этих ключей для каждой транзакции отключено по умолчанию, и вам нужно будет включить его перед отправкой, если вы считаете, что вам может понадобиться данная функция. Делается это с помощью команды:
+To view all generated addresses, run:
 
-    set store-tx-info 1
+```
+address all
+```
+
+## Proving to a third party you paid someone
+
+Если вы платите субъекту, а он заявляет, что не получил средств, вам может
+потребоваться доказать третьему лицу, которому вы отправляли средства, или
+даже самому субъекту, что платеж был действительно отправлен. Monero
+является конфиденциальной сетью, поэтому вы не можете просто указать на свою
+транзакцию в блокчейне, так как вы не можете сказать, кто ее отправил, и кто
+ее получил. Однако существует возможность предоставлять `tx key` (Ключ
+транзакций) третьей стороне, а эта сторона уже сможет определить, была ли
+отправлена эта транзакция Monero этому конкретному адресу. Обратите
+внимание, что сохранение этих ключей для каждой транзакции отключено по
+умолчанию, и вам нужно будет включить его перед отправкой, если вы считаете,
+что вам может понадобиться данная функция. Делается это с помощью команды:
+
+```
+set store-tx-info 1
+```
 
 Вы можете извлечь `tx key` (Ключ транзакций) из более ранней транзакции:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Введите идентификатор транзакции, для которого вы хотите узнать ключ. Помните, что платеж мог быть разделен более чем на одну транзакцию, поэтому вам может понадобиться несколько ключей для каждой транзакции. Затем вы можете отправить этот ключ или ключи кому-либо, кому вы хотите предоставить подтверждение совершения своей транзакции, а также идентификатор транзакции и адрес, на который вы отправили средства. Обратите внимание, что эта третья сторона, зная свой собственный адрес, и эти данные сможет узнать, какие именно средства вы ей отправили.
+Введите идентификатор транзакции, для которого вы хотите узнать
+ключ. Помните, что платеж мог быть разделен более чем на одну транзакцию,
+поэтому вам может понадобиться несколько ключей для каждой транзакции. Затем
+вы можете отправить этот ключ или ключи кому-либо, кому вы хотите
+предоставить подтверждение совершения своей транзакции, а также
+идентификатор транзакции и адрес, на который вы отправили средства. Обратите
+внимание, что эта третья сторона, зная свой собственный адрес, и эти данные
+сможет узнать, какие именно средства вы ей отправили.
 
-Если вы являетесь третьей стороной (то есть кто-то хочет доказать вам, что отправил Monero на ваш адрес), вы можете проверить это таким способом:
+Если вы являетесь третьей стороной (то есть кто-то хочет доказать вам, что
+отправил Monero на ваш адрес), вы можете проверить это таким способом:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Укажите вместо `TXID`, `TXKEY` и `ADDRESS` соответственно идентификатор транзакции, ключ транзакции и адрес получателя, которые были предоставлен вам. monero-wallet-cli проверит эту транзакцию и сообщит вам, сколько денег было оплачено этой транзакцией по указанному адресу.
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
+## How to find a payment to you
 
-## Включение опции подтвердить/отменить платеж
+Если вы получили платеж с использованием определенного `payment id`
+(Идентификатор платежа), вы можете посмотреть информацию об этом с помощью
+команды:
 
-Если вы всегда хотите вручную перед отправкой подтверждать (yes/no) каждый платеж, введите команду:
-
-    set always-confirm-transfers 1
-
-
-## Как найти отправленный вам платеж
-
-Если вы получили платеж с использованием определенного `payment id` (Идентификатор платежа), вы можете посмотреть информацию об этом с помощью команды:
-
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 Вы также можете указать более одного идентификатора платежа.
 
-В более общем плане вы можете просматривать информацию обо всех входящих и исходящих платежах, если введете команду:
+В более общем плане вы можете просматривать информацию обо всех входящих и
+исходящих платежах, если введете команду:
 
-    show_transfers
+```
+show_transfers
+```
 
-Вы можете дополнительно указать высоту блока, чтобы отображать только последние транзакции и запрашивать только входящие или исходящие транзакции. Например, команда:
+Вы можете дополнительно указать высоту блока, чтобы отображать только
+последние транзакции и запрашивать только входящие или исходящие
+транзакции. Например, команда:
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-покажет только входящие транзакции после блока 650000. Вы также можете указывать диапазоны высоты блоков.
+покажет только входящие транзакции после блока 650000. Вы также можете
+указывать диапазоны высоты блоков.
 
-Если вы хотите запустить фоновый майнинг, то можете сделать это прямо из кошелька командой:
+Если вы хотите запустить фоновый майнинг, то можете сделать это прямо из
+кошелька командой:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-Это запустит майнинг на демоне в 2 потока. Обратите внимание, что это соло-майнинг, и может потребоваться очень длительное время, прежде чем вы найдете блок. Чтобы остановить майнинг, введите команду:
+Это запустит майнинг на демоне в 2 потока. Обратите внимание, что это
+соло-майнинг, и может потребоваться очень длительное время, прежде чем вы
+найдете блок. Чтобы остановить майнинг, введите команду:
 
-    stop_mining
+```
+stop_mining
+```

--- a/_i18n/ru/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/ru/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:17+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,454 +22,402 @@ msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
-msgstr ""
-"`monero-wallet-cli` - это программное обеспечение кошелька, которое "
-"поставляется вместе с Monero. Оно представляет собой консольную программу, "
-"которая управляет учетными записями пользователей Monero. В то время как "
-"кошелек Bitcoin управляет как учетными записями, так и блокчейном, в Monero "
-"эти функции разделены: `monerod` обрабатывает блокчейн, а "
-"`monero-wallet-cli` обрабатывает учетные записи пользователей."
+#, fuzzy
+#| msgid "`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
+msgstr "`monero-wallet-cli` - это программное обеспечение кошелька, которое поставляется вместе с Monero. Оно представляет собой консольную программу, которая управляет учетными записями пользователей Monero. В то время как кошелек Bitcoin управляет как учетными записями, так и блокчейном, в Monero эти функции разделены: `monerod` обрабатывает блокчейн, а `monero-wallet-cli` обрабатывает учетные записи пользователей."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+#, fuzzy
+#| msgid "This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr "В этом руководстве будет показано, как выполнять различные операции из пользовательского интерфейса `monero-wallet-cli`. В руководстве предполагается, что вы используете самую последнюю версию Monero и уже создали учетную запись."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
-"В этом руководстве будет показано, как выполнять различные операции из "
-"пользовательского интерфейса `monero-wallet-cli`. В руководстве "
-"предполагается, что вы используете самую последнюю версию Monero и уже "
-"создали учетную запись."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
+#, no-wrap
+msgid ""
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
+#, fuzzy, no-wrap
+#| msgid "## Checking your balance"
+msgid "Checking your balance"
 msgstr "## Проверяем свой баланс"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-"Поскольку обработка данных в блокчейне и учетных записей кошельков "
-"пользователей совершаются отдельными программами, многие функции "
-"`monero-wallet-cli` не будут функционировать без работающего демона. Одной "
-"из таких функций является поиск входящих транзакций на ваш адрес. Только "
-"когда вы запустите оба приложения, `monero-wallet-cli` и `monerod`, сможете "
-"увидеть входящий баланс своего кошелька. Для этого введите команду "
-"`balance`."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr "Пример:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-"Эта команда синхронизирует блоки из демона, которые еще не «видел» кошелек, "
-"и обновит информацию о вашем поточном балансе, чтобы он соответствовал по "
-"времени текущему состоянию блокчейна. Этот процесс обычно выполняется "
-"автоматически в фоновом режиме каждую минуту или около того. Чтобы увидеть "
-"баланс без ожидания автоматического обновления:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
-msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-msgstr ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-"В этом примере `Balance` (Баланс) - это ваш текущий общий баланс. `Unlocked "
-"balance` (Разблокированный баланс) - это сумма, которую в настоящее время "
-"можно потратить. Недавно совершенные транзакции требуют 10 подтверждений в "
-"блокчейне перед разблокировкой. Разблокированная пыль (unlocked dust) "
-"относится к очень небольшим количествам неизрасходованных выходов, которые "
-"могут быть накоплены в процессе работы вашей учетной записи."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr "## Отправка Monero"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-"Вам понадобится `standart address` (Стандартный адрес), на который вы хотите "
-"отправить средства (длинная строка, начинающаяся с «4»), и, возможно, "
-"`payment id` (Идентификатор платежа), если принимающая сторона требует "
-"этого. В последнем случае принимающая сторона может вместо этого "
-"предоставить вам `integrated address` (Интегрированный адрес), который будет "
-"содержать в себе обе строки этих данных в упакованном виде в форме одного "
-"адреса."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr "### Отправка на стандартный адрес:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
-msgstr ""
-"Вместо `ADDRESS` укажите адрес, на который вы хотите отправить средства, "
-"вместо `AMOUNT`, какое количество Monero вы хотите отправить, и вместо "
-"`PAYMENTID` идентификатор платежа, который вы получили. Идентификаторы "
-"платежей являются необязательными. Если принимающая сторона не нуждается в "
-"них, просто не вводите ничего."
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
-msgstr "### Отправка на интегрированный адрес:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
+msgstr "Поскольку обработка данных в блокчейне и учетных записей кошельков пользователей совершаются отдельными программами, многие функции `monero-wallet-cli` не будут функционировать без работающего демона. Одной из таких функций является поиск входящих транзакций на ваш адрес. Только когда вы запустите оба приложения, `monero-wallet-cli` и `monerod`, сможете увидеть входящий баланс своего кошелька. Для этого введите команду `balance`."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr "    transfer ADDRESS AMOUNT\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
+msgid "Output:"
 msgstr ""
-"Идентификатор платежа в этом случае находится внутри интегрированного "
-"адреса."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr "### Указываем количество выходов для транзакции (размер кольца):"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
-msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
+#, no-wrap
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
-msgstr ""
-"Вместо `RINGSIZE` укажите количество выходов, которые вы хотите "
-"использовать. Если параметр не указан, **по умолчанию будет использоваться "
-"значение 11.** Рекомендуется использовать значение по умолчанию, но вы "
-"можете увеличить это число, если хотите добавить больше выходов. Чем выше "
-"число, тем больше по размеру транзакция и более высокие комиссии."
+#, fuzzy
+#| msgid "In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
+msgstr "В этом примере `Balance` (Баланс) - это ваш текущий общий баланс. `Unlocked balance` (Разблокированный баланс) - это сумма, которую в настоящее время можно потратить. Недавно совершенные транзакции требуют 10 подтверждений в блокчейне перед разблокировкой. Разблокированная пыль (unlocked dust) относится к очень небольшим количествам неизрасходованных выходов, которые могут быть накоплены в процессе работы вашей учетной записи."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
+#, fuzzy, no-wrap
+#| msgid "## Sending monero"
+msgid "Sending monero"
+msgstr "## Отправка Monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, fuzzy, no-wrap
+#| msgid "    transfer ADDRESS AMOUNT\n"
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr "    transfer ADDRESS AMOUNT\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, fuzzy, no-wrap
+#| msgid "## Receiving monero"
+msgid "Receiving monero"
 msgstr "## Получение Monero"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-"Если у вас есть собственный кошелек Monero, для получения средств на него "
-"вам просто нужно предоставить кому-то свой стандартный адрес."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr "Вы можете узнать свой стандартный адрес, если введете команду:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
-msgid "    address\n"
-msgstr "    address\n"
-
-#. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
-msgstr ""
-"Поскольку Monero анонимная криптовалюта, вы не увидите адрес источника, из "
-"которого вы получили свои средства. Если вам нужно знать эти данные, "
-"например, для кредитования конкретного клиента, вам нужно будет договориться "
-"с отправителем, чтобы он использовал идентификатор платежа, который является "
-"произвольным необязательным тегом, который привязывается к транзакции. Чтобы "
-"упростить себе жизнь, вы можете создать интегрированный адрес, который уже "
-"содержит этот случайный идентификатор платежа:"
+#, fuzzy
+#| msgid "If you have your own Monero address, you just need to give your standard address to someone."
+msgid "If you have your own Monero address, you just need to give your address to someone."
+msgstr "Если у вас есть собственный кошелек Monero, для получения средств на него вам просто нужно предоставить кому-то свой стандартный адрес."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-msgid "    integrated_address\n"
-msgstr "    integrated_address\n"
+#, fuzzy
+#| msgid "You can find out your address with:"
+msgid "You can find out your primary address with:"
+msgstr "Вы можете узнать свой стандартный адрес, если введете команду:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-"Это создаст случайный идентификатор платежа и предоставит вам адрес, который "
-"будет включать ваш стандартный адрес и этот идентификатор платежа. Если вы "
-"хотите выбрать конкретный идентификатор платежа, вы также можете это сделать "
-"с помощью команды:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
-msgid "    integrated_address 12346780abcdef00\n"
-msgstr "    integrated_address 12346780abcdef00\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address\n"
+msgstr "    address\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
+#, fuzzy
+#| msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life easier, you can generate an address that already includes a random payment ID:"
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
+msgstr "Поскольку Monero анонимная криптовалюта, вы не увидите адрес источника, из которого вы получили свои средства. Если вам нужно знать эти данные, например, для кредитования конкретного клиента, вам нужно будет договориться с отправителем, чтобы он использовал идентификатор платежа, который является произвольным необязательным тегом, который привязывается к транзакции. Чтобы упростить себе жизнь, вы можете создать интегрированный адрес, который уже содержит этот случайный идентификатор платежа:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
+#, no-wrap
 msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
 msgstr ""
-"Платежи, внесенные в интегрированный адрес, созданный в вашей учетной "
-"записи, будут отправляться вам с прикрепленным идентификатором платежа, "
-"чтобы вы могли вести их учет отдельно."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr "## Как доказать третьей стороне, что вы заплатили кому-то"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+#, fuzzy
+#| msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too:"
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr "Это создаст случайный идентификатор платежа и предоставит вам адрес, который будет включать ваш стандартный адрес и этот идентификатор платежа. Если вы хотите выбрать конкретный идентификатор платежа, вы также можете это сделать с помощью команды:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-"Если вы платите субъекту, а он заявляет, что не получил средств, вам может "
-"потребоваться доказать третьему лицу, которому вы отправляли средства, или "
-"даже самому субъекту, что платеж был действительно отправлен. Monero "
-"является конфиденциальной сетью, поэтому вы не можете просто указать на свою "
-"транзакцию в блокчейне, так как вы не можете сказать, кто ее отправил, и кто "
-"ее получил. Однако существует возможность предоставлять `tx key` (Ключ "
-"транзакций) третьей стороне, а эта сторона уже сможет определить, была ли "
-"отправлена эта транзакция Monero этому конкретному адресу. Обратите "
-"внимание, что сохранение этих ключей для каждой транзакции отключено по "
-"умолчанию, и вам нужно будет включить его перед отправкой, если вы считаете, "
-"что вам может понадобиться данная функция. Делается это с помощью команды:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
-msgid "    set store-tx-info 1\n"
-msgstr "    set store-tx-info 1\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, fuzzy, no-wrap
+#| msgid "    integrated_address 12346780abcdef00\n"
+msgid "integrated_address 82d79055f3b27f56\n"
+msgstr "    integrated_address 12346780abcdef00\n"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
-msgstr "Вы можете извлечь `tx key` (Ключ транзакций) из более ранней транзакции:"
+#, fuzzy
+#| msgid "Payments made to an integrated address generated from your account will go to your account, with that payment id attached, so you can tell payments apart."
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
+msgstr "Платежи, внесенные в интегрированный адрес, созданный в вашей учетной записи, будут отправляться вам с прикрепленным идентификатором платежа, чтобы вы могли вести их учет отдельно."
+
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
+#, no-wrap
+msgid "Using subaddresses"
+msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
 msgstr ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
-"Введите идентификатор транзакции, для которого вы хотите узнать "
-"ключ. Помните, что платеж мог быть разделен более чем на одну транзакцию, "
-"поэтому вам может понадобиться несколько ключей для каждой транзакции. Затем "
-"вы можете отправить этот ключ или ключи кому-либо, кому вы хотите "
-"предоставить подтверждение совершения своей транзакции, а также "
-"идентификатор транзакции и адрес, на который вы отправили средства. Обратите "
-"внимание, что эта третья сторона, зная свой собственный адрес, и эти данные "
-"сможет узнать, какие именно средства вы ей отправили."
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
-"Если вы являетесь третьей стороной (то есть кто-то хочет доказать вам, что "
-"отправил Monero на ваш адрес), вы можете проверить это таким способом:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
-msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
+#, no-wrap
+msgid "address new github_donations\n"
+msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
-"Укажите вместо `TXID`, `TXKEY` и `ADDRESS` соответственно идентификатор "
-"транзакции, ключ транзакции и адрес получателя, которые были предоставлен "
-"вам. monero-wallet-cli проверит эту транзакцию и сообщит вам, сколько денег "
-"было оплачено этой транзакцией по указанному адресу."
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
-msgstr "## Включение опции подтвердить/отменить платеж"
+#, fuzzy, no-wrap
+#| msgid "    address\n"
+msgid "address all\n"
+msgstr "    address\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-"Если вы всегда хотите вручную перед отправкой подтверждать (yes/no) каждый "
-"платеж, введите команду:"
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
-msgid "    set always-confirm-transfers 1\n"
-msgstr "    set always-confirm-transfers 1\n"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr "## Как найти отправленный вам платеж"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-"Если вы получили платеж с использованием определенного `payment id` "
-"(Идентификатор платежа), вы можете посмотреть информацию об этом с помощью "
-"команды:"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-msgid "    payments PAYMENTID\n"
-msgstr "    payments PAYMENTID\n"
+#, fuzzy, no-wrap
+#| msgid "## Proving to a third party you paid someone"
+msgid "Proving to a third party you paid someone"
+msgstr "## Как доказать третьей стороне, что вы заплатили кому-то"
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
+msgstr "Если вы платите субъекту, а он заявляет, что не получил средств, вам может потребоваться доказать третьему лицу, которому вы отправляли средства, или даже самому субъекту, что платеж был действительно отправлен. Monero является конфиденциальной сетью, поэтому вы не можете просто указать на свою транзакцию в блокчейне, так как вы не можете сказать, кто ее отправил, и кто ее получил. Однако существует возможность предоставлять `tx key` (Ключ транзакций) третьей стороне, а эта сторона уже сможет определить, была ли отправлена эта транзакция Monero этому конкретному адресу. Обратите внимание, что сохранение этих ключей для каждой транзакции отключено по умолчанию, и вам нужно будет включить его перед отправкой, если вы считаете, что вам может понадобиться данная функция. Делается это с помощью команды:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
+#, fuzzy, no-wrap
+#| msgid "    set store-tx-info 1\n"
+msgid "set store-tx-info 1\n"
+msgstr "    set store-tx-info 1\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr "Вы можете извлечь `tx key` (Ключ транзакций) из более ранней транзакции:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
+#, fuzzy, no-wrap
+#| msgid "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+msgstr "    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
+msgstr "Введите идентификатор транзакции, для которого вы хотите узнать ключ. Помните, что платеж мог быть разделен более чем на одну транзакцию, поэтому вам может понадобиться несколько ключей для каждой транзакции. Затем вы можете отправить этот ключ или ключи кому-либо, кому вы хотите предоставить подтверждение совершения своей транзакции, а также идентификатор транзакции и адрес, на который вы отправили средства. Обратите внимание, что эта третья сторона, зная свой собственный адрес, и эти данные сможет узнать, какие именно средства вы ей отправили."
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr "Если вы являетесь третьей стороной (то есть кто-то хочет доказать вам, что отправил Monero на ваш адрес), вы можете проверить это таким способом:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, fuzzy, no-wrap
+#| msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
+msgstr "    check_tx_key TXID TXKEY ADDRESS\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+#, fuzzy
+#| msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. monero-wallet-cli will check that transaction and let you know how much monero this transaction paid to the given address."
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr "Укажите вместо `TXID`, `TXKEY` и `ADDRESS` соответственно идентификатор транзакции, ключ транзакции и адрес получателя, которые были предоставлен вам. monero-wallet-cli проверит эту транзакцию и сообщит вам, сколько денег было оплачено этой транзакцией по указанному адресу."
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
+#, fuzzy, no-wrap
+#| msgid "## How to find a payment to you"
+msgid "How to find a payment to you"
+msgstr "## Как найти отправленный вам платеж"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr "Если вы получили платеж с использованием определенного `payment id` (Идентификатор платежа), вы можете посмотреть информацию об этом с помощью команды:"
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, fuzzy, no-wrap
+#| msgid "    payments PAYMENTID\n"
+msgid "payments PAYMENTID\n"
+msgstr "    payments PAYMENTID\n"
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
 msgid "You can give more than one payment ID too."
 msgstr "Вы также можете указать более одного идентификатора платежа."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
 msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-"В более общем плане вы можете просматривать информацию обо всех входящих и "
-"исходящих платежах, если введете команду:"
+msgstr "В более общем плане вы можете просматривать информацию обо всех входящих и исходящих платежах, если введете команду:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
-msgid "    show_transfers\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, fuzzy, no-wrap
+#| msgid "    show_transfers\n"
+msgid "show_transfers\n"
 msgstr "    show_transfers\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-"Вы можете дополнительно указать высоту блока, чтобы отображать только "
-"последние транзакции и запрашивать только входящие или исходящие "
-"транзакции. Например, команда:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr "Вы можете дополнительно указать высоту блока, чтобы отображать только последние транзакции и запрашивать только входящие или исходящие транзакции. Например, команда:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
-msgid "    show_transfers in 650000\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, fuzzy, no-wrap
+#| msgid "    show_transfers in 650000\n"
+msgid "show_transfers in 650000\n"
 msgstr "    show_transfers in 650000\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-"покажет только входящие транзакции после блока 650000. Вы также можете "
-"указывать диапазоны высоты блоков."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr "покажет только входящие транзакции после блока 650000. Вы также можете указывать диапазоны высоты блоков."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
 msgid "If you want to mine, you can do so from the wallet:"
-msgstr ""
-"Если вы хотите запустить фоновый майнинг, то можете сделать это прямо из "
-"кошелька командой:"
+msgstr "Если вы хотите запустить фоновый майнинг, то можете сделать это прямо из кошелька командой:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-msgid "    start_mining 2\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, fuzzy, no-wrap
+#| msgid "    start_mining 2\n"
+msgid "start_mining 2\n"
 msgstr "    start_mining 2\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
-msgstr ""
-"Это запустит майнинг на демоне в 2 потока. Обратите внимание, что это "
-"соло-майнинг, и может потребоваться очень длительное время, прежде чем вы "
-"найдете блок. Чтобы остановить майнинг, введите команду:"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr "Это запустит майнинг на демоне в 2 потока. Обратите внимание, что это соло-майнинг, и может потребоваться очень длительное время, прежде чем вы найдете блок. Чтобы остановить майнинг, введите команду:"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
-msgid "    stop_mining\n"
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, fuzzy, no-wrap
+#| msgid "    stop_mining\n"
+msgid "stop_mining\n"
 msgstr "    stop_mining\n"
+
+#~ msgid "Example:"
+#~ msgstr "Пример:"
+
+#~ msgid "This will pull blocks from the daemon the wallet did not yet see, and update your balance to match. This process will normally be done in the background every minute or so. To see the balance without refreshing:"
+#~ msgstr "Эта команда синхронизирует блоки из демона, которые еще не «видел» кошелек, и обновит информацию о вашем поточном балансе, чтобы он соответствовал по времени текущему состоянию блокчейна. Этот процесс обычно выполняется автоматически в фоновом режиме каждую минуту или около того. Чтобы увидеть баланс без ожидания автоматического обновления:"
+
+#~ msgid ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+#~ msgstr ""
+#~ "    balance\n"
+#~ "    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000\n"
+
+#~ msgid "You will need the standard address you want to send to (a long string starting with '4'), and possibly a payment ID, if the receiving party requires one. In that latter case, that party may instead give you an integrated address, which is both of these packed into a single address."
+#~ msgstr "Вам понадобится `standart address` (Стандартный адрес), на который вы хотите отправить средства (длинная строка, начинающаяся с «4»), и, возможно, `payment id` (Идентификатор платежа), если принимающая сторона требует этого. В последнем случае принимающая сторона может вместо этого предоставить вам `integrated address` (Интегрированный адрес), который будет содержать в себе обе строки этих данных в упакованном виде в форме одного адреса."
+
+#~ msgid "### Sending to a standard address:"
+#~ msgstr "### Отправка на стандартный адрес:"
+
+#~ msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
+#~ msgstr "    transfer ADDRESS AMOUNT PAYMENTID\n"
+
+#~ msgid "Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send, and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just omit it."
+#~ msgstr "Вместо `ADDRESS` укажите адрес, на который вы хотите отправить средства, вместо `AMOUNT`, какое количество Monero вы хотите отправить, и вместо `PAYMENTID` идентификатор платежа, который вы получили. Идентификаторы платежей являются необязательными. Если принимающая сторона не нуждается в них, просто не вводите ничего."
+
+#~ msgid "### Sending to an integrated address:"
+#~ msgstr "### Отправка на интегрированный адрес:"
+
+#~ msgid "The payment ID is implicit in the integrated address in that case."
+#~ msgstr "Идентификатор платежа в этом случае находится внутри интегрированного адреса."
+
+#~ msgid "### Specify the number of outputs for a transaction:"
+#~ msgstr "### Указываем количество выходов для транзакции (размер кольца):"
+
+#~ msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+#~ msgstr "    transfer RINGSIZE ADDRESS AMOUNT\n"
+
+#~ msgid "Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed."
+#~ msgstr "Вместо `RINGSIZE` укажите количество выходов, которые вы хотите использовать. Если параметр не указан, **по умолчанию будет использоваться значение 11.** Рекомендуется использовать значение по умолчанию, но вы можете увеличить это число, если хотите добавить больше выходов. Чем выше число, тем больше по размеру транзакция и более высокие комиссии."
+
+#~ msgid "    integrated_address\n"
+#~ msgstr "    integrated_address\n"
+
+#~ msgid "## Getting a chance to confirm/cancel payments"
+#~ msgstr "## Включение опции подтвердить/отменить платеж"
+
+#~ msgid "If you want to get a last chance confirmation when sending a payment:"
+#~ msgstr "Если вы всегда хотите вручную перед отправкой подтверждать (yes/no) каждый платеж, введите команду:"
+
+#~ msgid "    set always-confirm-transfers 1\n"
+#~ msgstr "    set always-confirm-transfers 1\n"

--- a/_i18n/tr/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/tr/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,211 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
-`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
-and manages an account. While a bitcoin wallet manages both an account and the blockchain,
-Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
+
+You can have a list of the most important commands by running `help`:
+
+```
+Important commands:
+
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
+
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
+
+"donate <amount>" - Donate XMR to the development team.
+```
 
 ## Checking your balance
 
-Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli`
-need to work with the @daemon. This includes looking for incoming transactions to your address.
-Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`.
+Since the blockchain handling and the wallet are separate programs, many
+uses of `monero-wallet-cli` need to work with the @daemon. This includes
+looking for incoming transactions to your address.  Once you are running
+both `monero-wallet-cli` and `monerod`, enter `balance`.
 
-Example:
+Output:
 
-This will pull blocks from the daemon the wallet did not yet see, and update your balance
-to match. This process will normally be done in the background every minute or so. To see the
-balance without refreshing:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-
-In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
 ## Sending monero
 
-You will need the standard address you want to send to (a long string starting with '4'), and
-possibly a payment ID, if the receiving party requires one. In that latter case, that party
-may instead give you an integrated address, which is both of these packed into a single address.
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-### Sending to a standard address:
+```
+transfer ADDRESS AMOUNT
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
-
-Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send,
-and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just
-omit it.
-
-### Sending to an integrated address:
-
-    transfer ADDRESS AMOUNT
-
-The payment ID is implicit in the integrated address in that case.
-
-### Specify the number of outputs for a transaction:
-
-    transfer RINGSIZE ADDRESS AMOUNT
-
-Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed.
-
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
 ## Receiving monero
 
-If you have your own Monero address, you just need to give your standard address to someone.
+If you have your own Monero address, you just need to give your address to
+someone.
 
-You can find out your address with:
+You can find out your primary address with:
 
-    address
+```
+address
+```
 
-Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you
-want to know, for instance to credit a particular customer, you'll have to tell the sender to use
-a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life
-easier, you can generate an address that already includes a random payment ID:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-    integrated_address
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-This will generate a random payment ID, and give you the address that includes your own account
-and that payment ID. If you want to select a particular payment ID, you can do that too:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    integrated_address 12346780abcdef00
+```
+integrated_address 82d79055f3b27f56
+```
 
-Payments made to an integrated address generated from your account will go to your account,
-with that payment id attached, so you can tell payments apart.
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
+### Using subaddresses
+
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
+
+```
+address new [<label text with white spaces allowed>]
+```
+
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
+
+```
+address new github_donations
+```
+
+will generate a subaddress and its label 'github_donations'.
+
+To view all generated addresses, run:
+
+```
+address all
+```
 
 ## Proving to a third party you paid someone
 
-If you pay a merchant, and the merchant claims to not have received the funds, you may need
-to prove to a third party you did send the funds - or even to the merchant, if it is a honest
-mistake. Monero is private, so you can't just point to your transaction in the blockchain,
-as you can't tell who sent it, and who received it. However, by supplying the per-transaction
-private key to a party, that party can tell whether that transaction sent monero to that
-particular address. Note that storing these per-transaction keys is disabled by default, and
-you will have to enable it before sending, if you think you may need it:
+If you pay a merchant, and the merchant claims to not have received the
+funds, you may need to prove to a third party you did send the funds - or
+even to the merchant, if it is a honest mistake. Monero is private, so you
+can't just point to your transaction in the blockchain, as you can't tell
+who sent it, and who received it. However, by supplying the per-transaction
+private key to a party, that party can tell whether that transaction sent
+monero to that particular address. Note that storing these per-transaction
+keys is disabled by default, and you will have to enable it before sending,
+if you think you may need it:
 
-    set store-tx-info 1
+```
+set store-tx-info 1
+```
 
 You can retrieve the tx key from an earlier transaction:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Pass in the transaction ID you want the key for. Remember that a payment might have been
-split in more than one transaction, so you may need several keys. You can then send that key,
-or these keys, to whoever you want to provide proof of your transaction, along with the
-transaction id and the address you sent to. Note that this third party, if knowing your
-own address, will be able to see how much change was returned to you as well.
+Pass in the transaction ID you want the key for. Remember that a payment
+might have been split in more than one transaction, so you may need several
+keys. You can then send that key, or these keys, to whoever you want to
+provide proof of your transaction, along with the transaction id and the
+address you sent to. Note that this third party, if knowing your own
+address, will be able to see how much change was returned to you as well.
 
-If you are the third party (that is, someone wants to prove to you that they sent monero
-to an address), then you can check this way:
+If you are the third party (that is, someone wants to prove to you that they
+sent monero to an address), then you can check this way:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination
-address which were supplied to you, respectively. monero-wallet-cli will check that transaction
-and let you know how much monero this transaction paid to the given address.
-
-
-## Getting a chance to confirm/cancel payments
-
-If you want to get a last chance confirmation when sending a payment:
-
-    set always-confirm-transfers 1
-
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
 ## How to find a payment to you
 
 If you received a payment using a particular payment ID, you can look it up:
 
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 You can give more than one payment ID too.
 
 More generally, you can review incoming and outgoing payments:
 
-    show_transfers
+```
+show_transfers
+```
 
-You can give an optional height to list only recent transactions, and request
-only incoming or outgoing transactions. For example,
+You can give an optional height to list only recent transactions, and
+request only incoming or outgoing transactions. For example,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-will only show incoming transfers after block 650000. You can also give a height
-range.
+will only show incoming transfers after block 650000. You can also give a
+height range.
 
 If you want to mine, you can do so from the wallet:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-This will start mining on the daemon usin two threads. Note that this is solo mining,
-and may take a while before you find a block. To stop mining:
+This will start mining on the daemon usin two threads. Note that this is
+solo mining, and may take a while before you find a block. To stop mining:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/tr/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/tr/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:13+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,360 +22,315 @@ msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
 #, no-wrap
 msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
+msgid "Checking your balance"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
+msgid "Output:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-#, no-wrap
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
 #, no-wrap
-msgid "    address\n"
+msgid "Sending monero"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, no-wrap
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, no-wrap
+msgid "Receiving monero"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
+msgid "If you have your own Monero address, you just need to give your address to someone."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-#, no-wrap
-msgid "    integrated_address\n"
+msgid "You can find out your primary address with:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
 #, no-wrap
-msgid "    integrated_address 12346780abcdef00\n"
+msgid "address\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
-msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
 #, no-wrap
-msgid "    set store-tx-info 1\n"
+msgid ""
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, no-wrap
+msgid "integrated_address 82d79055f3b27f56\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
 #, no-wrap
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "Using subaddresses"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
 #, no-wrap
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "address new github_donations\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
+#, no-wrap
+msgid "address all\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
 #, no-wrap
-msgid "    set always-confirm-transfers 1\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-#, no-wrap
-msgid "    payments PAYMENTID\n"
+msgid "Proving to a third party you paid someone"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
-msgid "You can give more than one payment ID too."
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
-msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
 #, no-wrap
-msgid "    show_transfers\n"
+msgid "set store-tx-info 1\n"
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
 #, no-wrap
-msgid "    show_transfers in 650000\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
-msgid "If you want to mine, you can do so from the wallet:"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-#, no-wrap
-msgid "    start_mining 2\n"
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, no-wrap
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
 #, no-wrap
-msgid "    stop_mining\n"
+msgid "How to find a payment to you"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, no-wrap
+msgid "payments PAYMENTID\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
+msgid "You can give more than one payment ID too."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
+msgid "More generally, you can review incoming and outgoing payments:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, no-wrap
+msgid "show_transfers\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, no-wrap
+msgid "show_transfers in 650000\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
+msgid "If you want to mine, you can do so from the wallet:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, no-wrap
+msgid "start_mining 2\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, no-wrap
+msgid "stop_mining\n"
 msgstr ""

--- a/_i18n/zh-cn/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/zh-cn/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,211 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
-`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
-and manages an account. While a bitcoin wallet manages both an account and the blockchain,
-Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
+
+You can have a list of the most important commands by running `help`:
+
+```
+Important commands:
+
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
+
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
+
+"donate <amount>" - Donate XMR to the development team.
+```
 
 ## Checking your balance
 
-Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli`
-need to work with the @daemon. This includes looking for incoming transactions to your address.
-Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`.
+Since the blockchain handling and the wallet are separate programs, many
+uses of `monero-wallet-cli` need to work with the @daemon. This includes
+looking for incoming transactions to your address.  Once you are running
+both `monero-wallet-cli` and `monerod`, enter `balance`.
 
-Example:
+Output:
 
-This will pull blocks from the daemon the wallet did not yet see, and update your balance
-to match. This process will normally be done in the background every minute or so. To see the
-balance without refreshing:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-
-In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
 ## Sending monero
 
-You will need the standard address you want to send to (a long string starting with '4'), and
-possibly a payment ID, if the receiving party requires one. In that latter case, that party
-may instead give you an integrated address, which is both of these packed into a single address.
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-### Sending to a standard address:
+```
+transfer ADDRESS AMOUNT
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
-
-Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send,
-and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just
-omit it.
-
-### Sending to an integrated address:
-
-    transfer ADDRESS AMOUNT
-
-The payment ID is implicit in the integrated address in that case.
-
-### Specify the number of outputs for a transaction:
-
-    transfer RINGSIZE ADDRESS AMOUNT
-
-Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed.
-
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
 ## Receiving monero
 
-If you have your own Monero address, you just need to give your standard address to someone.
+If you have your own Monero address, you just need to give your address to
+someone.
 
-You can find out your address with:
+You can find out your primary address with:
 
-    address
+```
+address
+```
 
-Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you
-want to know, for instance to credit a particular customer, you'll have to tell the sender to use
-a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life
-easier, you can generate an address that already includes a random payment ID:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-    integrated_address
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-This will generate a random payment ID, and give you the address that includes your own account
-and that payment ID. If you want to select a particular payment ID, you can do that too:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    integrated_address 12346780abcdef00
+```
+integrated_address 82d79055f3b27f56
+```
 
-Payments made to an integrated address generated from your account will go to your account,
-with that payment id attached, so you can tell payments apart.
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
+### Using subaddresses
+
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
+
+```
+address new [<label text with white spaces allowed>]
+```
+
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
+
+```
+address new github_donations
+```
+
+will generate a subaddress and its label 'github_donations'.
+
+To view all generated addresses, run:
+
+```
+address all
+```
 
 ## Proving to a third party you paid someone
 
-If you pay a merchant, and the merchant claims to not have received the funds, you may need
-to prove to a third party you did send the funds - or even to the merchant, if it is a honest
-mistake. Monero is private, so you can't just point to your transaction in the blockchain,
-as you can't tell who sent it, and who received it. However, by supplying the per-transaction
-private key to a party, that party can tell whether that transaction sent monero to that
-particular address. Note that storing these per-transaction keys is disabled by default, and
-you will have to enable it before sending, if you think you may need it:
+If you pay a merchant, and the merchant claims to not have received the
+funds, you may need to prove to a third party you did send the funds - or
+even to the merchant, if it is a honest mistake. Monero is private, so you
+can't just point to your transaction in the blockchain, as you can't tell
+who sent it, and who received it. However, by supplying the per-transaction
+private key to a party, that party can tell whether that transaction sent
+monero to that particular address. Note that storing these per-transaction
+keys is disabled by default, and you will have to enable it before sending,
+if you think you may need it:
 
-    set store-tx-info 1
+```
+set store-tx-info 1
+```
 
 You can retrieve the tx key from an earlier transaction:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Pass in the transaction ID you want the key for. Remember that a payment might have been
-split in more than one transaction, so you may need several keys. You can then send that key,
-or these keys, to whoever you want to provide proof of your transaction, along with the
-transaction id and the address you sent to. Note that this third party, if knowing your
-own address, will be able to see how much change was returned to you as well.
+Pass in the transaction ID you want the key for. Remember that a payment
+might have been split in more than one transaction, so you may need several
+keys. You can then send that key, or these keys, to whoever you want to
+provide proof of your transaction, along with the transaction id and the
+address you sent to. Note that this third party, if knowing your own
+address, will be able to see how much change was returned to you as well.
 
-If you are the third party (that is, someone wants to prove to you that they sent monero
-to an address), then you can check this way:
+If you are the third party (that is, someone wants to prove to you that they
+sent monero to an address), then you can check this way:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination
-address which were supplied to you, respectively. monero-wallet-cli will check that transaction
-and let you know how much monero this transaction paid to the given address.
-
-
-## Getting a chance to confirm/cancel payments
-
-If you want to get a last chance confirmation when sending a payment:
-
-    set always-confirm-transfers 1
-
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
 ## How to find a payment to you
 
 If you received a payment using a particular payment ID, you can look it up:
 
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 You can give more than one payment ID too.
 
 More generally, you can review incoming and outgoing payments:
 
-    show_transfers
+```
+show_transfers
+```
 
-You can give an optional height to list only recent transactions, and request
-only incoming or outgoing transactions. For example,
+You can give an optional height to list only recent transactions, and
+request only incoming or outgoing transactions. For example,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-will only show incoming transfers after block 650000. You can also give a height
-range.
+will only show incoming transfers after block 650000. You can also give a
+height range.
 
 If you want to mine, you can do so from the wallet:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-This will start mining on the daemon usin two threads. Note that this is solo mining,
-and may take a while before you find a block. To stop mining:
+This will start mining on the daemon usin two threads. Note that this is
+solo mining, and may take a while before you find a block. To stop mining:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/zh-cn/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/zh-cn/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:14+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,360 +22,315 @@ msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
 #, no-wrap
 msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
+msgid "Checking your balance"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
+msgid "Output:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-#, no-wrap
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
 #, no-wrap
-msgid "    address\n"
+msgid "Sending monero"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, no-wrap
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, no-wrap
+msgid "Receiving monero"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
+msgid "If you have your own Monero address, you just need to give your address to someone."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-#, no-wrap
-msgid "    integrated_address\n"
+msgid "You can find out your primary address with:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
 #, no-wrap
-msgid "    integrated_address 12346780abcdef00\n"
+msgid "address\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
-msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
 #, no-wrap
-msgid "    set store-tx-info 1\n"
+msgid ""
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, no-wrap
+msgid "integrated_address 82d79055f3b27f56\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
 #, no-wrap
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "Using subaddresses"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
 #, no-wrap
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "address new github_donations\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
+#, no-wrap
+msgid "address all\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
 #, no-wrap
-msgid "    set always-confirm-transfers 1\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-#, no-wrap
-msgid "    payments PAYMENTID\n"
+msgid "Proving to a third party you paid someone"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
-msgid "You can give more than one payment ID too."
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
-msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
 #, no-wrap
-msgid "    show_transfers\n"
+msgid "set store-tx-info 1\n"
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
 #, no-wrap
-msgid "    show_transfers in 650000\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
-msgid "If you want to mine, you can do so from the wallet:"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-#, no-wrap
-msgid "    start_mining 2\n"
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, no-wrap
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
 #, no-wrap
-msgid "    stop_mining\n"
+msgid "How to find a payment to you"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, no-wrap
+msgid "payments PAYMENTID\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
+msgid "You can give more than one payment ID too."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
+msgid "More generally, you can review incoming and outgoing payments:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, no-wrap
+msgid "show_transfers\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, no-wrap
+msgid "show_transfers in 650000\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
+msgid "If you want to mine, you can do so from the wallet:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, no-wrap
+msgid "start_mining 2\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, no-wrap
+msgid "stop_mining\n"
 msgstr ""

--- a/_i18n/zh-tw/resources/user-guides/monero-wallet-cli.md
+++ b/_i18n/zh-tw/resources/user-guides/monero-wallet-cli.md
@@ -1,145 +1,211 @@
 {% include disclaimer.html translated="no" translationOutdated="no" %}
 
-`monero-wallet-cli` is the wallet software that ships with the Monero tree. It is a console program,
-and manages an account. While a bitcoin wallet manages both an account and the blockchain,
-Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account.
+`monero-wallet-cli` is the wallet software shipped in the Monero
+archives. It is a console program, and manages an account. While a bitcoin
+wallet manages both an account and the blockchain, Monero separates these:
+`monerod` handles the blockchain, and `monero-wallet-cli` handles the
+account.
 
-This guide will show how to perform various operations from the `monero-wallet-cli` UI. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides.
+This guide will show how to perform various operations with
+`monero-wallet-cli`. The guide assumes you are using the most recent version
+of Monero and have already created an account according to the other guides.
 
+## Overview
+
+You can have a list of the most important commands by running `help`:
+
+```
+Important commands:
+
+"welcome" - Show welcome message.
+"help all" - Show the list of all available commands.
+"help <command>" - Show a command's documentation.
+"apropos <keyword>" - Show commands related to a keyword.
+
+"wallet_info" - Show wallet main address and other info.
+"balance" - Show balance.
+"address all" - Show all addresses.
+"address new [<label text with white spaces allowed>]" - Create new subaddress.
+"transfer <address> <amount>" - Send XMR to an address.
+"show_transfers [in|out|pending|failed|pool]" - Show transactions.
+"sweep_all <address>" - Send whole balance to another wallet.
+"seed" - Show secret 25 words that can be used to recover this wallet.
+"refresh" - Synchronize wallet with the Monero network.
+"status" - Check current status of wallet.
+"version" - Check software version.
+"exit" - Exit wallet.
+
+"donate <amount>" - Donate XMR to the development team.
+```
 
 ## Checking your balance
 
-Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli`
-need to work with the @daemon. This includes looking for incoming transactions to your address.
-Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`.
+Since the blockchain handling and the wallet are separate programs, many
+uses of `monero-wallet-cli` need to work with the @daemon. This includes
+looking for incoming transactions to your address.  Once you are running
+both `monero-wallet-cli` and `monerod`, enter `balance`.
 
-Example:
+Output:
 
-This will pull blocks from the daemon the wallet did not yet see, and update your balance
-to match. This process will normally be done in the background every minute or so. To see the
-balance without refreshing:
+```
+Currently selected account: [0] Primary account
+Tag: (No tag assigned)
+Balance: 7.499942880000, unlocked balance: 7.499942880000
+```
 
-    balance
-    Balance: 64.526198850000, unlocked balance: 44.526198850000, including unlocked dust: 0.006198850000
-
-In this example, `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked. `unlocked dust` refers to very small amounts of unspent outputs that may have accumulated in your account.
+In this example you're viewing the balance of your primary account (with
+index `[0]`). `Balance` is your total balance. The `unlocked balance` is the
+amount currently available to spend. Newly received transactions require 10
+confirmations on the blockchain before being unlocked.
 
 ## Sending monero
 
-You will need the standard address you want to send to (a long string starting with '4'), and
-possibly a payment ID, if the receiving party requires one. In that latter case, that party
-may instead give you an integrated address, which is both of these packed into a single address.
+You will need the standard address you want to send to (a long string
+starting with '4' or a '8'). The command structure is:
 
-### Sending to a standard address:
+```
+transfer ADDRESS AMOUNT
+```
 
-    transfer ADDRESS AMOUNT PAYMENTID
-
-Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how many monero you want to send,
-and `PAYMENTID` with the payment ID you were given. Payment ID's are optional. If the receiving party doesn't need one, just
-omit it.
-
-### Sending to an integrated address:
-
-    transfer ADDRESS AMOUNT
-
-The payment ID is implicit in the integrated address in that case.
-
-### Specify the number of outputs for a transaction:
-
-    transfer RINGSIZE ADDRESS AMOUNT
-
-Replace `RINGSIZE` with the number of outputs you wish to use. **If not specified, the default is 11.** It's a good idea to use the default, but you can increase the number if you want to include more outputs. The higher the number, the larger the transaction, and higher fees are needed.
-
+Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how
+many monero you want to send.
 
 ## Receiving monero
 
-If you have your own Monero address, you just need to give your standard address to someone.
+If you have your own Monero address, you just need to give your address to
+someone.
 
-You can find out your address with:
+You can find out your primary address with:
 
-    address
+```
+address
+```
 
-Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you
-want to know, for instance to credit a particular customer, you'll have to tell the sender to use
-a payment ID, which is an arbitrary optional tag which gets attached to a transaction. To make life
-easier, you can generate an address that already includes a random payment ID:
+Since Monero is anonymous, you won't see the origin address the funds you
+receive came from. If you want to know, for instance to credit a particular
+customer, you'll have to tell the sender to use a payment ID, which is an
+arbitrary optional tag which gets attached to a transaction. It's not
+possible to use standalone payment addresses, but you can generate an
+address that already includes a random payment ID (integrated addresss)
+using `integrated_address`:
 
-    integrated_address
+```
+Random payment ID: <82d79055f3b27f56>
+Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV
+```
 
-This will generate a random payment ID, and give you the address that includes your own account
-and that payment ID. If you want to select a particular payment ID, you can do that too:
+This will generate a random payment ID, and give you the address that
+includes your own account and that payment ID. If you want to select a
+particular payment ID, you can do that too. Use:
 
-    integrated_address 12346780abcdef00
+```
+integrated_address 82d79055f3b27f56
+```
 
-Payments made to an integrated address generated from your account will go to your account,
-with that payment id attached, so you can tell payments apart.
+Payments made to an integrated address generated from your account will go
+to your account, with that payment ID attached, so you can tell payments
+apart.
 
+### Using subaddresses
+
+It's suggested to use subaddresses (starting with `8`) instead of your main
+address (starting with `4`) to receive funds. Run:
+
+```
+address new [<label text with white spaces allowed>]
+```
+
+This will generate a subaddress and its optional label, which addess you can
+share to receive payment on the account it's linked to.  For example,
+
+```
+address new github_donations
+```
+
+will generate a subaddress and its label 'github_donations'.
+
+To view all generated addresses, run:
+
+```
+address all
+```
 
 ## Proving to a third party you paid someone
 
-If you pay a merchant, and the merchant claims to not have received the funds, you may need
-to prove to a third party you did send the funds - or even to the merchant, if it is a honest
-mistake. Monero is private, so you can't just point to your transaction in the blockchain,
-as you can't tell who sent it, and who received it. However, by supplying the per-transaction
-private key to a party, that party can tell whether that transaction sent monero to that
-particular address. Note that storing these per-transaction keys is disabled by default, and
-you will have to enable it before sending, if you think you may need it:
+If you pay a merchant, and the merchant claims to not have received the
+funds, you may need to prove to a third party you did send the funds - or
+even to the merchant, if it is a honest mistake. Monero is private, so you
+can't just point to your transaction in the blockchain, as you can't tell
+who sent it, and who received it. However, by supplying the per-transaction
+private key to a party, that party can tell whether that transaction sent
+monero to that particular address. Note that storing these per-transaction
+keys is disabled by default, and you will have to enable it before sending,
+if you think you may need it:
 
-    set store-tx-info 1
+```
+set store-tx-info 1
+```
 
 You can retrieve the tx key from an earlier transaction:
 
-    get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
+get_tx_key 1234567890123456789012345678901212345678901234567890123456789012
+```
 
-Pass in the transaction ID you want the key for. Remember that a payment might have been
-split in more than one transaction, so you may need several keys. You can then send that key,
-or these keys, to whoever you want to provide proof of your transaction, along with the
-transaction id and the address you sent to. Note that this third party, if knowing your
-own address, will be able to see how much change was returned to you as well.
+Pass in the transaction ID you want the key for. Remember that a payment
+might have been split in more than one transaction, so you may need several
+keys. You can then send that key, or these keys, to whoever you want to
+provide proof of your transaction, along with the transaction id and the
+address you sent to. Note that this third party, if knowing your own
+address, will be able to see how much change was returned to you as well.
 
-If you are the third party (that is, someone wants to prove to you that they sent monero
-to an address), then you can check this way:
+If you are the third party (that is, someone wants to prove to you that they
+sent monero to an address), then you can check this way:
 
-    check_tx_key TXID TXKEY ADDRESS
+```
+check_tx_key TXID TXKEY ADDRESS
+```
 
-Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination
-address which were supplied to you, respectively. monero-wallet-cli will check that transaction
-and let you know how much monero this transaction paid to the given address.
-
-
-## Getting a chance to confirm/cancel payments
-
-If you want to get a last chance confirmation when sending a payment:
-
-    set always-confirm-transfers 1
-
+Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID,
+per-transaction key, and destination address which were supplied to you,
+respectively. `monero-wallet-cli` will check that transaction and let you
+know how much monero this transaction paid to the given address.
 
 ## How to find a payment to you
 
 If you received a payment using a particular payment ID, you can look it up:
 
-    payments PAYMENTID
+```
+payments PAYMENTID
+```
 
 You can give more than one payment ID too.
 
 More generally, you can review incoming and outgoing payments:
 
-    show_transfers
+```
+show_transfers
+```
 
-You can give an optional height to list only recent transactions, and request
-only incoming or outgoing transactions. For example,
+You can give an optional height to list only recent transactions, and
+request only incoming or outgoing transactions. For example,
 
-    show_transfers in 650000
+```
+show_transfers in 650000
+```
 
-will only show incoming transfers after block 650000. You can also give a height
-range.
+will only show incoming transfers after block 650000. You can also give a
+height range.
 
 If you want to mine, you can do so from the wallet:
 
-    start_mining 2
+```
+start_mining 2
+```
 
-This will start mining on the daemon usin two threads. Note that this is solo mining,
-and may take a while before you find a block. To stop mining:
+This will start mining on the daemon usin two threads. Note that this is
+solo mining, and may take a while before you find a block. To stop mining:
 
-    stop_mining
-
+```
+stop_mining
+```

--- a/_i18n/zh-tw/resources/user-guides/weblate/monero-wallet-cli.po
+++ b/_i18n/zh-tw/resources/user-guides/weblate/monero-wallet-cli.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 12:14+0100\n"
+"POT-Creation-Date: 2021-07-12 16:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,360 +22,315 @@ msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:6
-msgid ""
-"`monero-wallet-cli` is the wallet software that ships with the Monero "
-"tree. It is a console program, and manages an account. While a bitcoin "
-"wallet manages both an account and the blockchain, Monero separates these: "
-"`monerod` handles the blockchain, and `monero-wallet-cli` handles the "
-"account."
+msgid "`monero-wallet-cli` is the wallet software shipped in the Monero archives. It is a console program, and manages an account. While a bitcoin wallet manages both an account and the blockchain, Monero separates these: `monerod` handles the blockchain, and `monero-wallet-cli` handles the account."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:8
-msgid ""
-"This guide will show how to perform various operations from the "
-"`monero-wallet-cli` UI. The guide assumes you are using the most recent "
-"version of Monero and have already created an account according to the other "
-"guides."
+msgid "This guide will show how to perform various operations with `monero-wallet-cli`. The guide assumes you are using the most recent version of Monero and have already created an account according to the other guides."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:9
+#, no-wrap
+msgid "Overview"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:11
-msgid "## Checking your balance"
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:12
+msgid "You can have a list of the most important commands by running `help`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:15
-msgid ""
-"Since the blockchain handling and the wallet are separate programs, many "
-"uses of `monero-wallet-cli` need to work with the @daemon. This includes "
-"looking for incoming transactions to your address.  Once you are running "
-"both `monero-wallet-cli` and `monerod`, enter `balance`."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:17
-msgid "Example:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:21
-msgid ""
-"This will pull blocks from the daemon the wallet did not yet see, and update "
-"your balance to match. This process will normally be done in the background "
-"every minute or so. To see the balance without refreshing:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:24
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:13
 #, no-wrap
 msgid ""
-"    balance\n"
-"    Balance: 64.526198850000, unlocked balance: 44.526198850000, including "
-"unlocked dust: 0.006198850000\n"
+"Important commands:\n"
+"\n"
+"\"welcome\" - Show welcome message.\n"
+"\"help all\" - Show the list of all available commands.\n"
+"\"help <command>\" - Show a command's documentation.\n"
+"\"apropos <keyword>\" - Show commands related to a keyword.\n"
+"\n"
+"\"wallet_info\" - Show wallet main address and other info.\n"
+"\"balance\" - Show balance.\n"
+"\"address all\" - Show all addresses.\n"
+"\"address new [<label text with white spaces allowed>]\" - Create new subaddress.\n"
+"\"transfer <address> <amount>\" - Send XMR to an address.\n"
+"\"show_transfers [in|out|pending|failed|pool]\" - Show transactions.\n"
+"\"sweep_all <address>\" - Send whole balance to another wallet.\n"
+"\"seed\" - Show secret 25 words that can be used to recover this wallet.\n"
+"\"refresh\" - Synchronize wallet with the Monero network.\n"
+"\"status\" - Check current status of wallet.\n"
+"\"version\" - Check software version.\n"
+"\"exit\" - Exit wallet.\n"
+"\n"
+"\"donate <amount>\" - Donate XMR to the development team.\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:26
-msgid ""
-"In this example, `Balance` is your total balance. The `unlocked balance` is "
-"the amount currently available to spend. Newly received transactions require "
-"10 confirmations on the blockchain before being unlocked. `unlocked dust` "
-"refers to very small amounts of unspent outputs that may have accumulated in "
-"your account."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:28
-msgid "## Sending monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:32
-msgid ""
-"You will need the standard address you want to send to (a long string "
-"starting with '4'), and possibly a payment ID, if the receiving party "
-"requires one. In that latter case, that party may instead give you an "
-"integrated address, which is both of these packed into a single address."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:34
-msgid "### Sending to a standard address:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:36
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:37
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT PAYMENTID\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:40
-msgid ""
-"Replace `ADDRESS` with the address you want to send to, `AMOUNT` with how "
-"many monero you want to send, and `PAYMENTID` with the payment ID you were "
-"given. Payment ID's are optional. If the receiving party doesn't need one, "
-"just omit it."
+msgid "Checking your balance"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:42
-msgid "### Sending to an integrated address:"
+msgid "Since the blockchain handling and the wallet are separate programs, many uses of `monero-wallet-cli` need to work with the @daemon. This includes looking for incoming transactions to your address.  Once you are running both `monero-wallet-cli` and `monerod`, enter `balance`."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:44
+msgid "Output:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:45
 #, no-wrap
-msgid "    transfer ADDRESS AMOUNT\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:46
-msgid "The payment ID is implicit in the integrated address in that case."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:48
-msgid "### Specify the number of outputs for a transaction:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:50
-#, no-wrap
-msgid "    transfer RINGSIZE ADDRESS AMOUNT\n"
+msgid ""
+"Currently selected account: [0] Primary account\n"
+"Tag: (No tag assigned)\n"
+"Balance: 7.499942880000, unlocked balance: 7.499942880000\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:52
-msgid ""
-"Replace `RINGSIZE` with the number of outputs you wish to use. **If not "
-"specified, the default is 11.** It's a good idea to use the default, but you "
-"can increase the number if you want to include more outputs. The higher the "
-"number, the larger the transaction, and higher fees are needed."
+msgid "In this example you're viewing the balance of your primary account (with index `[0]`). `Balance` is your total balance. The `unlocked balance` is the amount currently available to spend. Newly received transactions require 10 confirmations on the blockchain before being unlocked."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:55
-msgid "## Receiving monero"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
-msgid ""
-"If you have your own Monero address, you just need to give your standard "
-"address to someone."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:59
-msgid "You can find out your address with:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:61
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:53
 #, no-wrap
-msgid "    address\n"
+msgid "Sending monero"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:56
+msgid "You will need the standard address you want to send to (a long string starting with '4' or a '8'). The command structure is:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:57
+#, no-wrap
+msgid "transfer ADDRESS AMOUNT\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:62
+msgid "Replace `ADDRESS` with the address you want to send to and `AMOUNT` with how many monero you want to send."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:63
+#, no-wrap
+msgid "Receiving monero"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:66
-msgid ""
-"Since Monero is anonymous, you won't see the origin address the funds you "
-"receive came from. If you want to know, for instance to credit a particular "
-"customer, you'll have to tell the sender to use a payment ID, which is an "
-"arbitrary optional tag which gets attached to a transaction. To make life "
-"easier, you can generate an address that already includes a random payment "
-"ID:"
+msgid "If you have your own Monero address, you just need to give your address to someone."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:68
-#, no-wrap
-msgid "    integrated_address\n"
+msgid "You can find out your primary address with:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:71
-msgid ""
-"This will generate a random payment ID, and give you the address that "
-"includes your own account and that payment ID. If you want to select a "
-"particular payment ID, you can do that too:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:73
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:69
 #, no-wrap
-msgid "    integrated_address 12346780abcdef00\n"
+msgid "address\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:76
-msgid ""
-"Payments made to an integrated address generated from your account will go "
-"to your account, with that payment id attached, so you can tell payments "
-"apart."
+msgid "Since Monero is anonymous, you won't see the origin address the funds you receive came from. If you want to know, for instance to credit a particular customer, you'll have to tell the sender to use a payment ID, which is an arbitrary optional tag which gets attached to a transaction. It's not possible to use standalone payment addresses, but you can generate an address that already includes a random payment ID (integrated addresss) using `integrated_address`:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:79
-msgid "## Proving to a third party you paid someone"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:87
-msgid ""
-"If you pay a merchant, and the merchant claims to not have received the "
-"funds, you may need to prove to a third party you did send the funds - or "
-"even to the merchant, if it is a honest mistake. Monero is private, so you "
-"can't just point to your transaction in the blockchain, as you can't tell "
-"who sent it, and who received it. However, by supplying the per-transaction "
-"private key to a party, that party can tell whether that transaction sent "
-"monero to that particular address. Note that storing these per-transaction "
-"keys is disabled by default, and you will have to enable it before sending, "
-"if you think you may need it:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:89
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:77
 #, no-wrap
-msgid "    set store-tx-info 1\n"
+msgid ""
+"Random payment ID: <82d79055f3b27f56>\n"
+"Matching integrated address: 4KHQkZ4MmVePC2yau6Mb8vhuGGy8LVdsZD8CFcQJvr4BSTfC5AQX3aXCn5RiDPjvsEHiJu1TC1ybR8pRTCbZM5bhTrAD3HDwWMtAn1K7nV\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:84
+msgid "This will generate a random payment ID, and give you the address that includes your own account and that payment ID. If you want to select a particular payment ID, you can do that too. Use:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:85
+#, no-wrap
+msgid "integrated_address 82d79055f3b27f56\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:91
-msgid "You can retrieve the tx key from an earlier transaction:"
+msgid "Payments made to an integrated address generated from your account will go to your account, with that payment ID attached, so you can tell payments apart."
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:93
+#. type: Title ###
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:92
 #, no-wrap
-msgid ""
-"    get_tx_key "
-"1234567890123456789012345678901212345678901234567890123456789012\n"
+msgid "Using subaddresses"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:99
-msgid ""
-"Pass in the transaction ID you want the key for. Remember that a payment "
-"might have been split in more than one transaction, so you may need several "
-"keys. You can then send that key, or these keys, to whoever you want to "
-"provide proof of your transaction, along with the transaction id and the "
-"address you sent to. Note that this third party, if knowing your own "
-"address, will be able to see how much change was returned to you as well."
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:95
+msgid "It's suggested to use subaddresses (starting with `8`) instead of your main address (starting with `4`) to receive funds. Run:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:96
+#, no-wrap
+msgid "address new [<label text with white spaces allowed>]\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:102
-msgid ""
-"If you are the third party (that is, someone wants to prove to you that they "
-"sent monero to an address), then you can check this way:"
+msgid "This will generate a subaddress and its optional label, which addess you can share to receive payment on the account it's linked to.  For example,"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:104
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:103
 #, no-wrap
-msgid "    check_tx_key TXID TXKEY ADDRESS\n"
+msgid "address new github_donations\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:108
-msgid ""
-"Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, "
-"per-transaction key, and destination address which were supplied to you, "
-"respectively. monero-wallet-cli will check that transaction and let you know "
-"how much monero this transaction paid to the given address."
+msgid "will generate a subaddress and its label 'github_donations'."
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:110
+msgid "To view all generated addresses, run:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:111
-msgid "## Getting a chance to confirm/cancel payments"
+#, no-wrap
+msgid "address all\n"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:113
-msgid "If you want to get a last chance confirmation when sending a payment:"
-msgstr ""
-
-#. type: Plain text
+#. type: Title ##
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:115
 #, no-wrap
-msgid "    set always-confirm-transfers 1\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:118
-msgid "## How to find a payment to you"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:120
-msgid "If you received a payment using a particular payment ID, you can look it up:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:122
-#, no-wrap
-msgid "    payments PAYMENTID\n"
+msgid "Proving to a third party you paid someone"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:124
-msgid "You can give more than one payment ID too."
+msgid "If you pay a merchant, and the merchant claims to not have received the funds, you may need to prove to a third party you did send the funds - or even to the merchant, if it is a honest mistake. Monero is private, so you can't just point to your transaction in the blockchain, as you can't tell who sent it, and who received it. However, by supplying the per-transaction private key to a party, that party can tell whether that transaction sent monero to that particular address. Note that storing these per-transaction keys is disabled by default, and you will have to enable it before sending, if you think you may need it:"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:126
-msgid "More generally, you can review incoming and outgoing payments:"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:128
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:125
 #, no-wrap
-msgid "    show_transfers\n"
+msgid "set store-tx-info 1\n"
 msgstr ""
 
 #. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:130
+msgid "You can retrieve the tx key from an earlier transaction:"
+msgstr ""
+
+#. type: Fenced code block
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:131
-msgid ""
-"You can give an optional height to list only recent transactions, and "
-"request only incoming or outgoing transactions. For example,"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:133
 #, no-wrap
-msgid "    show_transfers in 650000\n"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:136
-msgid ""
-"will only show incoming transfers after block 650000. You can also give a "
-"height range."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:138
-msgid "If you want to mine, you can do so from the wallet:"
+msgid "get_tx_key 1234567890123456789012345678901212345678901234567890123456789012\n"
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:140
-#, no-wrap
-msgid "    start_mining 2\n"
+msgid "Pass in the transaction ID you want the key for. Remember that a payment might have been split in more than one transaction, so you may need several keys. You can then send that key, or these keys, to whoever you want to provide proof of your transaction, along with the transaction id and the address you sent to. Note that this third party, if knowing your own address, will be able to see how much change was returned to you as well."
 msgstr ""
 
 #. type: Plain text
 #: _i18n/en/resources/user-guides/monero-wallet-cli.md:143
-msgid ""
-"This will start mining on the daemon usin two threads. Note that this is "
-"solo mining, and may take a while before you find a block. To stop mining:"
+msgid "If you are the third party (that is, someone wants to prove to you that they sent monero to an address), then you can check this way:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:144
+#, no-wrap
+msgid "check_tx_key TXID TXKEY ADDRESS\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/monero-wallet-cli.md:145
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:151
+msgid "Replace `TXID`, `TXKEY` and `ADDRESS` with the transaction ID, per-transaction key, and destination address which were supplied to you, respectively. `monero-wallet-cli` will check that transaction and let you know how much monero this transaction paid to the given address."
+msgstr ""
+
+#. type: Title ##
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:152
 #, no-wrap
-msgid "    stop_mining\n"
+msgid "How to find a payment to you"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:155
+msgid "If you received a payment using a particular payment ID, you can look it up:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:156
+#, no-wrap
+msgid "payments PAYMENTID\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:161
+msgid "You can give more than one payment ID too."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:163
+msgid "More generally, you can review incoming and outgoing payments:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:164
+#, no-wrap
+msgid "show_transfers\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:170
+msgid "You can give an optional height to list only recent transactions, and request only incoming or outgoing transactions. For example,"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:171
+#, no-wrap
+msgid "show_transfers in 650000\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:177
+msgid "will only show incoming transfers after block 650000. You can also give a height range."
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:179
+msgid "If you want to mine, you can do so from the wallet:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:180
+#, no-wrap
+msgid "start_mining 2\n"
+msgstr ""
+
+#. type: Plain text
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:186
+msgid "This will start mining on the daemon usin two threads. Note that this is solo mining, and may take a while before you find a block. To stop mining:"
+msgstr ""
+
+#. type: Fenced code block
+#: _i18n/en/resources/user-guides/monero-wallet-cli.md:187
+#, no-wrap
+msgid "stop_mining\n"
 msgstr ""


### PR DESCRIPTION
The configuration file for po4all is not working as expected (multiple paths are not supported apparently). I've been testing solutions, but haven't come up with anything that doesn't require changing the structure of the .po file (which in any case it's not a big deal, beside the large amount of files moved around). These language files were updated by replacing `verification-allos-advanced` in the config file and then running po4a.

The structure changed substantially, so some translations got lost in the conversion. Still waiting for Weblate to support markdown file so that dealing with user guides will be much less a PITA.