### PR TITLE
roadmap: add haveno

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -798,6 +798,7 @@ roadmap:
   atomicswaps: Monero <-> Bitcoin atomic swaps
   bplus: Bulletproofs+
   p2pool: P2Pool released
+  haveno: Haveno
 
 
 research-lab:

--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -208,6 +208,7 @@ permalink: /resources/roadmap/index.html
                         <h2>{% t roadmap.future %}</h2>
                             <ul>
                                 <h3 class="months">{% t roadmap.comingsoon %}</h3>
+                                    <li class="ongoing"><a href="https://haveno.exchange">{% t roadmap.haveno %}</a></li>
                                     <li class="ongoing">{% t roadmap.bplus %}</li>
                                     <li class="ongoing">{% t roadmap.tryptych %}</li>
                                     <li class="upcoming">{% t roadmap.returnaddr %}</li>


### PR DESCRIPTION
Haveno is arguably one of the most important projects in Monero history, makes sense to add it to the roadmap.