### PR TITLE
Add CoinConsume to merchant list provider

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -17,6 +17,7 @@ permalink: /community/merchants/index.html
         <ul class="logo">
           <li><a href="https://cryptwerk.com/pay-with/xmr/">cryptwerk.com</a></li>
           <li><a href="https://www.acceptedhere.io/catalog/currency/xmr/">acceptedhere.io</a></li>
+          <li><a href="https://www.coinconsume.com/pay-with/monero/">coinconsume.com</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
CoinConsume is a tool that helps you to find websites where you can spend your cryptocurrencies.
A page dedicated for Monero is available : https://www.coinconsume.com/pay-with/monero/
It can be great to add this to the existing list.