### PR TITLE
user guides page alphabetic order

### DIFF
--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -49,8 +49,8 @@ title: titles.userguides
                         <div class="col">
                             <h2>{% t user-guides.nodesync %}</h2>
                             <p><a href="{{site.baseurl}}/resources/user-guides/remote_node_gui.html">{% t user-guides.remote-node-gui %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/vps_run_node.html">{% t user-guides.vps-node %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/importing_blockchain.html">{% t user-guides.import-blockchain %}</a></p>
+                            <p><a href="{{site.baseurl}}/resources/user-guides/vps_run_node.html">{% t user-guides.vps-node %}</a></p>
                         </div>
                     </div>
                 </div>
@@ -65,8 +65,8 @@ title: titles.userguides
                         <div class="col">
                             <h2>{% t user-guides.recovery %}</h2>
                             <p><a href="{{site.baseurl}}/resources/user-guides/howto_fix_stuck_funds.html">{% t user-guides.locked-funds %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/restore_account.html">{% t user-guides.restore-account %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/restore_from_keys.html">{% t user-guides.restore-from-keys %}</a></p>
+                            <p><a href="{{site.baseurl}}/resources/user-guides/restore_account.html">{% t user-guides.restore-account %}</a></p>
                         </div>
                     </div>
                 </div>
@@ -76,12 +76,12 @@ title: titles.userguides
                     <div class="row">
                         <div class="col">
                             <h2>{% t user-guides.wallets %}</h2>
+                            <p><a href="{{site.baseurl}}/resources/user-guides/monero-wallet-cli.html">{% t user-guides.cli-wallet %}</a></p>
                             <p><a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md">{% t user-guides.guiguide %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/change-restore-height.html">{% t user-guides.change-restore-height %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/verification-windows-beginner.html">{% t user-guides.verify-windows %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/verification-allos-advanced.html">{% t user-guides.verify-allos %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/monero-wallet-cli.html">{% t user-guides.cli-wallet %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/view_only.html">{% t user-guides.view-only %}</a></p>
+                            <p><a href="{{site.baseurl}}/resources/user-guides/verification-allos-advanced.html">{% t user-guides.verify-allos %}</a></p>
+                            <p><a href="{{site.baseurl}}/resources/user-guides/verification-windows-beginner.html">{% t user-guides.verify-windows %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/multisig-messaging-system.html">{% t user-guides.multisig-messaging-system %}</a></p>
                         </div>
                     </div>
@@ -107,9 +107,9 @@ title: titles.userguides
                         <div class="col">
                             <h2>{% t user-guides.anonimizationnetworks %}</h2>
                             <p><a href="{{site.baseurl}}/resources/user-guides/tor_wallet.html">{% t user-guides.tor_wallet %}</a></p>
-                            <p><a href="http://xmrguide42y34onq.onion/tails">{% t user-guides.tailsguide %}</a><img class="onion-mid" src="/img/onion-tor.svg" title="Onion link" alt="onion logo"></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html">{% t user-guides.qubes %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/node-i2p-zero.html">{% t user-guides.node-i2pzero %}</a></p>
+                            <p><a href="{{site.baseurl}}/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html">{% t user-guides.qubes %}</a></p>
+                            <p><a href="http://xmrguide42y34onq.onion/tails">{% t user-guides.tailsguide %}</a><img alt="onion logo" class="onion-mid" src="/img/onion-tor.svg" title="Onion link"/></p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The tutorials state that alphabetic order is needed for the [user guides page](https://www.getmonero.org/resources/user-guides/). This was automated by [a script](https://github.com/plowsof/userguide-drafts/blob/main/helper-scripts/user-guide-index-alphabetic/index-alphabetic.py)  i made.

![ba_1](https://user-images.githubusercontent.com/77655812/168707774-3d49beb1-c637-4d05-8eac-ad1401b0e5e5.png)
![ba_2](https://user-images.githubusercontent.com/77655812/168707784-f165637b-6a1c-4f72-b324-85a66cba857c.png)
![ba_3](https://user-images.githubusercontent.com/77655812/168707788-bd878f42-490b-49d6-ade0-2241fe393c05.png)

