### PR TITLE
custom.css: increase bottom margin of fixed page header

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -2447,7 +2447,7 @@ label[for="mobile-burger"] {
 :target::before {
   content: "";
   display: block;
-  height: 80px;
+  height: 110px;
   margin: -60px 0 0;
 }
 


### PR DESCRIPTION
This PR will fix overlaping of page anchors in user guides (on mobile) and will increase the bottom margin on downloads page (on mobile).