### PR TITLE
update remote_node guide to include direct monero.fail

### DIFF
--- a/_i18n/en/resources/user-guides/remote_node_gui.md
+++ b/_i18n/en/resources/user-guides/remote_node_gui.md
@@ -26,7 +26,7 @@ The main menu (`Welcome to Monero` screen) will open. At the bottom left, click 
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has an actively maintained list of functioning remote nodes. 
+First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes. 
 
 ## Configuring your wallet to connect to a custom public remote node
 

--- a/_i18n/en/resources/user-guides/remote_node_gui.md
+++ b/_i18n/en/resources/user-guides/remote_node_gui.md
@@ -26,7 +26,7 @@ The main menu (`Welcome to Monero` screen) will open. At the bottom left, click 
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has an actively maintained list of functioning remote nodes. 
 
 ## Configuring your wallet to connect to a custom public remote node
 


### PR DESCRIPTION
update remote_node guide to include direct link to monero.fail . I came across someone on the reddit monero support thread having troubles because they followed this guide and used outdated information from moneroworld. For those wanting a remote node, the current most up to date list of remote nodes is found on monero.fail