### PR TITLE
fix: remove last item on 'General change recommendations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A few random points of note:
 - After [a discussion](https://repo.getmonero.org/monero-project/monero-site/issues/982), the community decided to include only open source wallets in the 'Downloads' section of the website. Requests to add closed source wallets to that page will be rejected.
 - Adding and removing exchanges from the 'Merchants & Exchanges' page is at our discretion.
 - All external links must have `https://` in front of them or they will not redirect properly.
-- If you want to add a new page to the navigation, you should go to ALL LANGUAGES in the `_data/lang` folder and add the page.
 
 ### Tor
 


### PR DESCRIPTION
There is no more `_data/lang` folder (although it existed when the removed line was added to the REAME - see https://github.com/monero-project/monero-site/tree/325ceecd3293ea04edf891ef3e655878d85249fa/_data/lang).