### PR TITLE
remove Cake wallet

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -242,12 +242,6 @@ permalink: /downloads/index.html
                             <th>{% t downloads.sourcecode %}</th>
                         </tr>
                         <tr>
-                            <td><img class="small" src="/img/cakewallet.png" width="172" height="202" loading="lazy" alt="Cake Wallet Logo"><a href="https://cakewallet.com/">Cake Wallet</a></td>
-                            <td><span class="icon-android"></span><span class="icon-apple"></span></td>
-                            <td>X</td>
-                            <td><a class="ext-noicon" href="https://github.com/cake-tech/cake_wallet" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
-                        </tr>
-                        <tr>
                             <td><img class="small" src="/img/feather.png" width="100" height="100" loading="lazy" alt="Feather logo"><a href="https://featherwallet.org/">Feather</a></td>
                             <td>X</td>
                             <td><span class="icon-linux"></span><span class="icon-windows"></span><span class="icon-apple"></span></td>
@@ -286,7 +280,6 @@ permalink: /downloads/index.html
                             <h3>{% t downloads.localsync %}</h3>
                             <p>{% t downloads.localsyncinfo %}</p>
                             <ul>
-                                <li><a class="ext-noicon" href="https://cakewallet.io" aria-label="GitHub icon" target="_blank"><img class="mob" style="width: 50px" src="/img/cakewallet.png" width="172" height="202" loading="lazy" alt="Cake Wallet Logo">Cake Wallet</a></li>
                                 <li><a class="ext-noicon" href="https://featherwallet.org/" aria-label="Feather icon" target="_blank"><img class="mob" src="/img/feather.png" width="100" height="100" loading="lazy" alt="Feather Logo">Feather</a></li>
                                 <li><a class="ext-noicon" href="https://monerujo.io" aria-label="GitHub icon" target="_blank"><img class="mob" src="/img/Monerujo-wallet.png" width="100" height="100" loading="lazy" alt="Monerujo Logo">Monerujo</a></li>
                             </ul>


### PR DESCRIPTION
This is a principled removal, on the grounds that the Cake wallet people
are squatting the monero.com domain to push a version of Cake wallet
they call the "monero.com" wallet.

When called out, representatives of Cake wallet claimed that is is not
squatting, despite the fact $project.com is the most canonical domain
name possible for a project, and that they are trustworthy, therefore
it's fine for them to have that domain (they're a company, the bottom
line is what counts, and even if the current owners do believe this,
any buyers would turn against us without a second thought). Moreover,
they had the audacity to claim I did not complain early enough, as if
I was suposed to be keeping track of who owned monero themed domains.
Last, they claim that they do mention on the website that it is not
the official monero domain. While true, close to nobody reads the web
page footer, and they know it full well.

The intent seems glaringly obvious: to dishonestly cause visitors to
get their software by making it seem, at least for those people who
do not look really hard, that they are the monero project.

Being a company which considers its bottom line, not earning the money
they expected to get from this unethical move is likely the only thing
that will get them to reconsider any further similar moves, and their
wallet being removed from the monero site will help with this.

AFAIK the previous owner of monero.com was some building company, and
their registration predated our project, so there was no possible
confusion on the part of visitors.

Having worked for the Monero project for YEARS of my life, I feel pretty
aggrieved by this dishonesty, and thus I am registering my protest
by this patch, which I acknowledge has little change of being merged,
since practicalities will likely outweigh ethics. However, I tend to
weigh ethics more than practicalities, hence my work on monero for
all these years since pretty much its inception.