### PR TITLE
edit get_transfer_by_txid description

### DIFF
--- a/resources/developer-guides/wallet-rpc.md
+++ b/resources/developer-guides/wallet-rpc.md
@@ -1889,13 +1889,15 @@ Outputs:
 * *transfer* - JSON object containing payment information:
   * *address* - string; Address that transferred the funds. Base58 representation of the public keys.
   * *amount* - unsigned int; Amount of this transfer.
+  * *amounts* - list; Individual amounts if multiple where received.
   * *confirmations* - unsigned int; Number of block mined since the block containing this transaction (or block height at which the transaction should be added to a block if not yet confirmed).
-  * *destinations* - array of JSON objects containing transfer destinations:
+  * *destinations* - array of JSON objects containing transfer destinations: (only for outgoing transactions)
     * *amount* - unsigned int; Amount transferred to this destination.
     * *address* - string; Address for this destination. Base58 representation of the public keys.
   * *double_spend_seen* - boolean; True if the key image(s) for the transfer have been seen before.
   * *fee* - unsigned int; Transaction fee for this transfer.
   * *height* - unsigned int; Height of the first block that confirmed this transfer.
+  * *locked* - boolean;
   * *note* - string; Note about this transfer.
   * *payment_id* - string; Payment ID for this transfer.
   * *subaddr_index* - JSON object containing the major & minor subaddress index:
@@ -1906,41 +1908,152 @@ Outputs:
   * *txid* - string; Transaction ID of this transfer (same as input TXID).
   * *type* - string; Type of transfer, one of the following: "in", "out", "pending", "failed", "pool"
   * *unlock_time* - unsigned int; Number of blocks until transfer is safely spendable.
+* *transfers* - list; If the list length is > 1 then multiple outputs where received in this transaction, each of which has its own `transfer` JSON object.
 
-Example:
+In the example below, a single output was received at 1 address (note how it is duplicated in `transfers`:
 
 ```
-$ curl http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfer_by_txid","params":{"txid":"c36258a276018c3a4bc1f195a7fb530f50cd63a4fa765fb7c6f7f49fc051762a"}}' -H 'Content-Type: application/json'
+$ curl http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfer_by_txid","params":{"txid":"765f7124d01bd2eb2d4e7e59aa44a28c24339a41e4009f463955b087017b0ca3"}}' -H 'Content-Type: application/json'
 {
   "id": "0",
   "jsonrpc": "2.0",
   "result": {
     "transfer": {
-      "address": "55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt",
-      "amount": 300000000000,
-      "confirmations": 1,
-      "destinations": [{
-        "address": "7BnERTpvL5MbCLtj5n9No7J5oE5hHiB3tVCK5cjSvCsYWD2WRJLFuWeKTLiXo5QJqt2ZwUaLy2Vh1Ad51K7FNgqcHgjW85o",
-        "amount": 100000000000
-      },{
-        "address": "77Vx9cs1VPicFndSVgYUvTdLCJEZw9h81hXLMYsjBCXSJfUehLa9TDW3Ffh45SQa7xb6dUs18mpNxfUhQGqfwXPSMrvKhVp",
-        "amount": 200000000000
-      }],
+      "address": "53zii2WaqQwZU4oUsCUcrHgaSv2CrUGCSFJLdQnkLPyH7ZLPYHjtoHhi14dqjF6jywNRknYLwbate2eGv8TuZcS7GuR7wMY",
+      "amount": 100000000000,
+      "amounts": [100000000000],
+      "confirmations": 19,
       "double_spend_seen": false,
-      "fee": 21650200000,
-      "height": 153624,
+      "fee": 53840000,
+      "height": 1140109,
+      "locked": false,
       "note": "",
       "payment_id": "0000000000000000",
       "subaddr_index": {
         "major": 0,
         "minor": 0
       },
+      "subaddr_indices": [{
+        "major": 0,
+        "minor": 0
+      }],
       "suggested_confirmations_threshold": 1,
-      "timestamp": 1535918400,
-      "txid": "c36258a276018c3a4bc1f195a7fb530f50cd63a4fa765fb7c6f7f49fc051762a",
-      "type": "out",
+      "timestamp": 1658360753,
+      "txid": "765f7124d01bd2eb2d4e7e59aa44a28c24339a41e4009f463955b087017b0ca3",
+      "type": "in",
       "unlock_time": 0
-    }
+    },
+    "transfers": [{
+      "address": "53zii2WaqQwZU4oUsCUcrHgaSv2CrUGCSFJLdQnkLPyH7ZLPYHjtoHhi14dqjF6jywNRknYLwbate2eGv8TuZcS7GuR7wMY",
+      "amount": 100000000000,
+      "amounts": [100000000000],
+      "confirmations": 19,
+      "double_spend_seen": false,
+      "fee": 53840000,
+      "height": 1140109,
+      "locked": false,
+      "note": "",
+      "payment_id": "0000000000000000",
+      "subaddr_index": {
+        "major": 0,
+        "minor": 0
+      },
+      "subaddr_indices": [{
+        "major": 0,
+        "minor": 0
+      }],
+      "suggested_confirmations_threshold": 1,
+      "timestamp": 1658360753,
+      "txid": "765f7124d01bd2eb2d4e7e59aa44a28c24339a41e4009f463955b087017b0ca3",
+      "type": "in",
+      "unlock_time": 0
+    }]
+  }
+}
+```
+
+In the example below, 2 outputs where sent to 2 addresses in the same transaction. Note that `transfer` contains only one of them, but `transfers` contains both. If the length of transfers is != 1 then we have received multiple outputs in one transaction and must loop the `transfers` list accordingly.
+
+```
+$ curl http://localhost:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfer_by_txid","params":{"txid":"fb3a28d268ed21aa61dab0c0aec84bb9261b2b5ddc531124fc38422d86d2ded3"}}' -H 'Content-Type: application/json'
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "transfer": {
+      "address": "737i9TiWFvwPxabBEEi7gqGCirrSRmMxMapEbumEG4XiTtNj7aYA2fX4WafyJNi7CuVvhUtBkuN2Nb2bAohrvu4P7jkcTBb",
+      "amount": 100000000000,
+      "amounts": [100000000000],
+      "confirmations": 28,
+      "double_spend_seen": false,
+      "fee": 74860000,
+      "height": 1140111,
+      "locked": false,
+      "note": "",
+      "payment_id": "0000000000000000",
+      "subaddr_index": {
+        "major": 0,
+        "minor": 1
+      },
+      "subaddr_indices": [{
+        "major": 0,
+        "minor": 1
+      }],
+      "suggested_confirmations_threshold": 1,
+      "timestamp": 1658360798,
+      "txid": "fb3a28d268ed21aa61dab0c0aec84bb9261b2b5ddc531124fc38422d86d2ded3",
+      "type": "in",
+      "unlock_time": 0
+    },
+    "transfers": [{
+      "address": "737i9TiWFvwPxabBEEi7gqGCirrSRmMxMapEbumEG4XiTtNj7aYA2fX4WafyJNi7CuVvhUtBkuN2Nb2bAohrvu4P7jkcTBb",
+      "amount": 100000000000,
+      "amounts": [100000000000],
+      "confirmations": 28,
+      "double_spend_seen": false,
+      "fee": 74860000,
+      "height": 1140111,
+      "locked": false,
+      "note": "",
+      "payment_id": "0000000000000000",
+      "subaddr_index": {
+        "major": 0,
+        "minor": 1
+      },
+      "subaddr_indices": [{
+        "major": 0,
+        "minor": 1
+      }],
+      "suggested_confirmations_threshold": 1,
+      "timestamp": 1658360798,
+      "txid": "fb3a28d268ed21aa61dab0c0aec84bb9261b2b5ddc531124fc38422d86d2ded3",
+      "type": "in",
+      "unlock_time": 0
+    },{
+      "address": "77XVaxe4xY1RTxBt1xCuUHEtkiMYd38uABPoP2y2cgsVeZLUbhDFYxnc1abiC25o4N4BnzbNvqPPSfKWzjbu4tnoPXyXgs8",
+      "amount": 200000000000,
+      "amounts": [200000000000],
+      "confirmations": 28,
+      "double_spend_seen": false,
+      "fee": 74860000,
+      "height": 1140111,
+      "locked": false,
+      "note": "",
+      "payment_id": "0000000000000000",
+      "subaddr_index": {
+        "major": 0,
+        "minor": 2
+      },
+      "subaddr_indices": [{
+        "major": 0,
+        "minor": 2
+      }],
+      "suggested_confirmations_threshold": 1,
+      "timestamp": 1658360798,
+      "txid": "fb3a28d268ed21aa61dab0c0aec84bb9261b2b5ddc531124fc38422d86d2ded3",
+      "type": "in",
+      "unlock_time": 0
+    }]
   }
 }
 ```


### PR DESCRIPTION
https://github.com/monero-project/monero/issues/5611

added `(outgoing transactions only)` next to destinations as per https://github.com/monero-project/monero/issues/5992#issuecomment-552457929