### PR TITLE
custom: hide down arrow in tooltips

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -4719,7 +4719,6 @@ input.accordion[type=radio]:checked + label::after {
   border-top: 5px solid hsla(0, 0%, 20%, 0.9);
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
-  content: " ";
   font-size: 0;
   line-height: 0;
 }


### PR DESCRIPTION
This PR removes a down arrow at the bottom of every tooltip.
![image](https://user-images.githubusercontent.com/45968869/128323489-e5af17f2-da21-4edb-b5d2-3fc0d3d45361.png)