### PR TITLE
add links to p2pool block explorer

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1009,6 +1009,8 @@ tools:
   monerobase: Archive of some older meeting logs
   gateways: Payment Gateways
 
+  onion-service: Tor Onion service
+
 blog:
   allposts: All Posts
   urgent: Urgent

--- a/resources/tools/index.md
+++ b/resources/tools/index.md
@@ -22,6 +22,7 @@ permalink: /resources/tools/index.html
                         <p><a href="https://moneroblocks.info">MoneroBlocks</a></p>
                         <p><a href="https://www.exploremonero.com/">Explore Monero</a></p>
                         <p><a href="https://monerovision.com">MoneroVision</a></p>
+                        <p><a href="https://p2pool.io/explorer/">P2Pool</a> (<a href="http://yucmgsbw7nknw7oi3bkuwudvc657g2xcqahhbjyewazusyytapqo4xid.onion/explorer/">{% t tools.onion-service %}</a>)</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
All explorers listed on the page don't have Tor Onion Service (aka hidden service) available, so I added P2Pool's explorer.