### PR TITLE
localization: po/pot files for remote_node_gui guide

### DIFF
--- a/_i18n/ar/resources/user-guides/remote_node_gui.md
+++ b/_i18n/ar/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/ar/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/ar/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:28+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/de/resources/user-guides/remote_node_gui.md
+++ b/_i18n/de/resources/user-guides/remote_node_gui.md
@@ -2,46 +2,70 @@
 
 ## Den erweiterten Modus des Wallets überprüfen
 
-Um einen benutzerdefinierten Remote-Node zu nutzen, muss sich dein Wallet im erweiterten Modus befinden. Weder der einfache Modus noch der einfache Modus (Bootstrap) unterstützen diese Funktion. 
+Um einen benutzerdefinierten Remote-Node zu nutzen, muss sich dein Wallet im
+erweiterten Modus befinden. Weder der einfache Modus noch der einfache Modus
+(Bootstrap) unterstützen diese Funktion.
 
 Um zu überprüfen, ob sich dein Wallet im erweiterten Modus befindet, gehe zu `Einstellungen` > `Info` und sieh den `Wallet-Modus` ein.
 
-Sollte dein Wallet noch nicht im erweiterten Modus sein, musst du zu diesem wechseln (siehe nächster Schritt).
+Sollte dein Wallet noch nicht im erweiterten Modus sein, musst du zu diesem
+wechseln (siehe nächster Schritt).
 
-Wenn dein Wallet bereits im erweiterten Modus ist, kannst du den nächsten Schritt überspringen.
+Wenn dein Wallet bereits im erweiterten Modus ist, kannst du den nächsten
+Schritt überspringen.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## In den erweiterten Modus wechseln
 
 Wenn dein Wallet geöffnet ist, musst du es zunächst schließen. Gehe zu `Einstellungen` > `Wallet` > `Dieses Wallet schließen`.
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-Das Hauptmenü (`Willkommen bei Monero`-Maske) öffnet sich. Unten links klickst du zunächst auf den `Walletmodus ändern`-Button und wählst auf der nächsten Seite die Option `Erweiterter Modus` aus. Anschließend öffnest du deine Wallet-Datei erneut.
+Das Hauptmenü (`Willkommen bei Monero`-Maske) öffnet sich. Unten links
+klickst du zunächst auf den `Walletmodus ändern`-Button und wählst auf der
+nächsten Seite die Option `Erweiterter Modus` aus. Anschließend öffnest du
+deine Wallet-Datei erneut.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Einen öffentlichen Remote-Node finden
 
-Als Erstes musst du einen öffentlichen Remote-Node finden, zu dem du dich verbinden kannst. Einige gute Ressourcen zum Auffinden von Nodes sind auf der [moneroworld.com](https://moneroworld.com/#nodes)-Seite gelistet. Eine der einfachsten Methoden wäre es wohl, einen von Moneroworld betriebenen öffentlichen Remote-Node zu nutzen; dort gibt es aber auch ein Tool zum Aufspüren zufälliger Nodes.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Das Wallet zwecks Verbindung zu einem benutzerdefinierten Remote-Node konfigurieren
 
-Beim Öffnen deines Wallets erscheint ein Fenster mit der Option `Benutzerdefinierte Einstellungen verwenden`. Wenn du diese auswählst, wirst du über `Einstellungen` zu `Node` geleitet.
+Beim Öffnen deines Wallets erscheint ein Fenster mit der Option `Benutzerdefinierte Einstellungen verwenden`. Wenn du diese auswählst, wirst du über `Einstellungen` zu `Node` geleitet. 
 
 Wenn dieses Pop-up nicht erscheint, gehe direkt über `Einstellungen` zur `Node`-Seite.
 
-![Configure Remote Node](png/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](png/remote_node/remote_node_config.png){:width="600px"}
 
 Wähle auf dieser Seite `Remote-Node`.
 
-Bei `Adresse` trägst du die Adresse des Remote-Nodes, zu welchem du dich verbinden möchtest, ein. Diese kann in etwa wie `node.moneroworld.com` oder jedwede IP-Adresse aussehen.
+Bei `Adresse` trägst du die Adresse des Remote-Nodes, zu welchem du dich
+verbinden möchtest, ein. Diese kann in etwa wie `node.moneroworld.com` oder
+jedwede IP-Adresse aussehen.
 
-Bei `Port` trägst du den Port des Remote-Nodes ein. Wenn ein Node unter `node.moneroworld.com:18089` gelistet ist, ist die Adresse `node.moneroworld.com` und der Port ist `18089`. Der standardmäßig voreingestellte Port ist `18081`, er kann aber je nach gewähltem Node variieren. 
+Bei `Port` trägst du den Port des Remote-Nodes ein. Wenn ein Node unter
+`node.moneroworld.com:18089` gelistet ist, ist die Adresse
+`node.moneroworld.com` und der Port ist `18089`. Der standardmäßig
+voreingestellte Port ist `18081`, er kann aber je nach gewähltem Node
+variieren.
 
-Sollte dein Remote-Node einer Authentifizierung bedürfen, kannst du einen Nutzernamen in `Benutzername des Hintergrunddienstes` und ein Passwort in `Passwort des Hintergrunddienstes` eingeben.
- 
-Abschließend klickst du auf den `Verbinden`-Button und wartest darauf, dass sich dein Wallet verbindet.
+Sollte dein Remote-Node einer Authentifizierung bedürfen, kannst du einen
+Nutzernamen in `Benutzername des Hintergrunddienstes` und ein Passwort in
+`Passwort des Hintergrunddienstes` eingeben.
+
+Abschließend klickst du auf den `Verbinden`-Button und wartest darauf, dass
+sich dein Wallet verbindet.

--- a/_i18n/de/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/de/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:30+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,234 +16,155 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\" %}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
 #
-msgid "## Check if your wallet is in advanced mode"
-msgstr "## Den erweiterten Modus des Wallets überprüfen"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
+msgstr "Den erweiterten Modus des Wallets überprüfen"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
 #
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
-msgstr ""
-"Um einen benutzerdefinierten Remote-Node zu nutzen, muss sich dein Wallet im "
-"erweiterten Modus befinden. Weder der einfache Modus noch der einfache Modus "
-"(Bootstrap) unterstützen diese Funktion."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
+msgstr "Um einen benutzerdefinierten Remote-Node zu nutzen, muss sich dein Wallet im erweiterten Modus befinden. Weder der einfache Modus noch der einfache Modus (Bootstrap) unterstützen diese Funktion."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
 #
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
-msgstr ""
-"Um zu überprüfen, ob sich dein Wallet im erweiterten Modus befindet, gehe zu "
-"`Einstellungen` > `Info` und sieh den `Wallet-Modus` ein."
+#
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
+msgstr "Um zu überprüfen, ob sich dein Wallet im erweiterten Modus befindet, gehe zu `Einstellungen` > `Info` und sieh den `Wallet-Modus` ein.\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
 #
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
-msgstr ""
-"Sollte dein Wallet noch nicht im erweiterten Modus sein, musst du zu diesem "
-"wechseln (siehe nächster Schritt)."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
+msgstr "Sollte dein Wallet noch nicht im erweiterten Modus sein, musst du zu diesem wechseln (siehe nächster Schritt)."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
-msgstr ""
-"Wenn dein Wallet bereits im erweiterten Modus ist, kannst du den nächsten "
-"Schritt überspringen."
+msgstr "Wenn dein Wallet bereits im erweiterten Modus ist, kannst du den nächsten Schritt überspringen."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
 #
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
-msgstr ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
 #
-msgid "## Change your wallet to advanced mode"
-msgstr "## In den erweiterten Modus wechseln"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
+msgstr "In den erweiterten Modus wechseln"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
 #
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
-msgstr ""
-"Wenn dein Wallet geöffnet ist, musst du es zunächst schließen. Gehe zu "
-"`Einstellungen` > `Wallet` > `Dieses Wallet schließen`."
+#
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
+msgstr "Wenn dein Wallet geöffnet ist, musst du es zunächst schließen. Gehe zu `Einstellungen` > `Wallet` > `Dieses Wallet schließen`.\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
 #
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
-msgstr ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+msgstr "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
 #
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
-msgstr ""
-"Das Hauptmenü (`Willkommen bei Monero`-Maske) öffnet sich. Unten links "
-"klickst du zunächst auf den `Walletmodus ändern`-Button und wählst auf der "
-"nächsten Seite die Option `Erweiterter Modus` aus. Anschließend öffnest du "
-"deine Wallet-Datei erneut."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
+msgstr "Das Hauptmenü (`Willkommen bei Monero`-Maske) öffnet sich. Unten links klickst du zunächst auf den `Walletmodus ändern`-Button und wählst auf der nächsten Seite die Option `Erweiterter Modus` aus. Anschließend öffnest du deine Wallet-Datei erneut."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
 #
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
-msgstr ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+msgstr "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
 #
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
-msgstr ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
 #
-msgid "## Finding a public remote node"
-msgstr "## Einen öffentlichen Remote-Node finden"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
+msgstr "Einen öffentlichen Remote-Node finden"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
 #
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
-msgstr ""
-"Als Erstes musst du einen öffentlichen Remote-Node finden, zu dem du dich "
-"verbinden kannst. Einige gute Ressourcen zum Auffinden von Nodes sind auf "
-"der [moneroworld.com](https://moneroworld.com/#nodes)-Seite gelistet. Eine "
-"der einfachsten Methoden wäre es wohl, einen von Moneroworld betriebenen "
-"öffentlichen Remote-Node zu nutzen; dort gibt es aber auch ein Tool zum "
-"Aufspüren zufälliger Nodes."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+#, fuzzy
+#| msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too."
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr "Als Erstes musst du einen öffentlichen Remote-Node finden, zu dem du dich verbinden kannst. Einige gute Ressourcen zum Auffinden von Nodes sind auf der [moneroworld.com](https://moneroworld.com/#nodes)-Seite gelistet. Eine der einfachsten Methoden wäre es wohl, einen von Moneroworld betriebenen öffentlichen Remote-Node zu nutzen; dort gibt es aber auch ein Tool zum Aufspüren zufälliger Nodes."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
 #
-msgid "## Configuring your wallet to connect to a custom public remote node"
-msgstr ""
-"## Das Wallet zwecks Verbindung zu einem benutzerdefinierten Remote-Node "
-"konfigurieren"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
+msgstr "Das Wallet zwecks Verbindung zu einem benutzerdefinierten Remote-Node konfigurieren"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
 #
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-"Beim Öffnen deines Wallets erscheint ein Fenster mit der Option "
-"`Benutzerdefinierte Einstellungen verwenden`. Wenn du diese auswählst, wirst "
-"du über `Einstellungen` zu `Node` geleitet."
+#
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
+msgstr "Beim Öffnen deines Wallets erscheint ein Fenster mit der Option `Benutzerdefinierte Einstellungen verwenden`. Wenn du diese auswählst, wirst du über `Einstellungen` zu `Node` geleitet. \n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
 #
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-"Wenn dieses Pop-up nicht erscheint, gehe direkt über `Einstellungen` zur "
-"`Node`-Seite."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
+msgstr "Wenn dieses Pop-up nicht erscheint, gehe direkt über `Einstellungen` zur `Node`-Seite.\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
 #
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-"![Configure Remote "
-"Node](png/remote_node/remote_node_config.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
+msgstr "![Configure Remote Node](png/remote_node/remote_node_config.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr "Wähle auf dieser Seite `Remote-Node`."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
 #
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
-msgstr ""
-"Bei `Adresse` trägst du die Adresse des Remote-Nodes, zu welchem du dich "
-"verbinden möchtest, ein. Diese kann in etwa wie `node.moneroworld.com` oder "
-"jedwede IP-Adresse aussehen."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
+msgstr "Bei `Adresse` trägst du die Adresse des Remote-Nodes, zu welchem du dich verbinden möchtest, ein. Diese kann in etwa wie `node.moneroworld.com` oder jedwede IP-Adresse aussehen."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
 #
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
-msgstr ""
-"Bei `Port` trägst du den Port des Remote-Nodes ein. Wenn ein Node unter "
-"`node.moneroworld.com:18089` gelistet ist, ist die Adresse "
-"`node.moneroworld.com` und der Port ist `18089`. Der standardmäßig "
-"voreingestellte Port ist `18081`, er kann aber je nach gewähltem Node "
-"variieren."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
+msgstr "Bei `Port` trägst du den Port des Remote-Nodes ein. Wenn ein Node unter `node.moneroworld.com:18089` gelistet ist, ist die Adresse `node.moneroworld.com` und der Port ist `18089`. Der standardmäßig voreingestellte Port ist `18081`, er kann aber je nach gewähltem Node variieren."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
 #
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
-msgstr ""
-"Sollte dein Remote-Node einer Authentifizierung bedürfen, kannst du einen "
-"Nutzernamen in `Benutzername des Hintergrunddienstes` und ein Passwort in "
-"`Passwort des Hintergrunddienstes` eingeben."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
+msgstr "Sollte dein Remote-Node einer Authentifizierung bedürfen, kannst du einen Nutzernamen in `Benutzername des Hintergrunddienstes` und ein Passwort in `Passwort des Hintergrunddienstes` eingeben."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
-msgstr ""
-"Abschließend klickst du auf den `Verbinden`-Button und wartest darauf, dass "
-"sich dein Wallet verbindet."
+msgstr "Abschließend klickst du auf den `Verbinden`-Button und wartest darauf, dass sich dein Wallet verbindet."

--- a/_i18n/en/resources/user-guides/remote_node_gui.md
+++ b/_i18n/en/resources/user-guides/remote_node_gui.md
@@ -4,7 +4,7 @@
 
 To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
 If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
 

--- a/_i18n/en/resources/user-guides/weblate/remote_node_gui.pot
+++ b/_i18n/en/resources/user-guides/weblate/remote_node_gui.pot
@@ -3,172 +3,159 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:29+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
+#, markdown-text
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, markdown-text, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+#, markdown-text
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, markdown-text, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+#, markdown-text
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
+#, markdown-text
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+#, markdown-text
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, markdown-text, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, markdown-text, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+#, markdown-text
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+#, markdown-text
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+#, markdown-text
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+#, markdown-text
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, markdown-text, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+#, markdown-text
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, markdown-text, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, markdown-text, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, markdown-text, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+#, markdown-text
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
+#, markdown-text
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+#, markdown-text
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+#, markdown-text
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+#, markdown-text
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
+#, markdown-text
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/es/resources/user-guides/remote_node_gui.md
+++ b/_i18n/es/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/es/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/es/resources/user-guides/weblate/remote_node_gui.po
@@ -20,103 +20,108 @@ msgstr ""
 "X-Generator: Weblate 4.8\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
+<<<<<<< HEAD
 #: _i18n/en/resources/user-guides/remote_node_gui.md:28
 msgid "## Finding a public remote node"
 msgstr "## Encontrando un nodo remoto público"
+=======
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
+msgstr ""
+>>>>>>> 6ebd58f2 (localization: po/pot files for remote_node_gui guide)
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 "Primero, necesitarás encontrar un nodo remoto público al cual conectar. El "
 "sitio web [moneroworld.com](https://moneroworld.com/#nodes) contiene algunos "
@@ -125,61 +130,33 @@ msgstr ""
 "tienen una herramienta para encontrar nodos aleatorios."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 "## Configurando tu monedero para conectar a un nodo remoto público "
 "personalizado"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/fr/resources/user-guides/remote_node_gui.md
+++ b/_i18n/fr/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/fr/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/fr/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:28+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/it/resources/user-guides/remote_node_gui.md
+++ b/_i18n/it/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/it/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/it/resources/user-guides/weblate/remote_node_gui.po
@@ -20,159 +20,130 @@ msgstr ""
 "X-Generator: Weblate 4.8\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/nb-no/resources/user-guides/remote_node_gui.md
+++ b/_i18n/nb-no/resources/user-guides/remote_node_gui.md
@@ -2,46 +2,67 @@
 
 ## Sjekk om lommeboken din er i avansert modus
 
-For å bruke en tilpasset ekstern node, må lommeboken din være i avansert modus. Enkel modus og Enkel modus (oppstartmodus) støtter ikke denne funksjonen.
+For å bruke en tilpasset ekstern node, må lommeboken din være i avansert
+modus. Enkel modus og Enkel modus (oppstartmodus) støtter ikke denne
+funksjonen.
 
-For å sjekke om lommeboken din er i avansert modus, kan du gå til `Innstillinger` > `Informasjon` og se `Lommebokmodus`. 
+For å sjekke om lommeboken din er i avansert modus, kan du gå til `Innstillinger` > `Informasjon` og se `Lommebokmodus`.
 
-Hvis lommeboken din ikke er i avansert modus, må du endre den til avansert modus (se neste steg).
+Hvis lommeboken din ikke er i avansert modus, må du endre den til avansert
+modus (se neste steg).
 
-Hvis lommeboken din allerede er i avansert modus, kan du hoppe over neste steg.
+Hvis lommeboken din allerede er i avansert modus, kan du hoppe over neste
+steg.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Endre lommeboken din til avansert modus
 
 Hvis lommeboken din er åpen, må du først lukke den. Gå til `Innstillinger` > `Lommebok` > `Lukk denne lommeboken`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-Hovedmenyen (`Velkommen til Monero`-skjermen) vil åpnes. Nederst til venstre kan du trykke på `Endre lommebokmodus`-knappen, og på neste side velge `Avansert modus`. Etter det åpner du lommebokfilen din igjen.
+Hovedmenyen (`Velkommen til Monero`-skjermen) vil åpnes. Nederst til venstre
+kan du trykke på `Endre lommebokmodus`-knappen, og på neste side velge
+`Avansert modus`. Etter det åpner du lommebokfilen din igjen.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Å finne en offentlig, ekstern node
 
-Først må du finne en offentlig, ekstern node å koble til. Nettsiden [moneroworld.com](https://moneroworld.com/#nodes) har noen flotte ressurser for å finne noder. Én av de letteste metodene er å bruke offentlige noder som kjøres av moneroworld, men de har også et verktøy for å finne tilfeldige noder.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Å konfigurere lommeboken din til å koble til en tilpasset, offentlig ekstern node
 
-Når du åpner lommeboken din, dukker en popup opp med alternativet `Bruk tilpassede innstillinger`. Trykk på den, så blir du videresendt til siden `Innstilliger` > `Node`. 
+Når du åpner lommeboken din, dukker en popup opp med alternativet `Bruk tilpassede innstillinger`. Trykk på den, så blir du videresendt til siden `Innstilliger` > `Node`.
 
 Hvis du ikke ser denne popupen, kan du gå til siden `Innstillinger` > `Node`.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 På denne siden velger du `Ekstern node`.
 
-Under `Adresse` bør du fylle inn adressen til den eksterne noden som du vil koble til. Denne adressen ser kanskje ut som `node.moneroworld.com` eller så ser den ut som en hvilken som helst IP-adresse. 
+Under `Adresse` bør du fylle inn adressen til den eksterne noden som du vil
+koble til. Denne adressen ser kanskje ut som `node.moneroworld.com` eller så
+ser den ut som en hvilken som helst IP-adresse.
 
-Under `Port` bør du fylle inn porten til den eksterne noden. Hvis en ekstern node er oppført som `node.moneroworld.com:18089`, er adressen `node.moneroworld.com` og porten er `18089`. Standardporten er `18081`, men den kan variere avhengig av noden du er koblet til.
+Under `Port` bør du fylle inn porten til den eksterne noden. Hvis en ekstern
+node er oppført som `node.moneroworld.com:18089`, er adressen
+`node.moneroworld.com` og porten er `18089`. Standardporten er `18081`, men
+den kan variere avhengig av noden du er koblet til.
 
-Hvis din eksterne node krever autentisering, kan du legge inn et brukernavn i `Daemon-brukernavn` og et passord i `Daemon-passord`.
+Hvis din eksterne node krever autentisering, kan du legge inn et brukernavn
+i `Daemon-brukernavn` og et passord i `Daemon-passord`.
 
-Avslutningsvis kan du trykke på `Koble til`-knappen og vente på at lommeboken din kobler seg til.
+Avslutningsvis kan du trykke på `Koble til`-knappen og vente på at
+lommeboken din kobler seg til.

--- a/_i18n/nb-no/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/nb-no/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:30+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,230 +16,152 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr "{% include disclaimer.html translated=\"yes\" translationOutdated=\"no\" %}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
 #
-msgid "## Check if your wallet is in advanced mode"
-msgstr "## Sjekk om lommeboken din er i avansert modus"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
+msgstr "Sjekk om lommeboken din er i avansert modus"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
 #
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
-msgstr ""
-"For å bruke en tilpasset ekstern node, må lommeboken din være i avansert "
-"modus. Enkel modus og Enkel modus (oppstartmodus) støtter ikke denne "
-"funksjonen."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
+msgstr "For å bruke en tilpasset ekstern node, må lommeboken din være i avansert modus. Enkel modus og Enkel modus (oppstartmodus) støtter ikke denne funksjonen."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
 #
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
-msgstr ""
-"For å sjekke om lommeboken din er i avansert modus, kan du gå til "
-"`Innstillinger` > `Informasjon` og se `Lommebokmodus`."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
+msgstr "For å sjekke om lommeboken din er i avansert modus, kan du gå til `Innstillinger` > `Informasjon` og se `Lommebokmodus`.\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
 #
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
-msgstr ""
-"Hvis lommeboken din ikke er i avansert modus, må du endre den til avansert "
-"modus (se neste steg)."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
+msgstr "Hvis lommeboken din ikke er i avansert modus, må du endre den til avansert modus (se neste steg)."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
-msgstr ""
-"Hvis lommeboken din allerede er i avansert modus, kan du hoppe over neste "
-"steg."
+msgstr "Hvis lommeboken din allerede er i avansert modus, kan du hoppe over neste steg."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
 #
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
-msgstr ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
 #
-msgid "## Change your wallet to advanced mode"
-msgstr "## Endre lommeboken din til avansert modus"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
+msgstr "Endre lommeboken din til avansert modus"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
 #
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
-msgstr ""
-"Hvis lommeboken din er åpen, må du først lukke den. Gå til `Innstillinger` > "
-"`Lommebok` > `Lukk denne lommeboken`"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
+msgstr "Hvis lommeboken din er åpen, må du først lukke den. Gå til `Innstillinger` > `Lommebok` > `Lukk denne lommeboken`\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
 #
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
-msgstr ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+msgstr "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
 #
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
-msgstr ""
-"Hovedmenyen (`Velkommen til Monero`-skjermen) vil åpnes. Nederst til venstre "
-"kan du trykke på `Endre lommebokmodus`-knappen, og på neste side velge "
-"`Avansert modus`. Etter det åpner du lommebokfilen din igjen."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
+msgstr "Hovedmenyen (`Velkommen til Monero`-skjermen) vil åpnes. Nederst til venstre kan du trykke på `Endre lommebokmodus`-knappen, og på neste side velge `Avansert modus`. Etter det åpner du lommebokfilen din igjen."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
 #
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
-msgstr ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+msgstr "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
 #
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
-msgstr ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
 #
-msgid "## Finding a public remote node"
-msgstr "## Å finne en offentlig, ekstern node"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
+msgstr "Å finne en offentlig, ekstern node"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
 #
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
-msgstr ""
-"Først må du finne en offentlig, ekstern node å koble til. Nettsiden "
-"[moneroworld.com](https://moneroworld.com/#nodes) har noen flotte ressurser "
-"for å finne noder. Én av de letteste metodene er å bruke offentlige noder "
-"som kjøres av moneroworld, men de har også et verktøy for å finne tilfeldige "
-"noder."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+#, fuzzy
+#| msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too."
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr "Først må du finne en offentlig, ekstern node å koble til. Nettsiden [moneroworld.com](https://moneroworld.com/#nodes) har noen flotte ressurser for å finne noder. Én av de letteste metodene er å bruke offentlige noder som kjøres av moneroworld, men de har også et verktøy for å finne tilfeldige noder."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
 #
-msgid "## Configuring your wallet to connect to a custom public remote node"
-msgstr ""
-"## Å konfigurere lommeboken din til å koble til en tilpasset, offentlig "
-"ekstern node"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
+msgstr "Å konfigurere lommeboken din til å koble til en tilpasset, offentlig ekstern node"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
 #
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-"Når du åpner lommeboken din, dukker en popup opp med alternativet `Bruk "
-"tilpassede innstillinger`. Trykk på den, så blir du videresendt til siden "
-"`Innstilliger` > `Node`."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
+msgstr "Når du åpner lommeboken din, dukker en popup opp med alternativet `Bruk tilpassede innstillinger`. Trykk på den, så blir du videresendt til siden `Innstilliger` > `Node`.\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
 #
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-"Hvis du ikke ser denne popupen, kan du gå til siden `Innstillinger` > "
-"`Node`."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
+msgstr "Hvis du ikke ser denne popupen, kan du gå til siden `Innstillinger` > `Node`.\n"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
 #
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
+msgstr "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr "På denne siden velger du `Ekstern node`."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
 #
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
-msgstr ""
-"Under `Adresse` bør du fylle inn adressen til den eksterne noden som du vil "
-"koble til. Denne adressen ser kanskje ut som `node.moneroworld.com` eller så "
-"ser den ut som en hvilken som helst IP-adresse."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
+msgstr "Under `Adresse` bør du fylle inn adressen til den eksterne noden som du vil koble til. Denne adressen ser kanskje ut som `node.moneroworld.com` eller så ser den ut som en hvilken som helst IP-adresse."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
 #
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
-msgstr ""
-"Under `Port` bør du fylle inn porten til den eksterne noden. Hvis en ekstern "
-"node er oppført som `node.moneroworld.com:18089`, er adressen "
-"`node.moneroworld.com` og porten er `18089`. Standardporten er `18081`, men "
-"den kan variere avhengig av noden du er koblet til."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
+msgstr "Under `Port` bør du fylle inn porten til den eksterne noden. Hvis en ekstern node er oppført som `node.moneroworld.com:18089`, er adressen `node.moneroworld.com` og porten er `18089`. Standardporten er `18081`, men den kan variere avhengig av noden du er koblet til."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
 #
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
-msgstr ""
-"Hvis din eksterne node krever autentisering, kan du legge inn et brukernavn "
-"i `Daemon-brukernavn` og et passord i `Daemon-passord`."
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
+msgstr "Hvis din eksterne node krever autentisering, kan du legge inn et brukernavn i `Daemon-brukernavn` og et passord i `Daemon-passord`."
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
 #
+#. type: Plain text
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
-msgstr ""
-"Avslutningsvis kan du trykke på `Koble til`-knappen og vente på at "
-"lommeboken din kobler seg til."
+msgstr "Avslutningsvis kan du trykke på `Koble til`-knappen og vente på at lommeboken din kobler seg til."

--- a/_i18n/nl/resources/user-guides/remote_node_gui.md
+++ b/_i18n/nl/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/nl/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/nl/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:28+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/pl/resources/user-guides/remote_node_gui.md
+++ b/_i18n/pl/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/pl/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/pl/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:28+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/pt-br/resources/user-guides/remote_node_gui.md
+++ b/_i18n/pt-br/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/pt-br/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/pt-br/resources/user-guides/weblate/remote_node_gui.po
@@ -20,159 +20,130 @@ msgstr ""
 "X-Generator: Weblate 4.8\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/ru/resources/user-guides/remote_node_gui.md
+++ b/_i18n/ru/resources/user-guides/remote_node_gui.md
@@ -1,47 +1,70 @@
-{% include disclaimer.html translated="no" translationOutdated="no" %}
+{% include disclaimer.html translated="yes" translationOutdated="no" %}
 
-## Check if your wallet is in advanced mode
+## Убедитесь в том, что ваш кошелёк работает в продвинутом режиме
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+Чтобы использовать специализированный удалённый узел, ваш кошелек должен
+находиться в продвинутом режиме. Простой режим (Simple mode) и Простой режим
+с использованием узла начальной загрузки (bootstrap) не поддерживают эту
+возможность.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+Чтобы проверить, работает ли ваш кошелёк в продвинутом режиме, зайдите в `Настройки ` > `Информация` и проверьте `Режим кошелька`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+Если ваш кошелёк не находится в продвинутом режиме, вам нужно будет изменить
+его (см. следующий шаг).
 
-If your wallet is already in Advanced mode, you can skip the next step.
+Если ваш кошелёк уже работает в продвинутом режиме, вы можете пропустить
+следующий шаг.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Режим
+кошелька](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
-## Change your wallet to advanced mode
+## Переключение вашего кошелька в продвинутый режим
 
-If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
+Если ваш кошелёк открыт, вам нужно сначала закрыть его. Чтобы сделать это, перейдите в `Настройки` > `Кошёлек` > `Закрыть текущий кошелек`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Закрыть текущий
+кошелек](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+Откроется главное меню: экран `Добро пожаловать в Monero`. В левом нижнем
+углу нажмите кнопку `Изменить режим кошелька`, а на следующей странице
+выберите `Расширенный режим`. Затем снова откройте файл кошелька.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Изменить режим
+кошелька](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Продвинутый
+режим](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
-## Finding a public remote node
+## Поиск публичного удаленного узла
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
-## Configuring your wallet to connect to a custom public remote node
+## Настройка вашего кошелька перед подключением к пубчичному удаленному узлу
 
-When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. 
+При открытии вашего кошелька появится всплывающее окно с опцией `Использовать собственные настройки`. Нажмите на него, и вы будете перенаправлены на страницу `Настройки` > `Узел`.
 
-If you don't see this pop up, go to `Settings` > `Node` page.
+Если вы не видите этого всплывающего окна, то перейдите на страницу `Настройки` > `Узел`.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Настройка удаленного
+узла](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
-On this page select `Remote Node`.
+На этой странице выберите `Удаленный узел`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+В поле `Адрес` следует ввести адрес удалённого узла, к которому вы хотите
+подключиться. Этот адрес может выглядеть, как `node.moneroworld.com`, или
+же, как любой IP-адрес.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+В поле `Порт` следует указать номер порта удалённого узла. Если удалённый
+узел будет указан, как `node.moneroworld.com:18089`, адресом будет
+`node.moneroworld.com`, а номером порта - `18089`. По умолчанию номер порта
+указывается, как `18089`, но он может варьироваться в зависимости от узла, к
+которому вы пытаетесь подключиться.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+Если ваш удаленный узел требует аутентификации, вы можете ввести имя
+пользователя в поле `Имя пользователя демона` и пароль в `Пароль демона`.
 
-Finally, click on `Connect` button and wait for your wallet to connect.
+Наконец, нажмите кнопку `Подключиться` и дождитесь, пока ваш кошелёк не
+подсоединится к удалённому узлу.

--- a/_i18n/ru/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/ru/resources/user-guides/weblate/remote_node_gui.po
@@ -7,222 +7,143 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:29+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: 2021-08-09 10:31+0000\n"
 "Last-Translator: v1docq47 <chiptune@protonmail.ch>\n"
-"Language-Team: Russian <https://translate.getmonero.org/projects/"
-"getmonero-user-guides/remote_node_gui/ru/>\n"
+"Language-Team: Russian <https://translate.getmonero.org/projects/getmonero-user-guides/remote_node_gui/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5.3\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
-msgstr ""
-"{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
+msgstr "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
+msgstr "Убедитесь в том, что ваш кошелёк работает в продвинутом режиме"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
-msgstr "## Убедитесь в том, что ваш кошелёк работает в продвинутом режиме"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
+msgstr "Чтобы использовать специализированный удалённый узел, ваш кошелек должен находиться в продвинутом режиме. Простой режим (Simple mode) и Простой режим с использованием узла начальной загрузки (bootstrap) не поддерживают эту возможность."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
-msgstr ""
-"Чтобы использовать специализированный удалённый узел, ваш кошелек должен "
-"находиться в продвинутом режиме. Простой режим (Simple mode) и Простой режим "
-"с использованием узла начальной загрузки (bootstrap) не поддерживают эту "
-"возможность."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
+msgstr "Чтобы проверить, работает ли ваш кошелёк в продвинутом режиме, зайдите в `Настройки ` > `Информация` и проверьте `Режим кошелька`.\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
-msgstr ""
-"Чтобы проверить, работает ли ваш кошелёк в продвинутом режиме, зайдите в `"
-"Настройки ` > `Информация` и проверьте `Режим кошелька`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
+msgstr "Если ваш кошелёк не находится в продвинутом режиме, вам нужно будет изменить его (см. следующий шаг)."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
-msgstr ""
-"Если ваш кошелёк не находится в продвинутом режиме, вам нужно будет изменить "
-"его (см. следующий шаг)."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
-msgstr ""
-"Если ваш кошелёк уже работает в продвинутом режиме, вы можете пропустить "
-"следующий шаг."
+msgstr "Если ваш кошелёк уже работает в продвинутом режиме, вы можете пропустить следующий шаг."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
-msgstr ""
-"![Режим кошелька](/img/resources/user-guides/en/remote_node/wallet_mode_info."
-"png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr "![Режим кошелька](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
+msgstr "Переключение вашего кошелька в продвинутый режим"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
-msgstr "## Переключение вашего кошелька в продвинутый режим"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
+msgstr "Если ваш кошелёк открыт, вам нужно сначала закрыть его. Чтобы сделать это, перейдите в `Настройки` > `Кошёлек` > `Закрыть текущий кошелек`\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
-msgstr ""
-"Если ваш кошелёк открыт, вам нужно сначала закрыть его. Чтобы сделать это, "
-"перейдите в `Настройки` > `Кошёлек` > `Закрыть текущий кошелек`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+msgstr "![Закрыть текущий кошелек](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
-msgstr ""
-"![Закрыть текущий кошелек](/img/resources/user-guides/en/remote_node/"
-"close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
+msgstr "Откроется главное меню: экран `Добро пожаловать в Monero`. В левом нижнем углу нажмите кнопку `Изменить режим кошелька`, а на следующей странице выберите `Расширенный режим`. Затем снова откройте файл кошелька."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
-msgstr ""
-"Откроется главное меню: экран `Добро пожаловать в Monero`. В левом нижнем "
-"углу нажмите кнопку `Изменить режим кошелька`, а на следующей странице "
-"выберите `Расширенный режим`. Затем снова откройте файл кошелька."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+msgstr "![Изменить режим кошелька](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
-msgstr ""
-"![Изменить режим кошелька](/img/resources/user-guides/en/remote_node/"
-"change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr "![Продвинутый режим](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
+msgstr "Поиск публичного удаленного узла"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
-msgstr ""
-"![Продвинутый режим](/img/resources/user-guides/en/remote_node/advanced_mode."
-"png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+#, fuzzy
+#| msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too."
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr "Сначала нужно найти публичный удалённый узел, к которому можно подключиться. На веб-сайте [moneroworld.com](https://moneroworld.com/#nodes) размещена подробная информация, касающаяся того, как находить публичные узлы. Одним из самых простых способов является использование удалённого узла, поддерживаемого сервисом moneroworld, но и у них также есть инструмент, позволяющий находить случайные узлы."
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
+msgstr "Настройка вашего кошелька перед подключением к пубчичному удаленному узлу"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
-msgstr "## Поиск публичного удаленного узла"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
+msgstr "При открытии вашего кошелька появится всплывающее окно с опцией `Использовать собственные настройки`. Нажмите на него, и вы будете перенаправлены на страницу `Настройки` > `Узел`.\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
-msgstr ""
-"Сначала нужно найти публичный удалённый узел, к которому можно подключиться. "
-"На веб-сайте [moneroworld.com](https://moneroworld.com/#nodes) размещена "
-"подробная информация, касающаяся того, как находить публичные узлы. Одним из "
-"самых простых способов является использование удалённого узла, "
-"поддерживаемого сервисом moneroworld, но и у них также есть инструмент, "
-"позволяющий находить случайные узлы."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
+msgstr "Если вы не видите этого всплывающего окна, то перейдите на страницу `Настройки` > `Узел`.\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
-msgstr ""
-"## Настройка вашего кошелька перед подключением к пубчичному удаленному узлу"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
+msgstr "![Настройка удаленного узла](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-"При открытии вашего кошелька появится всплывающее окно с опцией `"
-"Использовать собственные настройки`. Нажмите на него, и вы будете "
-"перенаправлены на страницу `Настройки` > `Узел`."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-"Если вы не видите этого всплывающего окна, то перейдите на страницу "
-"`Настройки` > `Узел`."
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-"![Настройка удаленного узла](/img/resources/user-guides/en/remote_node/"
-"remote_node_config.png){:width=\"600px\"}"
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr "На этой странице выберите `Удаленный узел`."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
-msgstr ""
-"В поле `Адрес` следует ввести адрес удалённого узла, к которому вы хотите "
-"подключиться. Этот адрес может выглядеть, как `node.moneroworld.com`, или "
-"же, как любой IP-адрес."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
+msgstr "В поле `Адрес` следует ввести адрес удалённого узла, к которому вы хотите подключиться. Этот адрес может выглядеть, как `node.moneroworld.com`, или же, как любой IP-адрес."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
-msgstr ""
-"В поле `Порт` следует указать номер порта удалённого узла. Если удалённый "
-"узел будет указан, как `node.moneroworld.com:18089`, адресом будет `node."
-"moneroworld.com`, а номером порта - `18089`. По умолчанию номер порта "
-"указывается, как `18089`, но он может варьироваться в зависимости от узла, к "
-"которому вы пытаетесь подключиться."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
+msgstr "В поле `Порт` следует указать номер порта удалённого узла. Если удалённый узел будет указан, как `node.moneroworld.com:18089`, адресом будет `node.moneroworld.com`, а номером порта - `18089`. По умолчанию номер порта указывается, как `18089`, но он может варьироваться в зависимости от узла, к которому вы пытаетесь подключиться."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
-msgstr ""
-"Если ваш удаленный узел требует аутентификации, вы можете ввести имя "
-"пользователя в поле `Имя пользователя демона` и пароль в `Пароль демона`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
+msgstr "Если ваш удаленный узел требует аутентификации, вы можете ввести имя пользователя в поле `Имя пользователя демона` и пароль в `Пароль демона`."
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
-msgstr ""
-"Наконец, нажмите кнопку `Подключиться` и дождитесь, пока ваш кошелёк не "
-"подсоединится к удалённому узлу."
+msgstr "Наконец, нажмите кнопку `Подключиться` и дождитесь, пока ваш кошелёк не подсоединится к удалённому узлу."

--- a/_i18n/tr/resources/user-guides/remote_node_gui.md
+++ b/_i18n/tr/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/tr/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/tr/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:29+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/zh-cn/resources/user-guides/remote_node_gui.md
+++ b/_i18n/zh-cn/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/zh-cn/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/zh-cn/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:30+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/_i18n/zh-tw/resources/user-guides/remote_node_gui.md
+++ b/_i18n/zh-tw/resources/user-guides/remote_node_gui.md
@@ -2,31 +2,42 @@
 
 ## Check if your wallet is in advanced mode
 
-To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature.
+To use a custom remote node, your wallet must be in advanced mode. Simple
+mode and Simple mode (bootstrap) don't support this feature.
 
-To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`. 
+To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.
 
-If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step).
+If your wallet is not in Advanced mode, you will have to change it to
+Advanced mode (see next step).
 
 If your wallet is already in Advanced mode, you can skip the next step.
 
-![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
+![Wallet
+mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width="600px"}
 
 ## Change your wallet to advanced mode
 
 If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`
 
-![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
+![Close
+Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width="600px"}
 
-The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again.
+The main menu (`Welcome to Monero` screen) will open. At the bottom left,
+click on `Change wallet mode` button, and on the next page select `Advanced
+mode`. Next, open your wallet file again.
 
-![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
+![Change Wallet
+Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width="600px"}
 
-![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
+![Advanced
+Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width="600px"}
 
 ## Finding a public remote node
 
-First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources for finding nodes. One of the easiest methods would be to use a public remote node run by moneroworld, but they have a tool for finding random nodes too.
+First, you will need to find a public remote node to connect to. The website
+[moneroworld.com](https://moneroworld.com/#nodes) has some great resources
+about remote nodes, and the website [monero.fail](https://monero.fail) has
+a list of functioning remote nodes.
 
 ## Configuring your wallet to connect to a custom public remote node
 
@@ -34,14 +45,21 @@ When opening your wallet, a pop up will appear with the option `Use custom setti
 
 If you don't see this pop up, go to `Settings` > `Node` page.
 
-![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
+![Configure Remote
+Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width="600px"}
 
 On this page select `Remote Node`.
 
-In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address. 
+In `Address` you should fill the address of the remote node that you want to
+connect to. This address might look like `node.moneroworld.com` or it could
+look like any IP address.
 
-In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to.
+In `Port` you should fill the port of the remote node. If a remote node is
+listed as `node.moneroworld.com:18089`, the address is
+`node.moneroworld.com` and the port is `18089`. The default port is `18081`,
+but it can vary depending on the node you are connecting to.
 
-If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`.
+If your remote node requires authentication, you can enter a username in
+`Daemon username` and a password in `Daemon password`.
 
 Finally, click on `Connect` button and wait for your wallet to connect.

--- a/_i18n/zh-tw/resources/user-guides/weblate/remote_node_gui.po
+++ b/_i18n/zh-tw/resources/user-guides/weblate/remote_node_gui.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-28 11:30+0200\n"
+"POT-Creation-Date: 2022-11-20 16:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,158 +17,129 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:2
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:2
 msgid "{% include disclaimer.html translated=\"no\" translationOutdated=\"no\" %}"
 msgstr ""
 
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:4
-msgid "## Check if your wallet is in advanced mode"
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:3
+#, no-wrap
+msgid "Check if your wallet is in advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:6
-msgid ""
-"To use a custom remote node, your wallet must be in advanced mode. Simple "
-"mode and Simple mode (bootstrap) don't support this feature."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:6
+msgid "To use a custom remote node, your wallet must be in advanced mode. Simple mode and Simple mode (bootstrap) don't support this feature."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:8
-msgid ""
-"To check if your wallet is in advanced mode, go to `Settings` > `Info` and "
-"see `Wallet mode`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:8
+#, no-wrap
+msgid "To check if your wallet is in advanced mode, go to `Settings` > `Info` and see `Wallet mode`.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:10
-msgid ""
-"If your wallet is not in Advanced mode, you will have to change it to "
-"Advanced mode (see next step)."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:10
+msgid "If your wallet is not in Advanced mode, you will have to change it to Advanced mode (see next step)."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:12
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:12
 msgid "If your wallet is already in Advanced mode, you can skip the next step."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:14
-msgid ""
-"![Wallet "
-"mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:14
+msgid "![Wallet mode](/img/resources/user-guides/en/remote_node/wallet_mode_info.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:15
+#, no-wrap
+msgid "Change your wallet to advanced mode"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:16
-msgid "## Change your wallet to advanced mode"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:18
+#, no-wrap
+msgid "If your wallet is open, you need to close it first. Go to `Settings` > `Wallet` > `Close this wallet`\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:18
-msgid ""
-"If your wallet is open, you need to close it first. Go to `Settings` > "
-"`Wallet` > `Close this wallet`"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:20
+msgid "![Close Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:20
-msgid ""
-"![Close "
-"Wallet](/img/resources/user-guides/en/remote_node/close_open_wallet.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:22
+msgid "The main menu (`Welcome to Monero` screen) will open. At the bottom left, click on `Change wallet mode` button, and on the next page select `Advanced mode`. Next, open your wallet file again."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:22
-msgid ""
-"The main menu (`Welcome to Monero` screen) will open. At the bottom left, "
-"click on `Change wallet mode` button, and on the next page select `Advanced "
-"mode`. Next, open your wallet file again."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:24
+msgid "![Change Wallet Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:24
-msgid ""
-"![Change Wallet "
-"Mode](/img/resources/user-guides/en/remote_node/change_wallet_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:26
+msgid "![Advanced Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:27
+#, no-wrap
+msgid "Finding a public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:26
-msgid ""
-"![Advanced "
-"Mode](/img/resources/user-guides/en/remote_node/advanced_mode.png){:width=\"600px\"}"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:30
+msgid "First, you will need to find a public remote node to connect to. The website [moneroworld.com](https://moneroworld.com/#nodes) has some great resources about remote nodes, and the website [monero.fail](https://monero.fail) has a list of functioning remote nodes."
+msgstr ""
+
+#. type: Title ##
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:31
+#, no-wrap
+msgid "Configuring your wallet to connect to a custom public remote node"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:28
-msgid "## Finding a public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:34
+#, no-wrap
+msgid "When opening your wallet, a pop up will appear with the option `Use custom settings`. Click on it, and you will be sent to `Settings` > `Node` page. \n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:30
-msgid ""
-"First, you will need to find a public remote node to connect to. The website "
-"[moneroworld.com](https://moneroworld.com/#nodes) has some great resources "
-"for finding nodes. One of the easiest methods would be to use a public "
-"remote node run by moneroworld, but they have a tool for finding random "
-"nodes too."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:36
+#, no-wrap
+msgid "If you don't see this pop up, go to `Settings` > `Node` page.\n"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:32
-msgid "## Configuring your wallet to connect to a custom public remote node"
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:38
+msgid "![Configure Remote Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:34
-msgid ""
-"When opening your wallet, a pop up will appear with the option `Use custom "
-"settings`. Click on it, and you will be sent to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:36
-msgid "If you don't see this pop up, go to `Settings` > `Node` page."
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:38
-msgid ""
-"![Configure Remote "
-"Node](/img/resources/user-guides/en/remote_node/remote_node_config.png){:width=\"600px\"}"
-msgstr ""
-
-#. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:40
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:40
 msgid "On this page select `Remote Node`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:42
-msgid ""
-"In `Address` you should fill the address of the remote node that you want to "
-"connect to. This address might look like `node.moneroworld.com` or it could "
-"look like any IP address."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:42
+msgid "In `Address` you should fill the address of the remote node that you want to connect to. This address might look like `node.moneroworld.com` or it could look like any IP address."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:44
-msgid ""
-"In `Port` you should fill the port of the remote node. If a remote node is "
-"listed as `node.moneroworld.com:18089`, the address is "
-"`node.moneroworld.com` and the port is `18089`. The default port is `18081`, "
-"but it can vary depending on the node you are connecting to."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:44
+msgid "In `Port` you should fill the port of the remote node. If a remote node is listed as `node.moneroworld.com:18089`, the address is `node.moneroworld.com` and the port is `18089`. The default port is `18081`, but it can vary depending on the node you are connecting to."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:46
-msgid ""
-"If your remote node requires authentication, you can enter a username in "
-"`Daemon username` and a password in `Daemon password`."
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:46
+msgid "If your remote node requires authentication, you can enter a username in `Daemon username` and a password in `Daemon password`."
 msgstr ""
 
 #. type: Plain text
-#: _i18n/en/resources/user-guides/remote_node_gui.md:47
+#: ../_i18n/en/resources/user-guides/remote_node_gui.md:47
 msgid "Finally, click on `Connect` button and wait for your wallet to connect."
 msgstr ""

--- a/po/user-guides/remote_node_gui.config
+++ b/po/user-guides/remote_node_gui.config
@@ -1,0 +1,13 @@
+[po4a_langs] es it pl fr ar ru de nl pt-br tr zh-cn zh-tw nb-no
+[po4a_paths] ../_i18n/en/resources/user-guides/weblate/remote_node_gui.pot $lang:../_i18n/$lang/resources/user-guides/weblate/remote_node_gui.po
+
+[options] opt:"--keep=0"
+[options] opt:"--localized-charset=UTF-8"
+[options] opt:"--master-charset=UTF-8"
+[options] opt:"--master-language=en_US"
+[options] opt:"--msgmerge-opt='--no-wrap'"
+[options] opt:"--wrap-po=newlines"
+
+[po4a_alias:markdown] text opt:"--option markdown"
+
+[type: markdown] ../_i18n/en/resources/user-guides/remote_node_gui.md $lang:../_i18n/$lang/resources/user-guides/remote_node_gui.md


### PR DESCRIPTION
Removed whitespace at the end of one in ctrl+f: " \`wallet mode\`. " (appeared to be messing with some string replace) - allowed us to pull in (new) ru translations and not break the norwegian ones.

set 'is translated' to yes on the Russian page.
po4a version 0.68 