### PR TITLE
research-lab: Fix link to original whitepaper

### DIFF
--- a/resources/research-lab/index.md
+++ b/resources/research-lab/index.md
@@ -180,7 +180,7 @@ permalink: /resources/research-lab/index.html
                         <div class="col">
                             <h2>{% t research-lab.cryptonote %}</h2>
                             <div class="whitepaper">
-                                <a href="https://cryptonote.org/whitepaper.pdf">{% t research-lab.cryptonote-whitepaper %}</a>
+                                <a href="https://web.archive.org/web/20201028121818/https://cryptonote.org/whitepaper.pdf">{% t research-lab.cryptonote-whitepaper %}</a>
                                 <p>{% t research-lab.cryptonote-whitepaper_para %}</p>
                             </div>
                             <div class="whitepaper">


### PR DESCRIPTION
I noticed that the link to the original whitepaper was broken - https://cryptonote.org/ appears to be down.

Wikipedia's CryptoNote page uses an Internet Archive link to reference the original paper, while Monero's links to https://bytecoin.org/old/whitepaper.pdf . This patch changes link to Internet Archive, but happy to revise to use bytecoin.org 