### PR TITLE
Added 8 to make example more clear

### DIFF
--- a/_i18n/en/resources/moneropedia/address.md
+++ b/_i18n/en/resources/moneropedia/address.md
@@ -7,7 +7,7 @@ summary: "either an alias, such as donate.getmonero.org, or a set of 95 characte
 
 ### The Basics
 
-When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4'. The Monero donation address, for instance, is 888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H.
+When you send Monero to someone you only need one piece of information, and that is their Monero address. A *raw* Monero address is a set of 95 characters starting with a '4' or an '8'. The Monero donation address, for instance, is 888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H.
 
 Because those addresses are long and complex, you will often encounter an @OpenAlias address instead. For example, Monero donations can be sent to donate@getmonero.org or donate.getmonero.org.
 


### PR DESCRIPTION
Some exchanges have 8 to start their wallets: Binance, Bitfinex, KuCoinhave wallet adresses starting with digit '8'.

And the monero donate address starts with an 8, so saying they start with 4 might be confusing as alphatomcat said.

Closes #1947