### PR TITLE
FAQ in alphabetical order

### DIFF
--- a/get-started/faq/index.md
+++ b/get-started/faq/index.md
@@ -20,45 +20,45 @@ permalink: /get-started/faq/index.html
                 <ul>
                     <li class="category">{% t faq.general %}</li>
                     <ul class="logo">
-                        <li><a href="#anchor-word">{% t faq.qword %}</a></li>
+                        <li><a href="#vulnerabilities">{% t faq.qvuln %}</a></li>
+                        <li><a href="#videos">{% t faq.qvideos %}</a></li>
                         <li><a href="#anchor-contribute">{% t faq.qcontribute %}</a></li>
-                        <li><a href="#anchor-value">{% t faq.q1 %}</a></li>
                         <li><a href="#anchor-buy">{% t faq.q2 %}</a></li>
-                        <li><a href="#anchor-different">{% t faq.q4 %}</a></li>
+                        <li><a href="#anchor-value">{% t faq.q1 %}</a></li>
                         <li><a href="#anchor-btc-difference">{% t faq.q7 %}</a></li>
+                        <li><a href="#anchor-different">{% t faq.q4 %}</a></li>
+                        <li><a href="#anchor-anonymous">{% t faq.q14 %}</a></li>
+                        <li><a href="#anchor-magic">{% t faq.q13 %}</a></li>
+                        <li><a href="#hardforks">{% t faq.qhf %}</a></li>
                         <li><a href="#asic-resistance">{% t faq.qasicresistance %}</a></li>
                         <li><a href="#anchor-fungibility">{% t faq.q11 %}</a></li>
-                        <li><a href="#anchor-magic">{% t faq.q13 %}</a></li>
-                        <li><a href="#anchor-anonymous">{% t faq.q14 %}</a></li>
-                        <li><a href="#vulnerabilities">{% t faq.qvuln %}</a></li>
-                        <li><a href="#antivirus">{% t faq.qantivirus %}</a></li>
+                        <li><a href="#anchor-word">{% t faq.qword %}</a></li>
                         <li><a href="#monero-meaning">{% t faq.qmoneromeaning %}</a></li>
-                        <li><a href="#hardforks">{% t faq.qhf %}</a></li>
-                        <li><a href="#videos">{% t faq.qvideos %}</a></li>
+                        <li><a href="#antivirus">{% t faq.qantivirus %}</a></li>
                     </ul>
                     <li class="category">{% t faq.advanced %}</li>
                     <ul class="logo">
-                        <li><a href="#anchor-thin-air">{% t faq.q12 %}</a></li>
-                        <li><a href="#anchor-light-normal">{% t faq.q6 %}</a></li>
-                        <li><a href="#anchor-block-limit">{% t faq.q8 %}</a></li>
-                        <li><a href="#anchor-mixing">{% t faq.q15 %}</a></li>
                         <li><a href="#import-blockchain">{% t faq.qimporting %}</a></li>
+                        <li><a href="#anchor-block-limit">{% t faq.q8 %}</a></li>
+                        <li><a href="#anchor-thin-air">{% t faq.q12 %}</a></li>
+                        <li><a href="#anchor-mixing">{% t faq.q15 %}</a></li>
                         <li><a href="#max-supply">{% t faq.qmaxsupply %}</a></li>
+                        <li><a href="#anchor-light-normal">{% t faq.q6 %}</a></li>
                     </ul>
                     <li class="category">{% t faq.nodeandwallet %}</li>
                     <ul class="logo">
-                        <li><a href="#anchor-wallet">{% t faq.qwallet %}</a></li>
+                        <li><a href="#anchor-avoid-bc">{% t faq.qavoidbc %}</a></li>
+                        <li><a href="#anchor-block-size">{% t faq.qblocksize %}</a></li>
+                        <li><a href="#anchor-tor-node">{% t faq.qnodetor %}</a></li>
+                        <li><a href="#anchor-full-pruned">{% t faq.qfullpruned %}</a></li>
                         <li><a href="#anchor-lost-funds">{% t faq.qnofunds %}</a></li>
                         <li><a href="#long-time-move">{% t faq.qlongtimemove %}</a></li>
-                        <li><a href="#anchor-tor-node">{% t faq.qnodetor %}</a></li>
-                        <li><a href="#anchor-long-sync">{% t faq.q5 %}</a></li>
-                        <li><a href="#anchor-full-pruned">{% t faq.qfullpruned %}</a></li>
-                        <li><a href="#anchor-block-size">{% t faq.qblocksize %}</a></li>
-                        <li><a href="#anchor-block-space">{% t faq.qblockspace %}</a></li>
-                        <li><a href="#anchor-avoid-bc">{% t faq.qavoidbc %}</a></li>
-                        <li><a href="#anchor-scanned-wallet">{% t faq.qscanned %}</a></li>
                         <li><a href="#anchor-danger-node">{% t faq.qdangernode %}</a></li>
                         <li><a href="#anchor-danger-rnode">{% t faq.qdangerrnode %}</a></li>
+                        <li><a href="#anchor-wallet">{% t faq.qwallet %}</a></li>
+                        <li><a href="#anchor-block-space">{% t faq.qblockspace %}</a></li>
+                        <li><a href="#anchor-long-sync">{% t faq.q5 %}</a></li>
+                        <li><a href="#anchor-scanned-wallet">{% t faq.qscanned %}</a></li>
                     </ul>
                 </ul>
             </div>
@@ -96,11 +96,24 @@ permalink: /get-started/faq/index.html
                     <!-- 'General' section-->
                     <div class="col"><h2>{% t faq.general %}</h2></div>
                 </div>
-                <div class="tab" id="anchor-word">
-                    <h3><a class="anchor" href="#anchor-word"></a>{% t faq.qword %}</h3>
+                <div class="tab" id="vulnerabilities">
+                    <h3><a class="anchor" href="#vulnerabilities"></a>{% t faq.qvuln %}</h3>
                     <div class="tab-answer">
-                        <p>{% t faq.aword %} <a href="{{ site.baseurl }}/resources/moneropedia/">Moneropedia</a>. {% t faq.aword1 %}
-                        </p>
+                        <p>{% t faq.avuln %}</p>
+                        <p>{% t faq.additional %} <a href="https://open.spotify.com/episode/77xsCeuy02Aztv0bgs3Drt?si=hyIGHD5TQjyV44b46fkhoQ&amp;dl_branch=1">{% t faq.vulnspotify %}</a></p>
+                    </div>
+                </div>
+                <div class="tab" id="videos">
+                    <h3><a class="anchor" href="#videos"></a>{% t faq.qvideos %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.avideos %}</p>
+                        <ol>
+                            <li><a href="{{ site.baseurl_root }}/media/Monero_Promo.m4v">{% t faq.video_intro %}</a> ({% t faq.aavailable %} <a href="{{ site.baseurl_root }}/media/ru/Monero_Promo.m4v">Russian</a> {% t faq.and %} <a href="{{ site.baseurl_root }}/media/pt-br/Monero_Promo.m4v">Brazilian Portuguese</a>)</li>
+                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20The%20Essentials.m4v">{% t faq.video_essentials %}</a></li>
+                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20Stealth%20Addresses.m4v">{% t faq.video_sa %}</a> - {% t faq.mvideos %} @Stealth-Addresses</li>
+                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20Ring%20Signatures.m4v">{% t faq.video_ringsig %}</a> - {% t faq.mvideos %} @Ring-Signatures</li>
+                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20RingCT.m4v">{% t faq.video_ringct %}</a> - {% t faq.mvideos %} @RingCT</li>
+                        </ol>
                     </div>
                 </div>
                 <div class="tab" id="anchor-contribute">
@@ -114,18 +127,24 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.additional %} <a href="{{ site.baseurl }}/get-started/accepting/">{% t titles.contributing %}</a></p>
                     </div>
                 </div>
-                <div class="tab" id="anchor-value">
-                    <h3><a class="anchor" href="#anchor-value"></a>{% t faq.q1 %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.a1 %}</p>
-                    </div>
-                </div>
                 <div class="tab" id="anchor-buy">
                     <h3><a class="anchor" href="#anchor-buy"></a>{% t faq.q2 %}</h3>
                     <div class="tab-answer">
                         <p>{% t faq.a2 %}</p>
                         <p>{% t faq.a2exchanges %} <a href="{{ site.baseurl }}/community/merchants/#exchanges">{% t titles.merchants %}</a>.</p>
                         <p>{% t faq.additional %} <a href="https://www.monerooutreach.org/how-to-buy-monero.html">How to Buy Monero (Monero Outreach)</a></p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-value">
+                    <h3><a class="anchor" href="#anchor-value"></a>{% t faq.q1 %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.a1 %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-btc-difference">
+                    <h3><a class="anchor" href="#anchor-btc-difference"></a>{% t faq.q7 %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.a7 %}</p>
                     </div>
                 </div>
                 <div class="tab" id="anchor-different">
@@ -135,10 +154,24 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.additional %} <a href="{{ site.baseurl }}/resources/about/">{% t titles.about %}</a></p>
                     </div>
                 </div>
-                <div class="tab" id="anchor-btc-difference">
-                    <h3><a class="anchor" href="#anchor-btc-difference"></a>{% t faq.q7 %}</h3>
+                <div class="tab" id="anchor-anonymous">
+                    <h3><a class="anchor" href="#anchor-anonymous"></a>{% t faq.q14 %}</h3>
                     <div class="tab-answer">
-                        <p>{% t faq.a7 %}</p>
+                        <p>{% t faq.a14 %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-magic">
+                    <h3><a class="anchor" href="#anchor-magic"></a>{% t faq.q13 %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.a13 %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="hardforks">
+                    <h3><a class="anchor" href="#monero-meaning"></a>{% t faq.qhf %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.ahf %}</p>
+                        <p>{% t faq.ahf1 %}</p>
+                        <p>{% t faq.additional %} <a href="{{ site.baseurl_root }}/2020/09/01/note-scheduled-upgrades.html">A note on scheduled protocol upgrades</a></p>
                     </div>
                 </div>
                 <div class="tab" id="asic-resistance">
@@ -155,23 +188,17 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.a11 %}</p>
                     </div>
                 </div>
-                <div class="tab" id="anchor-magic">
-                    <h3><a class="anchor" href="#anchor-magic"></a>{% t faq.q13 %}</h3>
+                <div class="tab" id="anchor-word">
+                    <h3><a class="anchor" href="#anchor-word"></a>{% t faq.qword %}</h3>
                     <div class="tab-answer">
-                        <p>{% t faq.a13 %}</p>
+                        <p>{% t faq.aword %} <a href="{{ site.baseurl }}/resources/moneropedia/">Moneropedia</a>. {% t faq.aword1 %}
+                        </p>
                     </div>
                 </div>
-                <div class="tab" id="anchor-anonymous">
-                    <h3><a class="anchor" href="#anchor-anonymous"></a>{% t faq.q14 %}</h3>
+                <div class="tab" id="monero-meaning">
+                    <h3><a class="anchor" href="#monero-meaning"></a>{% t faq.qmoneromeaning %}</h3>
                     <div class="tab-answer">
-                        <p>{% t faq.a14 %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="vulnerabilities">
-                    <h3><a class="anchor" href="#vulnerabilities"></a>{% t faq.qvuln %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.avuln %}</p>
-                        <p>{% t faq.additional %} <a href="https://open.spotify.com/episode/77xsCeuy02Aztv0bgs3Drt?si=hyIGHD5TQjyV44b46fkhoQ&dl_branch=1">{% t faq.vulnspotify %}</a></p>
+                        <p>{% t faq.amoneromeaning %}</p>
                     </div>
                 </div>
                 <div class="tab" id="antivirus">
@@ -182,36 +209,22 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.additional %} <a href="{{ site.baseurl }}/resources/user-guides/verification-windows-beginner.html">{% t user-guides.verify-windows %}</a>, <a href="{{ site.baseurl }}/resources/user-guides/verification-allos-advanced.html">{% t user-guides.verify-allos %}</a></p>
                     </div>
                 </div>
-                <div class="tab" id="monero-meaning">
-                    <h3><a class="anchor" href="#monero-meaning"></a>{% t faq.qmoneromeaning %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.amoneromeaning %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="hardforks">
-                    <h3><a class="anchor" href="#monero-meaning"></a>{% t faq.qhf %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.ahf %}</p>
-                        <p>{% t faq.ahf1 %}</p>
-                        <p>{% t faq.additional %} <a href="{{ site.baseurl_root }}/2020/09/01/note-scheduled-upgrades.html">A note on scheduled protocol upgrades</a></p>
-                    </div>
-                </div>
-                <div class="tab" id="videos">
-                    <h3><a class="anchor" href="#videos"></a>{% t faq.qvideos %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.avideos %}</p>
-                        <ol>
-                            <li><a href="{{ site.baseurl_root }}/media/Monero_Promo.m4v">{% t faq.video_intro %}</a> ({% t faq.aavailable %} <a href="{{ site.baseurl_root }}/media/ru/Monero_Promo.m4v">Russian</a> {% t faq.and %} <a href="{{ site.baseurl_root }}/media/pt-br/Monero_Promo.m4v">Brazilian Portuguese</a>)</li>
-                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20The%20Essentials.m4v">{% t faq.video_essentials %}</a></li>
-                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20Stealth%20Addresses.m4v">{% t faq.video_sa %}</a> - {% t faq.mvideos %} @Stealth-Addresses</li>
-                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20Ring%20Signatures.m4v">{% t faq.video_ringsig %}</a> - {% t faq.mvideos %} @Ring-Signatures</li>
-                            <li><a href="{{ site.baseurl_root }}/media/Monero%20-%20RingCT.m4v">{% t faq.video_ringct %}</a> - {% t faq.mvideos %} @RingCT</li>
-                        </ol>
-                    </div>
-                </div>
                 <div class="row center-xs">
                     <!-- 'Advanced' section-->
                     <div class="col"><h2>{% t faq.advanced %}</h2></div>
+                </div>
+                <div class="tab" id="import-blockchain">
+                    <h3><a class="anchor" href="#import-blockchain"></a>{% t faq.qimporting %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.aimporting %}</p>
+                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/downloads/#blockchain">{% t downloads.blockchain %}</a></p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-block-limit">
+                    <h3><a class="anchor" href="#anchor-block-limit"></a>{% t faq.q8 %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.a8 %}</p>
+                    </div>
                 </div>
                 <div class="tab" id="anchor-thin-air">
                     <h3><a class="anchor" href="#anchor-thin-air"></a>{% t faq.q12 %}</h3>
@@ -222,29 +235,10 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.additional %} <a href="{{ site.baseurl_root }}/2020/01/17/auditability.html">About supply auditability</a></p>
                     </div>
                 </div>
-                <div class="tab" id="anchor-light-normal">
-                    <h3><a class="anchor" href="#anchor-light-normal"></a>{% t faq.q6 %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.a6 %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-block-limit">
-                    <h3><a class="anchor" href="#anchor-block-limit"></a>{% t faq.q8 %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.a8 %}</p>
-                    </div>
-                </div>
                 <div class="tab" id="anchor-mixing">
                     <h3><a class="anchor" href="#anchor-mixing"></a>{% t faq.q15 %}</h3>
                     <div class="tab-answer">
                         <p>{% t faq.a15 %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="import-blockchain">
-                    <h3><a class="anchor" href="#import-blockchain"></a>{% t faq.qimporting %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.aimporting %}</p>
-                         <p>{% t faq.additional %} <a href="{{ site.baseurl }}/downloads/#blockchain">{% t downloads.blockchain %}</a></p>
                     </div>
                 </div>
                 <div class="tab" id="max-supply">
@@ -253,15 +247,40 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.amaxsupply %}</p>
                     </div>
                 </div>
+                <div class="tab" id="anchor-light-normal">
+                    <h3><a class="anchor" href="#anchor-light-normal"></a>{% t faq.q6 %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.a6 %}</p>
+                    </div>
+                </div>
                 <div class="row center-xs">
                     <!-- 'Node and Wallet' section-->
                     <div class="col"><h2>{% t faq.nodeandwallet %}</h2></div>
                 </div>
-                <div class="tab" id="anchor-wallet">
-                    <h3><a class="anchor" href="#anchor-wallet"></a>{% t faq.qwallet %}</h3>
+                <div class="tab" id="anchor-avoid-bc">
+                    <h3><a class="anchor" href="#anchor-avoid-bc"></a>{% t faq.qavoidbc %}</h3>
                     <div class="tab-answer">
-                        <p>{% t faq.awallet %}</p>
-                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/downloads">{% t titles.downloads %}</a></p>
+                        <p>{% t faq.aavoidbc %}</p>
+                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/resources/user-guides/remote_node_gui.html">{% t user-guides.remote-node-gui %}</a></p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-block-size">
+                    <h3><a class="anchor" href="#anchor-block-size"></a>{% t faq.qblocksize %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.ablocksize %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-tor-node">
+                    <h3><a class="anchor" href="#anchor-tor-node"></a>{% t faq.qnodetor %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.anodetor %}</p>
+                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/resources/user-guides/tor_wallet.html">{% t user-guides.tor_wallet %}</a></p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-full-pruned">
+                    <h3><a class="anchor" href="#anchor-full-pruned"></a>{% t faq.qfullpruned %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.afullpruned %}</p>
                     </div>
                 </div>
                 <div class="tab" id="anchor-lost-funds">
@@ -276,50 +295,6 @@ permalink: /get-started/faq/index.html
                         <p>{% t faq.alongtimemove %}</p>
                     </div>
                 </div>
-                <div class="tab" id="anchor-tor-node">
-                    <h3><a class="anchor" href="#anchor-tor-node"></a>{% t faq.qnodetor %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.anodetor %}</p>
-                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/resources/user-guides/tor_wallet.html">{% t user-guides.tor_wallet %}</a></p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-long-sync">
-                    <h3><a class="anchor" href="#anchor-long-sync"></a>{% t faq.q5 %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.a5 %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-full-pruned">
-                    <h3><a class="anchor" href="#anchor-full-pruned"></a>{% t faq.qfullpruned %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.afullpruned %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-block-size">
-                    <h3><a class="anchor" href="#anchor-block-size"></a>{% t faq.qblocksize %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.ablocksize %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-block-space">
-                    <h3><a class="anchor" href="#anchor-block-space"></a>{% t faq.qblockspace %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.ablockspace %}</p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-avoid-bc">
-                    <h3><a class="anchor" href="#anchor-avoid-bc"></a>{% t faq.qavoidbc %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.aavoidbc %}</p>
-                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/resources/user-guides/remote_node_gui.html">{% t user-guides.remote-node-gui %}</a></p>
-                    </div>
-                </div>
-                <div class="tab" id="anchor-scanned-wallet">
-                    <h3><a class="anchor" href="#anchor-scanned-wallet"></a>{% t faq.qscanned %}</h3>
-                    <div class="tab-answer">
-                        <p>{% t faq.ascanned %}</p>
-                    </div>
-                </div>
                 <div class="tab" id="anchor-danger-node">
                     <h3><a class="anchor" href="#anchor-danger-node"></a>{% t faq.qdangernode %}</h3>
                     <div class="tab-answer">
@@ -330,6 +305,31 @@ permalink: /get-started/faq/index.html
                     <h3><a class="anchor" href="#anchor-danger-rnode"></a>{% t faq.qdangerrnode %}</h3>
                     <div class="tab-answer">
                         <p>{% t faq.adangerrnode %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-wallet">
+                    <h3><a class="anchor" href="#anchor-wallet"></a>{% t faq.qwallet %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.awallet %}</p>
+                        <p>{% t faq.additional %} <a href="{{ site.baseurl }}/downloads">{% t titles.downloads %}</a></p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-block-space">
+                    <h3><a class="anchor" href="#anchor-block-space"></a>{% t faq.qblockspace %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.ablockspace %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-long-sync">
+                    <h3><a class="anchor" href="#anchor-long-sync"></a>{% t faq.q5 %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.a5 %}</p>
+                    </div>
+                </div>
+                <div class="tab" id="anchor-scanned-wallet">
+                    <h3><a class="anchor" href="#anchor-scanned-wallet"></a>{% t faq.qscanned %}</h3>
+                    <div class="tab-answer">
+                        <p>{% t faq.ascanned %}</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The FAQ in the [get started](https://www.getmonero.org/get-started/faq/) tab is not in alphabetical order, so i made a [script](https://github.com/plowsof/userguide-drafts/blob/main/helper-scripts/add-a-faq/faq_alphabetic_order.py) to do that.

This would also be useful my other 'add a simple faq' automated [script](https://github.com/plowsof/userguide-drafts/blob/main/helper-scripts/add-a-faq/add_a_faq.py) that adds the new q/a in alphabetical order too.
