### PR TITLE
css: fix missing margin top in guides

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -3113,7 +3113,7 @@ footer {
 }
 
 .guides h2:first-of-type {
-    margin-top: 0;
+    margin-top: 2rem;
 }
 
 .guides span {


### PR DESCRIPTION
Before

<img width="686" alt="Screenshot  Before" src="https://user-images.githubusercontent.com/7697454/165188799-05f81268-714d-4652-a339-1529f05b1e26.png">

After

<img width="675" alt="Screenshot After" src="https://user-images.githubusercontent.com/7697454/165188806-f192fb6c-53de-47a4-9756-b05e875bd668.png">

