### PR TITLE
custom.css: avoid fixed page header overlapping in-page anchors on mobile

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -2443,6 +2443,14 @@ label[for="mobile-burger"] {
     background-color: #f5f5f5;
 }
 
+/*Avoid fixed page header overlapping in-page anchors on mobile*/
+:target::before {
+  content: "";
+  display: block;
+  height: 80px;
+  margin: -60px 0 0;
+}
+
 #drop1:checked ~ .dropdown-content, #drop2:checked ~ .dropdown-content, #drop3:checked ~ .dropdown-content, #drop4:checked ~ .dropdown-content {
     background-color: #fcfcfc;
 }


### PR DESCRIPTION
Before
![overlap1](https://user-images.githubusercontent.com/45968869/128648773-f2ae9c19-daf3-472c-8040-bcff9dae1931.gif)

After
![overlap2](https://user-images.githubusercontent.com/45968869/128648772-13f939b0-6a71-4c2f-a0df-15c9e796cb35.gif)
