### PR TITLE
Add .jekyll-metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site/*
 .idea/
 *.swp
 .jekyll-cache/
+.jekyll-metadata


### PR DESCRIPTION
When developing the site with incremental generation enabled Jekyll produces a .jekyll-metadata file. Per the [Jekyll documentation](https://jekyllrb.com/docs/structure/) this should be added to the .gitignore 
![image](https://user-images.githubusercontent.com/104728777/167264850-86b3a584-18b8-4201-8a61-80ead161c251.png)
