### PR TITLE
Adding a swapper

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -99,6 +99,7 @@ permalink: /community/merchants/index.html
         <h3>Swappers</h3>
         <p>{% t merchants.swappersp %}</p>
         <ul class="logo">
+            <li><a href="https://fixedfloat.com/">Fixedfloat</a></li>
             <li><a href="https://sideshift.ai/">Sideshift.ai</a></li>
             <li><a href="https://www.morphtoken.com/">Morphtoken</a></li>
             <li><a href="https://simpleswap.io/">SimpleSwap</a></li>


### PR DESCRIPTION
XMR does not always show up as an option (most likely due to blocking some countries, this can be overcome with VPN or selecting the appropriate tor exit node). Nevertheless, **fixedfloat.com** seems to be the only swapper that offers BTC lightning to Monero.