### PR TITLE
edit node-i2p-zero user-guide

### DIFF
--- a/_i18n/en/resources/user-guides/node-i2p-zero.md
+++ b/_i18n/en/resources/user-guides/node-i2p-zero.md
@@ -9,9 +9,8 @@
 5. Create a socks tunnel for outgoing I2P connections by typing: `router/bin/tunnel-control.sh socks.create 8060`
 6. Create a server tunnel for incoming I2P connections by typing: `router/bin/tunnel-control.sh server.create 127.0.0.1 8061`.
 7. The command above will result in an I2P address being printed to the command line, which will end with `.b32.i2p`. This is your new I2P address.
-8. Run monerod by typing the following, replacing `XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p` with your own I2P address that was printed from step 6: `monerod --tx-proxy i2p,127.0.0.1:8060 --add-peer core5hzivg4v5ttxbor4a3haja6dssksqsmiootlptnsrfsgwqqa.b32.i2p --add-peer dsc7fyzzultm7y6pmx2avu6tze3usc7d27nkbzs5qwuujplxcmzq.b32.i2p --add-peer sel36x6fibfzujwvt4hf5gxolz6kd3jpvbjqg6o3ud2xtionyl2q.b32.i2p --add-peer yht4tm2slhyue42zy5p2dn3sft2ffjjrpuy7oc2lpbhifcidml4q.b32.i2p --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach`
+8. Run monerod by typing the following, replacing `XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p` with your own I2P address that was printed from step 6: `monerod --tx-proxy i2p,127.0.0.1:8060 --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach`
 
-That's it! Do not replace the dsc****.b32.i2p address with yours, only replace the XXXXXXX.b32.i2p one. The dsc****.b32.i2p is a seed node that will help you discover other I2P-accessible monero nodes.
 
 ## Setting up Linux services so that monerod and I2P-zero are automatically started
 
@@ -46,7 +45,7 @@ After=network.target
 [Service]
 Type=forking
 PIDFile=/home/<username>/monerod.pid
-ExecStart=/home/<username>/monero-x86_64-linux-gnu-v0.16.0.0/monerod --tx-proxy i2p,127.0.0.1:8060 --add-peer core5hzivg4v5ttxbor4a3haja6dssksqsmiootlptnsrfsgwqqa.b32.i2p --add-peer dsc7fyzzultm7y6pmx2avu6tze3usc7d27nkbzs5qwuujplxcmzq.b32.i2p --add-peer sel36x6fibfzujwvt4hf5gxolz6kd3jpvbjqg6o3ud2xtionyl2q.b32.i2p --add-peer yht4tm2slhyue42zy5p2dn3sft2ffjjrpuy7oc2lpbhifcidml4q.b32.i2p --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach --pidfile /home/<username>/monerod.pid
+ExecStart=/home/<username>/monero-x86_64-linux-gnu-v0.16.0.0/monerod --tx-proxy i2p,127.0.0.1:8060 --anonymous-inbound XXXXXXXXXXXXXXXXXXXXXXXXXXXXX.b32.i2p,127.0.0.1:8061 --detach --pidfile /home/<username>/monerod.pid
 User=<username>
 Group=<usergroup>
 


### PR DESCRIPTION
The translation tool po4a is more advanced than i thought, can edit the /en/ markdown directly before running the tool on this config file: (any 'manual labour' involved. please let me know, willing to do it)
```
[po4a_langs] es it pl fr ar ru de nl pt-br tr zh-cn zh-tw nb-no
[po4a_paths] ../_i18n/en/resources/user-guides/weblate/node-i2p-zero.pot $lang:../_i18n/$lang/resources/user-guides/weblate/node-i2p-zero.po

[options] opt:"--keep=0"
[options] opt:"--localized-charset=UTF-8"
[options] opt:"--master-charset=UTF-8"
[options] opt:"--master-language=en_US"
[options] opt:"--msgmerge-opt='--no-wrap'"
[options] opt:"--wrap-po=newlines"

[po4a_alias:markdown] text opt:"--option markdown"

[type: markdown] ../_i18n/en/resources/user-guides/node-i2p-zero.md $lang:../_i18n/$lang/resources/user-guides/node-i2p-zero.md
```
Reason for edit 'monerod versions v0.17.1.3 onwards comes with a list of hardcoded monerod peers' and <- and in my opinion this sentence does not need to be mentioned in the guide.