### PR TITLE
moneropedia add p2pool sidechain merge-mining

### DIFF
--- a/_i18n/ar/resources/moneropedia/merge-mining.md
+++ b/_i18n/ar/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/ar/resources/moneropedia/merge-mining.md
+++ b/_i18n/ar/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/ar/resources/moneropedia/merge-mining.md
+++ b/_i18n/ar/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/ar/resources/moneropedia/merge-mining.md
+++ b/_i18n/ar/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/ar/resources/moneropedia/p2pool.md
+++ b/_i18n/ar/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/ar/resources/moneropedia/p2pool.md
+++ b/_i18n/ar/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/ar/resources/moneropedia/sidechain.md
+++ b/_i18n/ar/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/ar/resources/moneropedia/sidechain.md
+++ b/_i18n/ar/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/ar/resources/moneropedia/sidechain.md
+++ b/_i18n/ar/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/de/resources/moneropedia/merge-mining.md
+++ b/_i18n/de/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/de/resources/moneropedia/merge-mining.md
+++ b/_i18n/de/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/de/resources/moneropedia/merge-mining.md
+++ b/_i18n/de/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/de/resources/moneropedia/merge-mining.md
+++ b/_i18n/de/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/de/resources/moneropedia/p2pool.md
+++ b/_i18n/de/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/de/resources/moneropedia/p2pool.md
+++ b/_i18n/de/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/de/resources/moneropedia/sidechain.md
+++ b/_i18n/de/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/de/resources/moneropedia/sidechain.md
+++ b/_i18n/de/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/de/resources/moneropedia/sidechain.md
+++ b/_i18n/de/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -943,6 +943,9 @@ moneropedia:
     viewkey: View Key
     wallet: Wallet
     clsag: CLSAG
+    p2pool: P2Pool
+    merge-mining: Merge Mining
+    sidechain: Sidechain
 
 tools:
   intro1: Below is a list of third-party tools for interacting with the Monero ecosystem. <b>These tools are not vetted by the Getmonero team, see the disclaimer at the bottom of this page.</b> If a tool no longer supports Monero or you would like a Monero tool to be listed, please

--- a/_i18n/en/resources/moneropedia/merge-mining.md
+++ b/_i18n/en/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 ### The Basics

--- a/_i18n/en/resources/moneropedia/merge-mining.md
+++ b/_i18n/en/resources/moneropedia/merge-mining.md
@@ -9,4 +9,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/en/resources/moneropedia/merge-mining.md
+++ b/_i18n/en/resources/moneropedia/merge-mining.md
@@ -9,10 +9,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/en/resources/moneropedia/merge-mining.md
+++ b/_i18n/en/resources/moneropedia/merge-mining.md
@@ -1,0 +1,18 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/en/resources/moneropedia/p2pool.md
+++ b/_i18n/en/resources/moneropedia/p2pool.md
@@ -1,0 +1,40 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/en/resources/moneropedia/p2pool.md
+++ b/_i18n/en/resources/moneropedia/p2pool.md
@@ -6,35 +6,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/en/resources/moneropedia/sidechain.md
+++ b/_i18n/en/resources/moneropedia/sidechain.md
@@ -8,7 +8,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/en/resources/moneropedia/sidechain.md
+++ b/_i18n/en/resources/moneropedia/sidechain.md
@@ -8,7 +8,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/en/resources/moneropedia/sidechain.md
+++ b/_i18n/en/resources/moneropedia/sidechain.md
@@ -1,0 +1,15 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/es/resources/moneropedia/merge-mining.md
+++ b/_i18n/es/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/es/resources/moneropedia/merge-mining.md
+++ b/_i18n/es/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/es/resources/moneropedia/merge-mining.md
+++ b/_i18n/es/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/es/resources/moneropedia/merge-mining.md
+++ b/_i18n/es/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/es/resources/moneropedia/p2pool.md
+++ b/_i18n/es/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/es/resources/moneropedia/p2pool.md
+++ b/_i18n/es/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/es/resources/moneropedia/sidechain.md
+++ b/_i18n/es/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/es/resources/moneropedia/sidechain.md
+++ b/_i18n/es/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/es/resources/moneropedia/sidechain.md
+++ b/_i18n/es/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/fr/resources/moneropedia/merge-mining.md
+++ b/_i18n/fr/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/fr/resources/moneropedia/merge-mining.md
+++ b/_i18n/fr/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/fr/resources/moneropedia/merge-mining.md
+++ b/_i18n/fr/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/fr/resources/moneropedia/merge-mining.md
+++ b/_i18n/fr/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/fr/resources/moneropedia/p2pool.md
+++ b/_i18n/fr/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/fr/resources/moneropedia/p2pool.md
+++ b/_i18n/fr/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/fr/resources/moneropedia/sidechain.md
+++ b/_i18n/fr/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/fr/resources/moneropedia/sidechain.md
+++ b/_i18n/fr/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/fr/resources/moneropedia/sidechain.md
+++ b/_i18n/fr/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/it/resources/moneropedia/merge-mining.md
+++ b/_i18n/it/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/it/resources/moneropedia/merge-mining.md
+++ b/_i18n/it/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/it/resources/moneropedia/merge-mining.md
+++ b/_i18n/it/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/it/resources/moneropedia/merge-mining.md
+++ b/_i18n/it/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/it/resources/moneropedia/p2pool.md
+++ b/_i18n/it/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/it/resources/moneropedia/p2pool.md
+++ b/_i18n/it/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/it/resources/moneropedia/sidechain.md
+++ b/_i18n/it/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/it/resources/moneropedia/sidechain.md
+++ b/_i18n/it/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/it/resources/moneropedia/sidechain.md
+++ b/_i18n/it/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/nb-no/resources/moneropedia/merge-mining.md
+++ b/_i18n/nb-no/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/nb-no/resources/moneropedia/merge-mining.md
+++ b/_i18n/nb-no/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/nb-no/resources/moneropedia/merge-mining.md
+++ b/_i18n/nb-no/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/nb-no/resources/moneropedia/merge-mining.md
+++ b/_i18n/nb-no/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/nb-no/resources/moneropedia/p2pool.md
+++ b/_i18n/nb-no/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/nb-no/resources/moneropedia/p2pool.md
+++ b/_i18n/nb-no/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/nb-no/resources/moneropedia/sidechain.md
+++ b/_i18n/nb-no/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/nb-no/resources/moneropedia/sidechain.md
+++ b/_i18n/nb-no/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/nb-no/resources/moneropedia/sidechain.md
+++ b/_i18n/nb-no/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/nl/resources/moneropedia/merge-mining.md
+++ b/_i18n/nl/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/nl/resources/moneropedia/merge-mining.md
+++ b/_i18n/nl/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/nl/resources/moneropedia/merge-mining.md
+++ b/_i18n/nl/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/nl/resources/moneropedia/merge-mining.md
+++ b/_i18n/nl/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/nl/resources/moneropedia/p2pool.md
+++ b/_i18n/nl/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/nl/resources/moneropedia/p2pool.md
+++ b/_i18n/nl/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/nl/resources/moneropedia/sidechain.md
+++ b/_i18n/nl/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/nl/resources/moneropedia/sidechain.md
+++ b/_i18n/nl/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/nl/resources/moneropedia/sidechain.md
+++ b/_i18n/nl/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/pl/resources/moneropedia/merge-mining.md
+++ b/_i18n/pl/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/pl/resources/moneropedia/merge-mining.md
+++ b/_i18n/pl/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/pl/resources/moneropedia/merge-mining.md
+++ b/_i18n/pl/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/pl/resources/moneropedia/merge-mining.md
+++ b/_i18n/pl/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/pl/resources/moneropedia/p2pool.md
+++ b/_i18n/pl/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/pl/resources/moneropedia/p2pool.md
+++ b/_i18n/pl/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/pl/resources/moneropedia/sidechain.md
+++ b/_i18n/pl/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/pl/resources/moneropedia/sidechain.md
+++ b/_i18n/pl/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/pl/resources/moneropedia/sidechain.md
+++ b/_i18n/pl/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/pt-br/resources/moneropedia/merge-mining.md
+++ b/_i18n/pt-br/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/pt-br/resources/moneropedia/merge-mining.md
+++ b/_i18n/pt-br/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/pt-br/resources/moneropedia/merge-mining.md
+++ b/_i18n/pt-br/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/pt-br/resources/moneropedia/merge-mining.md
+++ b/_i18n/pt-br/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/pt-br/resources/moneropedia/p2pool.md
+++ b/_i18n/pt-br/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/pt-br/resources/moneropedia/p2pool.md
+++ b/_i18n/pt-br/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/pt-br/resources/moneropedia/sidechain.md
+++ b/_i18n/pt-br/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/pt-br/resources/moneropedia/sidechain.md
+++ b/_i18n/pt-br/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/pt-br/resources/moneropedia/sidechain.md
+++ b/_i18n/pt-br/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/ru/resources/moneropedia/merge-mining.md
+++ b/_i18n/ru/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/ru/resources/moneropedia/merge-mining.md
+++ b/_i18n/ru/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/ru/resources/moneropedia/merge-mining.md
+++ b/_i18n/ru/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/ru/resources/moneropedia/merge-mining.md
+++ b/_i18n/ru/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/ru/resources/moneropedia/p2pool.md
+++ b/_i18n/ru/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/ru/resources/moneropedia/p2pool.md
+++ b/_i18n/ru/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/ru/resources/moneropedia/sidechain.md
+++ b/_i18n/ru/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/ru/resources/moneropedia/sidechain.md
+++ b/_i18n/ru/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/ru/resources/moneropedia/sidechain.md
+++ b/_i18n/ru/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/tr/resources/moneropedia/merge-mining.md
+++ b/_i18n/tr/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/tr/resources/moneropedia/merge-mining.md
+++ b/_i18n/tr/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/tr/resources/moneropedia/merge-mining.md
+++ b/_i18n/tr/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/tr/resources/moneropedia/merge-mining.md
+++ b/_i18n/tr/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/tr/resources/moneropedia/p2pool.md
+++ b/_i18n/tr/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/tr/resources/moneropedia/p2pool.md
+++ b/_i18n/tr/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/tr/resources/moneropedia/sidechain.md
+++ b/_i18n/tr/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/tr/resources/moneropedia/sidechain.md
+++ b/_i18n/tr/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/tr/resources/moneropedia/sidechain.md
+++ b/_i18n/tr/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/zh-cn/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-cn/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/zh-cn/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-cn/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/zh-cn/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-cn/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/zh-cn/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-cn/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/zh-cn/resources/moneropedia/p2pool.md
+++ b/_i18n/zh-cn/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/zh-cn/resources/moneropedia/p2pool.md
+++ b/_i18n/zh-cn/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/zh-cn/resources/moneropedia/sidechain.md
+++ b/_i18n/zh-cn/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/zh-cn/resources/moneropedia/sidechain.md
+++ b/_i18n/zh-cn/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/zh-cn/resources/moneropedia/sidechain.md
+++ b/_i18n/zh-cn/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/zh-tw/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-tw/resources/moneropedia/merge-mining.md
@@ -11,10 +11,4 @@ summary: "the process of mining two or more blockchains at the same time "
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
-
-#### External Links
-
-- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
-- [Townforge -About](https://townforge.net/about)
-- [P2Pool GitHub](https://townforge.net/about)
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).

--- a/_i18n/zh-tw/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-tw/resources/moneropedia/merge-mining.md
@@ -1,0 +1,20 @@
+---
+entry: "Merge Mining"
+terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
+summary: "the process of mining two or more blockchains at the same time "
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
+
+Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
+Some examples that currently exist or are in development are: a blockchain game (TownForge), digital assets platform (Tari) or a decentralized mining pool (@P2Pool).
+
+#### External Links
+
+- [Tari - What is Tari](https://www.tari.com/#what-is-tari)
+- [Townforge -About](https://townforge.net/about)
+- [P2Pool GitHub](https://townforge.net/about)

--- a/_i18n/zh-tw/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-tw/resources/moneropedia/merge-mining.md
@@ -1,7 +1,7 @@
 ---
 entry: "Merge Mining"
 terms: ["merge-mine", "merge-mining", "merged-mining","merge-mined"]
-summary: "the process of mining two or more blockchains at the same time "
+summary: "the process of mining two or more blockchains at the same time"
 ---
 
 {% include disclaimer.html translated="no" translationOutdated="no" %}

--- a/_i18n/zh-tw/resources/moneropedia/merge-mining.md
+++ b/_i18n/zh-tw/resources/moneropedia/merge-mining.md
@@ -11,4 +11,4 @@ summary: "the process of mining two or more blockchains at the same time"
 Merge mining is the process of @mining two or more @blockchains at the same time. Generally there is a parent @blockchain and an auxillary blockchain both of which use the same proof of work algorithm. In most cases the auxillary chain will have a lower difficulty than the parent block chain.
 
 Merge mining can be used for securing a lower hashrate blockchain or developing a @sidechain that does something different than the primary chain.
-Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari) or a decentralized mining pool (@P2Pool).
+Some examples that currently exist or are in development are: a blockchain game [TownForge](https://townforge.net/about), digital assets platform [Tari](https://www.tari.com/#what-is-tari), and a decentralized mining pool (@P2Pool).

--- a/_i18n/zh-tw/resources/moneropedia/p2pool.md
+++ b/_i18n/zh-tw/resources/moneropedia/p2pool.md
@@ -1,0 +1,42 @@
+---
+entry: "P2Pool"
+terms: ["P2Pool", "monero-p2pool"]
+summary: "Peer to peer mining pool for Monero"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
+P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
+P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
+It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+
+To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
+
+### More Information
+
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
+Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
+High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
+Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
+If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+
+### Technical Details
+
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
+There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
+The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
+Each individual miner payout takes only 38 bytes on the Monero blockchain.
+
+### External Links
+
+- [P2Pool source](https://github.com/SChernykh/p2pool)
+- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
+- [P2Pool pool stats](https://p2pool.io)
+- [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/zh-tw/resources/moneropedia/p2pool.md
+++ b/_i18n/zh-tw/resources/moneropedia/p2pool.md
@@ -8,35 +8,24 @@ summary: "Peer to peer mining pool for Monero"
 
 ### The Basics
 
-Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1).
-P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
+Monero P2Pool is a peer-to-peer Monero @mining pool developed by SChernykh (also known as sech1). P2Pool was a concept was first developed for the Bitcoin blockchain but was never fully realized due to certain limitations, mainly because it had a problem with orphaned @blocks which is solved in Monero P2Pool with uncle blocks.
 
-Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines.
-P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero.
-It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
+Unlike a traditional mining pool, P2Pool allows it's users to fully control their own @node and what it mines. P2Pool has no central server that can be shutdown/blocked because it uses a separate blockchain to @merge-mine with Monero. It is designed so that all blocks found by the pool pay out to the miners immediately which means that funds are never in custody of a single party.
 
 To accomplish this P2Pool uses PPLNS payout scheme which rewards miners only once the block has been found by the pool; miners with a share in the PPLNS window are rewarded directly via the @coinbase-transaction reward for the block.
 
 ### More Information
 
-P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks.
-Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window.
-High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
+P2Pool is a @sidechain to Monero, and P2Pool blocks are potentially Monero @blocks. Each miner submits block templates that include a payout for all of the miners that currently have shares in the PPLNS window. High quality block templates are added to the P2Pool blockchain as blocks which count as "shares" for the miner who found them.
 
-If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain.
-Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template.
-If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
+If a block is good enough to be a Monero block it is also submitted to the Monero network to be included in its blockchain. Once the Monero block is confirmed by the network, those miners are directly paid in the @coinbase-transaction because they were included already in the block template. If P2Pool "shares" are found at the same block height as an existing share, it is included as an uncle block (worth 20% less than a normal share) so miners still get paid for it (uncle blocks can be submitted up to 3 blocks behind the current height and still be included).
 
 ### Technical Details
 
-Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections.
-There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours).
-The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees).
-Each individual miner payout takes only 38 bytes on the Monero blockchain.
+Monero P2Pool is written from scratch in C++. It uses the high-performance libuv library so each node is able to handle thousands of concurrent miner connections. There are 2160 blocks in the PPLNS window with a block time of 10 seconds (approximately 6 hours). The number of blocks was chosen so that the minimum payout would be approximately 0.0004 XMR (this amount was considered high enough that it could be transferred with minimal fees). Each individual miner payout takes only 38 bytes on the Monero blockchain.
 
 ### External Links
 
 - [P2Pool source](https://github.com/SChernykh/p2pool)
-- [P2Pool releases](https://github.com/SChernykh/p2pool/releases)
 - [P2Pool pool stats](https://p2pool.io)
 - [P2Pool Observer (mining data)](https://p2pool.observer)

--- a/_i18n/zh-tw/resources/moneropedia/sidechain.md
+++ b/_i18n/zh-tw/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/_i18n/zh-tw/resources/moneropedia/sidechain.md
+++ b/_i18n/zh-tw/resources/moneropedia/sidechain.md
@@ -1,0 +1,17 @@
+---
+entry: "sidechain"
+terms: ["sidechain", "side-chain", "auxillary-chain"]
+summary: "a blockchain that is merge mined with a primary blockchain"
+---
+
+{% include disclaimer.html translated="no" translationOutdated="no" %}
+
+### The Basics
+
+A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
+
+A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+
+### More Information
+
+For more information see the @merge-mining article on Moneropedia.

--- a/_i18n/zh-tw/resources/moneropedia/sidechain.md
+++ b/_i18n/zh-tw/resources/moneropedia/sidechain.md
@@ -10,7 +10,7 @@ summary: "a blockchain that is merge mined with a primary blockchain"
 
 A sidechain (also known as an auxillary chain) is a @blockchain that is @merge-mined with Monero or other cryptocurrency. In most cases the sidechain will have a lower difficulty than the primary blockchain.
 
-A pegged sidechain is a sidechain that allows you to transfer assets between different blockchains by pegging the value of one asset to another on an alternate blockchain. Currently there are no pegged sidechains that exist for Monero.
+A sidechain that that allows you to transfer assets between different blockchains is called a "pegged blockchain". It works by setting the value of one asset equal to the value of another asset on an alternate blockchain, otherwise known as pegging. Currently there are no pegged sidechains that exist for Monero.
 
 ### More Information
 

--- a/resources/moneropedia/merge-mining.md
+++ b/resources/moneropedia/merge-mining.md
@@ -1,0 +1,10 @@
+---
+layout: moneropedia
+title: titles.moneropedia
+entry: moneropedia.entries.merge-mining
+---
+
+@moneropedia_article
+
+{% t global.lang_tag %}
+{% tf resources/moneropedia/merge-mining.md %}

--- a/resources/moneropedia/p2pool.md
+++ b/resources/moneropedia/p2pool.md
@@ -1,0 +1,10 @@
+---
+layout: moneropedia
+title: titles.moneropedia
+entry: moneropedia.entries.p2pool
+---
+
+@moneropedia_article
+
+{% t global.lang_tag %}
+{% tf resources/moneropedia/p2pool.md %}

--- a/resources/moneropedia/sidechain.md
+++ b/resources/moneropedia/sidechain.md
@@ -1,0 +1,10 @@
+---
+layout: moneropedia
+title: titles.moneropedia
+entry: moneropedia.entries.sidechain
+---
+
+@moneropedia_article
+
+{% t global.lang_tag %}
+{% tf resources/moneropedia/sidechain.md %}


### PR DESCRIPTION
First PR for a Moneropedia page after translation changes, so let me know if it's missing anything.

Adds pages for P2Pool, sidechain, and merge mining. A lot of the text is borrowed from announcement blog post but I attempted to adjust for appropriate tone. Feedback is appreciated.

Resolves #1845