### PR TITLE
README: add PR workflow (github's project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ This website is available natively on Tor. The onion address is in `_includes/on
 
 If you want to post getmonero's onion address somewhere on the website, don't simply write it, instead include it using `{% include onion.html %}`. This avoids problems with typos and allow us top change the address only in one file if necessary.
 
+## PR workflow
+
+To simplify the process of drafting, reviewing and merging pull requests, we use a GitHub Project board. This Kanban board makes easier for people to see and participate to the pull request workflow: [monero-site: PR workflow](https://github.com/orgs/monero-project/projects/1).
+
 ## Translation
 In this section you'll find the info you need to translate a page and add a new translation, but keep in mind that Monero has a [Localization Workgroup](https://github.com/monero-ecosystem/monero-translations) who coordinate and give support to translators-volunteers. For live support/request of information, come chat on `#monero-translations` on Matrix or IRC (Libera.chat)
 The entire website, except for the Moneropedia entries, is translatable on Weblate, an easy to use localization platform that provide contributors with a user friendly interface: [translate.getmonero.org](https://translate.getmonero.org). Before translating, please read [the guide for translators](https://github.com/monero-ecosystem/monero-translations/blob/master/weblate.md), which contains all the info and workflows you need to know before starting.


### PR DESCRIPTION
We add a section where we introduce the Kanban board we are going to use to keep track of the status of pull requests. This process is partly automated and PRs will move from one column to another depending by actions performed by maintainers and reviewers (we don't use GitHub's team so the automation capabilities are limited).

The board: https://github.com/orgs/monero-project/projects/1

We have four columns at the moment:

### Draft
These are PRs that for various reasons are not ready for reviews yet. They might be simple WIP drafts or PRs that were ready for review but needed to be reworked heavily before becoming ready for another review.

### Review Needed
PRs that are completed and are waiting for 1 or more reviewers to approve them. This column substitutes the old 'needs review' label, which was applied (usually by me) to PRs. When the PR is approved, it will be moved to the next column: "Ready for Merge"

### Ready for Merge
When a PR is moved here, it means it's ready to be merged by a maintainer. If needed, the PR can be moved back to "Review Needed". This will happen automatically in some situations (e.g a maintainer asks for changes). This column can substitute the PR bot we use on `#monero-site`

### Done
Merged or closed pull requests will automatically move here. If the PR is reopened, it will move automatically to the "Review Needed" column.

More about github project boards: [About project boards (github docs)](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/about-project-boards).