### PR TITLE
Update confidential_para1 to "a" not "the only" cryptocurrency

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -581,7 +581,7 @@ what-is-monero:
   leading_para1: The majority of existing @cryptocurrencies, including Bitcoin and Ethereum, have transparent @blockchains. Transactions can be verified and/or traced by anyone in the world. This means that the sending and receiving @addresses of these @transactions could potentially be linked to real-world identities.
   leading_para2: Monero, on the other hand, uses various privacy-enhancing technologies to ensure the anonymity of its users. 
   confidential: Monero transactions are confidential and untraceable.
-  confidential_para1: "Unlike selectively transparent alternatives (e.g. Zcash), Monero is the only cryptocurrency where every user is anonymous by default. The sender, receiver, and amount of every single transaction are hidden through the use of three important technologies: @Stealth-Addresses, @Ring-Signatures, and @RingCT."
+  confidential_para1: "Unlike selectively transparent alternatives (e.g. Zcash), Monero is the only major cryptocurrency where every user is anonymous by default. The sender, receiver, and amount of every single transaction are hidden through the use of three important technologies: @Stealth-Addresses, @Ring-Signatures, and @RingCT."
   confidential_para2: Because every transaction is private, Monero cannot be traced. This makes it a true, @fungible currency. Merchants and individuals accepting Monero do not need to worry about blacklisted or tainted coins.
   grassroots: Monero is a grassroots community attracting the world's best cryptocurrency researchers and engineering talent.
   grassroots_p1: The Monero Project is at the forefront of cryptocurrency privacy and security. Its 


### PR DESCRIPTION
Changed "Monero is the only cryptocurrency where every user is anonymous by default." to "Monero is a cryptocurrency where every user is anonymous by default." to address issue [1934](https://github.com/monero-project/monero-site/issues/1934)
