### PR TITLE
Downloads: fill width of buttons on menu bar

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -193,6 +193,7 @@ downloads:
   blockchain3: Importing the Monero blockchain
   blockchain4: for step-by-step instructions for Windows.
   blockchainbutton: Download Blockchain
+  mobilelight0: Mobile & Light
   mobilelight: Mobile & Light Wallets
   hardware: Hardware Wallets
   gui_intro: The GUI wallet provides a nice user interface, adaptable to all kinds of users, but it is especially recommended for less technical people who want to quickly send and receive XMR.

--- a/css/custom.css
+++ b/css/custom.css
@@ -3138,6 +3138,10 @@ footer {
   text-align: center;
 }
 
+.downloads .col {
+  width: 20%;
+}
+
 .downloads img.screen {
     margin: 1rem auto;
 }
@@ -3182,6 +3186,7 @@ footer {
     display: flex;
     padding: 1rem 2rem;
     font-weight: bold;
+    justify-content: center;
     -webkit-transition: all ease-out .2s;
     -moz-transition: all ease-out .2s;
     -o-transition: all ease-out .2s;

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -14,7 +14,7 @@ permalink: /downloads/index.html
         <div class="info-block download-nav row middle-xs between-xs" id="selections">
             <div class="col"><a href="#gui">{% t downloads.gui %}</a></div>
             <div class="col"><a href="#cli">{% t downloads.cli %}</a></div>
-            <div class="col"><a href="#mobilelight">{% t downloads.mobilelight %}</a></div>
+            <div class="col"><a href="#mobilelight">{% t downloads.mobilelight0 %}</a></div>
             <div class="col"><a href="#blockchain">{% t downloads.blockchain %}</a></div>
             <div class="col"><a href="#hardware">{% t downloads.hardware %}</a></div>
         </div>


### PR DESCRIPTION
Changes:
- make each button fill 20% of total width (consistent with Blog navigation bar)
- rename "Mobile & Light Wallets" to "Mobile & Light" (not enough space)

Before:
![downloadsbarbefore](https://user-images.githubusercontent.com/45968869/128421167-11adb218-f951-4f66-b201-8907b6a6168a.gif)

After:
![downloadsbarafter](https://user-images.githubusercontent.com/45968869/128421207-7dc30876-8b7b-4049-bfa6-e45655a10102.gif)