### PR TITLE
Workflows: userguide index alphabetic test

### DIFF
--- a/.github/alphabetic-userguide.py
+++ b/.github/alphabetic-userguide.py
@@ -1,0 +1,42 @@
+from bs4 import BeautifulSoup
+import yaml 
+import sys
+
+en_yaml = "_i18n/en.yml"
+index = "resources/user-guides/index.md"
+
+with open(en_yaml, 'r') as stream:
+    data_loaded = yaml.safe_load(stream)
+with open(index, "r") as f:
+    soup = BeautifulSoup(f, "html.parser")
+
+divs = soup.find_all("div", {"class": "col"})
+data = {}
+for div in divs:
+    category = str(div.find("h2"))
+    category = category.split(".")[1].split(" ")[0]
+    data[category] = []
+    items = div.find_all("p")
+    for raw_html in items:
+        title_key = raw_html.text.split(".")[1].split(" ")[0]
+        title_yaml = data_loaded["user-guides"][title_key]
+        info = { 
+                    "title_key": title_key,
+                    "title_yaml": title_yaml,
+                    "raw_data": raw_html
+                }
+        data[category].append(info)
+
+success = 1
+for category in data:
+    original = data[category]
+    alphabetic = sorted(data[category], key=lambda d: d['title_yaml']) 
+    data[category] = alphabetic
+    if original == alphabetic:
+        print(f"--> Category: {category} [ OK ]")
+    else:
+        print(f"--> Category: {category} [ FAIL ]")
+        success = 0
+
+if success == 0:
+    sys.exit(1)

--- a/.github/workflows/alphabetic-userguide.yaml
+++ b/.github/workflows/alphabetic-userguide.yaml
@@ -1,0 +1,22 @@
+---
+name: User-guides alphabetic ordering
+on:
+  push:
+    paths:
+      - 'resources/user-guides/index.md'
+  pull_request:
+    paths:
+      - 'resources/user-guides/index.md'
+jobs:
+  alphabetic-order:
+    name: User-guides alphabetic ordering
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends python3-pip
+          sudo pip install beautifulsoup4 PyYAML
+      - name: Alphabetic-order script
+        run: |
+          python3 .github/alphabetic-userguide.py


### PR DESCRIPTION
Test will fail on push/pr of the user-guide index page if its not in alphabetic order / succeed if it is. will help repo maintainer with #1967 . (there is an easy-guide.py script to help with creating a guide / auto alphabetic ordering too, not in this PR) 

help for reviewer : im new to workflows so 'the names for jobs' may be wrong / vague 

To test, a PR can be made to [this repo](https://github.com/plowsof/userguide-drafts/blob/main/resources/user-guides/index.md) where the same script is being used (the index is currently in alphabetic order) 