### PR TITLE
downloads: hide remote sync section until wallets upgrade to v16

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -260,6 +260,7 @@ permalink: /downloads/index.html
                             <td><a class="ext-noicon" href="https://github.com/m2049r/xmrwallet" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
                         </tr>
                         </table>
+                        <!-- 
                         <h3 class="desktop-only">{% t downloads.remotesync %}</h3>
                         <p class="desktop-only">{% t downloads.remotesyncinfo %}</p>
                         <table class="desktop-only">
@@ -282,6 +283,7 @@ permalink: /downloads/index.html
                             <td><a class="ext-noicon" href="https://github.com/EdgeApp" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
                         </tr>
                         </table>
+                        -->
                         <div class="row between-xs mob-wallets mobile-only">
                             <h3>{% t downloads.localsync %}</h3>
                             <p>{% t downloads.localsyncinfo %}</p>
@@ -290,12 +292,14 @@ permalink: /downloads/index.html
                                 <li><a class="ext-noicon" href="https://featherwallet.org/" aria-label="Feather icon" target="_blank"><img class="mob" src="/img/feather.png" width="100" height="100" loading="lazy" alt="Feather Logo">Feather</a></li>
                                 <li><a class="ext-noicon" href="https://monerujo.io" aria-label="GitHub icon" target="_blank"><img class="mob" src="/img/Monerujo-wallet.png" width="100" height="100" loading="lazy" alt="Monerujo Logo">Monerujo</a></li>
                             </ul>
+                            <!--
                             <h3>{% t downloads.remotesync %}</h3>
                             <p>{% t downloads.remotesyncinfo %}</p>
                             <ul>
                                 <li><a class="ext-noicon" href="https://mymonero.com" aria-label="GitHub icon" target="_blank"><img class="mob" src="/img/mymonero.png" width="141" height="95" loading="lazy" alt="MyMonero Logo">MyMonero</a></li>
                                 <li><a class="ext-noicon" href="https://edge.app/" aria-label="GitHub icon" target="_blank"><img class="mob" src="/img/edge-wallet.png" width="141" height="142" loading="lazy" alt="Edge Logo">Edge</a></li>
                             </ul>
+                            -->
                         </div>
             </div>
             <!-- End 'Mobile & Light Wallets' -->


### PR DESCRIPTION
Closes #2029

Edge and MyMonero haven't upgraded to the latest network version
(v16) yet. Removing them resulted in the remote sync section to
become empty, so we hide the entire section.