### PR TITLE
Add CoinLoan CEX to merchant page

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -94,6 +94,7 @@ permalink: /community/merchants/index.html
             <li><a href="https://www.binance.com/trade.html?symbol=XMR_BTC">Binance</a> (USD, EUR, RUB, TRY, NGN, UAH, KZT, INR, ...)</li>
             <li><a href="https://dvchain.co/">DV Chain (OTC)</a> (USD*, CAD*, GBP*, EUR*, JPY*, ...)</li>
             <li><a href="https://www.bitfinex.com/">Bitfinex</a> (USD*)</li>
+            <li><a href="https://www.coinloan.io/">CoinLoan</a> (GBP*, EUR*)</li>
           </ul>
           <p>*Fiat currency to Monero trading pair (e.g. XMR/USD, XMR/EUR)</p>
         <h3>Swappers</h3>


### PR DESCRIPTION
CoinLoan reached out to the press@getmonero.org email asking to be added to this page.

They allow KYC'd users to trade XMR with other currencies, including GBP and EUR. XMR and fiat deposits and withdrawals enabled.