### PR TITLE
user guides: remove link and reference to kovri in multisig-messaging-system.md

### DIFF
--- a/_i18n/en/resources/user-guides/multisig-messaging-system.md
+++ b/_i18n/en/resources/user-guides/multisig-messaging-system.md
@@ -114,8 +114,6 @@ The MMS basically has 3 parts:
 
 The author of the MMS hopes that you will give it a try: PyBitmessage is fully open source, is under continued development, has enough users to almost assure message transport at any time, and takes privacy very seriously - just like Monero.
 
-Hopefully a future MMS will build on Monero's "native" private communication system, [Kovri](https://kovri.io/), but we are probably still quite some time away from a Kovri release ready for broad use.
-
 MMS communications should be **safe**: The Bitmessage system is considered safe as it's completely invisible who sends messages to whom, and all traffic is encrypted. For additional safety the MMS encrypts any message contents itself as well: Nobody except the receiver of an MMS message can decrypt and use its content, and the messages are signed, meaning the receiver can be sure they come from the right sender.
 
 ## The MMS User Experience


### PR DESCRIPTION
As reported by throwawayaccount12 on Matrix:

> When you go to the page https://web.getmonero.org/resources/user-guides/multisig-messaging-system.html#the-architecture-of-the-mms and click the Kovri hyperlink, it redirects to a strange site that attempts to force you to install an add-on in your browser. I am using Firefox. If you wait long enough, it will redirect you to a Russian escort page.

I initially wanted to remove only the link, but since kovri is long time gone, makes sense to remove the entire paragraph.

Note that this document probably needs a complete review, as some parts might be obsolete.