### PR TITLE
Set anchors target for external urls to _blank

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -542,7 +542,7 @@ faq:
   alongtimemove: Don't worry, your coins are safe. To be able to spend them you only have to download and run the latest Monero software. You can use the @mnemonic-seed you previously saved to restore your wallet at any time. Note that hard forks in Monero are scheduled and non-contentious. Which means no new coin is created.
   qvuln: Are there known vulnerabilities in Monero?
   avuln: >
-    The Monero community has created a series of videos called "Breaking Monero", where potential Monero vulnerabilities are explored and discussed. There are 14 videos, with each exploring a different subject. Check out <a href="https://www.monerooutreach.org/breaking-monero/">the videos on monerooutreach.org</a>.
+    The Monero community has created a series of videos called "Breaking Monero", where potential Monero vulnerabilities are explored and discussed. There are 14 videos, with each exploring a different subject. Check out <a href="https://www.monerooutreach.org/breaking-monero/" target="_blank">the videos on monerooutreach.org</a>.
   vulnspotify: Available on Spotify as podcast
   qasicresistance: "What is ASIC resistance? Why is it important?"
   aasicresistance: ASICs are basically special computers created to do only one job, contrary to normal computers, which are made for general purpose. This characteristic makes ASICs very efficient for @mining.
@@ -576,13 +576,13 @@ mining:
   conpolcent: Too many people mining on a single pool might lead on the pool having >50% of the total hashrate, which is dangerous
   choosepol: "If you need help choosing a pool or you just want more information about them, use:"
   hardware: Hardware
-  hardwarep: Monero can be mined on both CPUs and GPUs, but the latter is much less efficient than the former. You can get an idea of how your hardware performs compared to others, using <a href="https://xmrig.com/benchmark">xmrig benchmarks page</a> (some results might be out of date).
+  hardwarep: Monero can be mined on both CPUs and GPUs, but the latter is much less efficient than the former. You can get an idea of how your hardware performs compared to others, using <a href="https://xmrig.com/benchmark" target="_blank">xmrig benchmarks page</a> (some results might be out of date).
   software: Software
   softwarep: >
     There are several options when it comes to mining software. As already said, to solo mine, the CLI or GUI wallets can be used (CPU only). If you want to mine to a pool or mine with a GPU, you'll need dedicated software. Miners supporting Monero:
   software_para: Note that some miners may have developer fees.
   support: Support
-  supportp: If you have questions or just want to confront with fellow miners, come chat on Monero Pools. On <a href="https://matrix.to/#/#monero-pools:monero.social">Matrix</a> and <a href="irc://irc.libera.chat/#monero-pools">Libera</a>.
+  supportp: If you have questions or just want to confront with fellow miners, come chat on Monero Pools. On <a href="https://matrix.to/#/#monero-pools:monero.social" target="_blank">Matrix</a> and <a href="irc://irc.libera.chat/#monero-pools">Libera</a>.
   p2poolh: "P2Pool: The best of both solo and pool mining"
   p2poolnew: >
     P2Pool is a clever new way of mining Monero, which allows miners to receive the frequent payouts offered by pools without needing to trust a centralized pool. P2Pool is a Peer-To-Peer mining pool that gives miners full control over their Monero node and what it mines. More details in <a href="/2021/10/05/p2pool-released.html">the announcement post</a>.
@@ -906,12 +906,12 @@ library:
   books: Books
   zerotomonerov2: "Zero to Monero: Second Edition"
   zerotomonerov2p: >
-    Published: 4 April 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a><br>
+    Published: 4 April 2020, with <a href="https://github.com/UkoeHB/Monero-RCT-report" target="_blank">LaTeX source code here</a><br>
     A comprehensive conceptual (and technical) explanation of Monero.<br>
     We endeavor to teach anyone who knows basic algebra and simple computer science concepts like the ‘bit representation’ of a number not only how Monero works at a deep and comprehensive level, but also how useful and beautiful cryptography can be.
   zerotomonerov1: "Zero to Monero: First Edition"
   zerotomonerov1p: >
-    Published: 26 June 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report">LaTeX source code here</a>
+    Published: 26 June 2018, with <a href="https://github.com/UkoeHB/Monero-RCT-report" target="_blank">LaTeX source code here</a>
   masteringmonerop: >
     A guide through the seemingly complex world of Monero.<br>
     It includes:

--- a/_includes/disclaimer.html
+++ b/_includes/disclaimer.html
@@ -12,7 +12,7 @@
 
 <!-- The page is not translated -->
 {% elsif include.translated == "no" %}
-    {% capture disclaimer %}{% t global.untranslated %} <a class="disclaimer-link" href="https://github.com/monero-project/monero-site/blob/master/README.md">README</a>{% endcapture %}
+    {% capture disclaimer %}{% t global.untranslated %} <a class="disclaimer-link" href="https://github.com/monero-project/monero-site/blob/master/README.md" target="_blank">README</a>{% endcapture %}
 
 {% endif %}
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,15 +26,15 @@
                         <h3>{% t navigation.community %}</h3>
                             <ul class="list-unstyled">
                                  <li><a class="white" href="{{ site.baseurl}}/community/merchants/">{% t titles.merchants %}</a></li>
-                                 <li><a class="white" href="https://monero.stackexchange.com/">Stack Exchange</a></li>
-                                 <li><a class="white" href="https://bitcointalk.org/index.php?topic=583449.0">BitcoinTalk</a></li>
+                                 <li><a class="white" href="https://monero.stackexchange.com/" target="_blank">Stack Exchange</a></li>
+                                 <li><a class="white" href="https://bitcointalk.org/index.php?topic=583449.0" target="_blank">BitcoinTalk</a></li>
                                  <li><a class="white" href="https://translate.getmonero.org/">Weblate</a></li>
                             </ul>
                     </div>
                     <div class="col-sm-3 col-xs-6">
                         <h3>{% t global.monero_project %}</h3>
                             <ul class="list-unstyled">
-                                 <li><a class="white" href="https://openalias.org/">Open Alias</a></li>
+                                 <li><a class="white" href="https://openalias.org/" target="_blank">Open Alias</a></li>
                                  <li><a class="white" href="{{ site.baseurl }}/resources/research-lab/">{% t titles.researchlab %}</a></li>
                                  <li><a class="white" href="{{ site.baseurl }}/press-kit/">{% t titles.presskit %}</a></li>
                                  <li><a class="white" href="https://ccs.getmonero.org">{% t footer.ccs %}</a></li>
@@ -45,7 +45,7 @@
                         <ul class="list-unstyled list-inline">
                             <li><a href="{% include onion.html %}" class="white footer-link"><img class="tor" src="/img/onion-tor.svg" alt="onion service">{% t tools.onion-service %}</a></li>
                              <li><a href="{{ site.baseurl }}/legal/" class="white footer-link">{% t footer.legal %}</a></li>
-                             <li><a href="https://github.com/monero-project/monero-site" class="white footer-link">{% t footer.source %}</a></li>
+                             <li><a href="https://github.com/monero-project/monero-site" target="_blank" class="white footer-link">{% t footer.source %}</a></li>
                              <li><a href="{{ site.baseurl}}/sitemap.xml" class="white footer-link">Sitemap</a></li>
                              <li><a class="white" href="{{ site.baseurl_root }}/feed.xml"><img src="/img/feed.svg" width="30" height="30" alt="Feed icon">{% t footer.feed %}</a></li>
                         </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -65,7 +65,7 @@
                  <div class="row">
                      <div class="col-xs-12">
                          <div class="text-center nav-item mob">
-                            <a href="https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md">Vulnerability Response</a>
+                            <a href="https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md" target="_blank">Vulnerability Response</a>
                          </div>
                      </div>
                  </div>
@@ -100,7 +100,7 @@
                       <div class="row end-xs middle-xs">
                          <div class="col-md-12">
                           <a href="https://ccs.getmonero.org" class="top-link">Community Crowdfunding</a>
-                          <a href="https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md" class="top-link">Vulnerability Response</a>
+                          <a href="https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md" target="_blank" class="top-link">Vulnerability Response</a>
                           <a href="https://translate.getmonero.org" class="top-link">Translate</a>
                           <div href="#" class="dropdown top-link language-change">
                             <input class="burger-checkdropdown" id="langdrop" type="checkbox" tabindex="0">

--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -16,8 +16,8 @@ meta_descr: merchants.descr
         <p>{% t merchants.use %}</p>
         <p>{% t merchants.dirdescr %}</p>
         <ul class="logo">
-          <li><a href="https://cryptwerk.com/pay-with/xmr/">cryptwerk.com</a></li>
-          <li><a href="https://www.acceptedhere.io/catalog/currency/xmr/">acceptedhere.io</a></li>
+          <li><a href="https://cryptwerk.com/pay-with/xmr/" target="_blank">cryptwerk.com</a></li>
+          <li><a href="https://www.acceptedhere.io/catalog/currency/xmr/" target="_blank">acceptedhere.io</a></li>
         </ul>
       </div>
     </div>
@@ -25,7 +25,7 @@ meta_descr: merchants.descr
       <div class="info-block">
         <h2>P2P exchanges and Atomic Swaps</h2>
         <p>{% t merchants.descrp2p %}</p>
-        <p>{% t merchants.swapsdescr %} <a href="https://unstoppableswap.net/">unstoppableswap.net</a>.</p>
+        <p>{% t merchants.swapsdescr %} <a href="https://unstoppableswap.net/" target="_blank">unstoppableswap.net</a>.</p>
       </div>
     </div>
     <div class="row">
@@ -91,19 +91,19 @@ meta_descr: merchants.descr
         <h3>CEXes</h3>
         <p>{% t merchants.cexp %}</p>
         <ul class="logo">
-            <li><a href="https://www.kraken.com/">Kraken</a> (EUR*, USD*, CAD, GBP, JPY, AUD, CHF)</li>
-            <li><a href="https://www.binance.com/trade.html?symbol=XMR_BTC">Binance</a> (USD, EUR, RUB, TRY, NGN, UAH, KZT, INR, ...)</li>
-            <li><a href="https://dvchain.co/">DV Chain (OTC)</a> (USD*, CAD*, GBP*, EUR*, JPY*, ...)</li>
-            <li><a href="https://www.bitfinex.com/">Bitfinex</a> (USD*)</li>
+            <li><a href="https://www.kraken.com/" target="_blank">Kraken</a> (EUR*, USD*, CAD, GBP, JPY, AUD, CHF)</li>
+            <li><a href="https://www.binance.com/trade.html?symbol=XMR_BTC" target="_blank">Binance</a> (USD, EUR, RUB, TRY, NGN, UAH, KZT, INR, ...)</li>
+            <li><a href="https://dvchain.co/" target="_blank">DV Chain (OTC)</a> (USD*, CAD*, GBP*, EUR*, JPY*, ...)</li>
+            <li><a href="https://www.bitfinex.com/" target="_blank">Bitfinex</a> (USD*)</li>
           </ul>
           <p>*Fiat currency to Monero trading pair (e.g. XMR/USD, XMR/EUR)</p>
         <h3>Swappers</h3>
         <p>{% t merchants.swappersp %}</p>
         <ul class="logo">
-            <li><a href="https://sideshift.ai/">Sideshift.ai</a></li>
-            <li><a href="https://simpleswap.io/">SimpleSwap</a></li>
-            <li><a href="https://changenow.io/">ChangeNow</a></li>
-            <li><a href="https://godex.io/">Godex</a></li>
+            <li><a href="https://sideshift.ai/" target="_blank">Sideshift.ai</a></li>
+            <li><a href="https://simpleswap.io/" target="_blank">SimpleSwap</a></li>
+            <li><a href="https://changenow.io/" target="_blank">ChangeNow</a></li>
+            <li><a href="https://godex.io/" target="_blank">Godex</a></li>
           </ul>
       </div>
     </div>

--- a/community/sponsorships/index.md
+++ b/community/sponsorships/index.md
@@ -85,13 +85,13 @@ meta_descr: meta_descr.sponsorships
                 <div class="info-block">
                     <h2>{% t sponsorships.pastsponsors %}</h2>
                     <ul>
-                        <li><a href="https://globee.com">Globee</a></li>
-                        <li><a href="https://www.navicat.com">Navicat</a></li>
-                        <li><a href="https://www.forked.net">Forked</a></li>
-                        <li><a href="https://www.kitware.com/">Kitware</a></li>
-                        <li><a href="https://dome9.com/">Dome9 Security</a></li>
-                        <li><a href="https://www.jetbrains.com/">JetBrains</a></li>
-                        <li><a href="https://mymonero.com/">My Monero</a></li>
+                        <li><a href="https://globee.com" target="_blank">Globee</a></li>
+                        <li><a href="https://www.navicat.com" target="_blank">Navicat</a></li>
+                        <li><a href="https://www.forked.net" target="_blank">Forked</a></li>
+                        <li><a href="https://www.kitware.com/" target="_blank">Kitware</a></li>
+                        <li><a href="https://dome9.com/" target="_blank">Dome9 Security</a></li>
+                        <li><a href="https://www.jetbrains.com/" target="_blank">JetBrains</a></li>
+                        <li><a href="https://mymonero.com/" target="_blank">My Monero</a></li>
                     </ul>
                 </div>
             </div>

--- a/community/workgroups/index.md
+++ b/community/workgroups/index.md
@@ -43,7 +43,7 @@ meta_descr: meta_descr.workgroups
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
             <li>{% t team.chat %} <code>#monero-community</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-community"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-community:monero.social?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-community"></a></li>
-            <li>{% t team.website %} <a href="https://www.communityworkgroup.org/">www.communityworkgroup.org</a></li>
+            <li>{% t team.website %} <a href="https://www.communityworkgroup.org/" target="_blank">www.communityworkgroup.org</a></li>
           </ul>
           <div class="row center-xs icons">
             <a class="ext-noicon" href="https://repo.getmonero.org/monero-project/" target="_blank" rel="noreferrer, noopener" aria-label="Gitlab logo"><div class="col social-icon gitlab"></div></a><a class="ext-noicon" href="https://www.reddit.com/r/MoneroCommunity/" target="_blank" rel="noreferrer, noopener" aria-label="Reddit logo"><div class="col social-icon reddit"></div></a>
@@ -118,7 +118,7 @@ meta_descr: meta_descr.workgroups
           <p>{% t team.outreach_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.telegram %} <a href="https://t.me/monerooutreach">monerooutreach</a></li>
+            <li>{% t team.telegram %} <a href="https://t.me/monerooutreach" target="_blank">monerooutreach</a></li>
             <li>{% t team.chat %} <code>#monero-outreach</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-outreach"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-outreach:monero.social?via=matrix.org&via=monero.social&via=haveno.network"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-outreach"></a></li>
           </ul>
           <div class="row center-xs icons">
@@ -178,7 +178,7 @@ meta_descr: meta_descr.workgroups
           <ul class="logo">
             <li>{% t team.chat %} <code>#monero-policy</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-policy"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-policy:matrix.org?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
             <li>Email: <code>policy[at]getmonero[dot]org</code></li>
-            <li>{% t team.website %} <a href="https://moneropolicy.org">moneropolicy.org</a></li>
+            <li>{% t team.website %} <a href="https://moneropolicy.org" target="_blank">moneropolicy.org</a></li>
           </ul>
         </div>
       </div>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -243,19 +243,19 @@ meta_descr: downloads.intro
                             <th>{% t downloads.sourcecode %}</th>
                         </tr>
                         <tr>
-                            <td><img class="small" src="/img/cakewallet.png" width="172" height="202" loading="lazy" alt="Cake Wallet Logo"><a href="https://cakewallet.com/">Cake Wallet</a></td>
+                            <td><img class="small" src="/img/cakewallet.png" width="172" height="202" loading="lazy" alt="Cake Wallet Logo"><a href="https://cakewallet.com/" target="_blank">Cake Wallet</a></td>
                             <td><span class="icon-android"></span><span class="icon-apple"></span></td>
                             <td><span class="icon-linux"></span><span class="icon-apple"></span></td>
                             <td><a class="ext-noicon" href="https://github.com/cake-tech/cake_wallet" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
                         </tr>
                         <tr>
-                            <td><img class="small" src="/img/feather.png" width="100" height="100" loading="lazy" alt="Feather logo"><a href="https://featherwallet.org/">Feather</a></td>
+                            <td><img class="small" src="/img/feather.png" width="100" height="100" loading="lazy" alt="Feather logo"><a href="https://featherwallet.org/" target="_blank">Feather</a></td>
                             <td>X</td>
                             <td><span class="icon-linux"></span><span class="icon-windows"></span><span class="icon-apple"></span></td>
-                            <td><a class="ext-noicon" href="https://github.com/feather-wallet/feather" aria-label="GitHub icon"><span class="icon-github"></span></a></td>
+                            <td><a class="ext-noicon" href="https://github.com/feather-wallet/feather" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
                         </tr>
                         <tr>
-                            <td><img class="small" src="/img/Monerujo-wallet.png" width="100" height="100" loading="lazy" alt="Monerujo logo"><a href="https://monerujo.io/">Monerujo</a></td>
+                            <td><img class="small" src="/img/Monerujo-wallet.png" width="100" height="100" loading="lazy" alt="Monerujo logo"><a href="https://monerujo.io/" target="_blank">Monerujo</a></td>
                             <td><span class="icon-android"></span></td>
                             <td>X</td>
                             <td><a class="ext-noicon" href="https://github.com/m2049r/xmrwallet" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
@@ -271,13 +271,13 @@ meta_descr: downloads.intro
                             <th>{% t downloads.sourcecode %}</th>
                         </tr>
                         <tr>
-                            <td><img class="small" src="/img/mymonero.png" width="141" height="95" loading="lazy" alt="Mymonero logo" style="height: 15px;"><a href="https://mymonero.com/">MyMonero</a></td>
+                            <td><img class="small" src="/img/mymonero.png" width="141" height="95" loading="lazy" alt="Mymonero logo" style="height: 15px;"><a href="https://mymonero.com/" target="_blank">MyMonero</a></td>
                             <td><span class="icon-android"></span><span class="icon-apple"></span></td>
                             <td><span title="Browser" class="icon-browser"></span><span class="icon-linux"></span><span class="icon-windows"></span><span class="icon-apple"></span></td>
                             <td><a class="ext-noicon" href="https://github.com/mymonero" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>
                         </tr>
                         <tr>
-                            <td><img class="small" src="/img/edge-wallet.png" width="141" height="142" loading="lazy" alt="Edge Logo"><a href="https://edge.app/">Edge</a></td>
+                            <td><img class="small" src="/img/edge-wallet.png" width="141" height="142" loading="lazy" alt="Edge Logo"><a href="https://edge.app/" target="_blank">Edge</a></td>
                             <td><span class="icon-android"></span><span class="icon-apple"></span></td>
                             <td>X</td>
                             <td><a class="ext-noicon" href="https://github.com/EdgeApp" aria-label="GitHub icon" target="_blank"><span class="icon-github"></span></a></td>

--- a/get-started/accepting/index.md
+++ b/get-started/accepting/index.md
@@ -17,10 +17,10 @@ meta_descr: meta_descr.accepting
             </ul>
             <h3 id="gui">{% t accepting.title_gui %}</h3>
               <p>{% t accepting.gui1 %}</p>
-              <p>{% t accepting.gui2 %} <a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md#receive-monero">{% t accepting.guilinkguide %}</a></p>
+              <p>{% t accepting.gui2 %} <a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md#receive-monero" target="_blank">{% t accepting.guilinkguide %}</a></p>
                 <img class="top-margin" src="/img/receive.png" width="980" height="800" loading="lazy" alt="receive page">
               <p>{% t accepting.guiinstructions %}</p>
-              <p>{% t accepting.guimerchant %} <a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md#merchant-view">{% t accepting.guilinkguide1 %}</a>.</p>
+              <p>{% t accepting.guimerchant %} <a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md#merchant-view" target="_blank">{% t accepting.guilinkguide1 %}</a>.</p>
                 <img class="top-margin" src="/img/merchant_page.png" width="980" height="800" loading="lazy" alt="merchant view">
               <p>{% t accepting.guimerchant1 %}</p>
               <p>{% t accepting.guisteps %}</p>
@@ -45,7 +45,7 @@ meta_descr: meta_descr.accepting
               <p><i>{% t accepting.clinotes %}</i></p>
             <h3 id="merchants">{% t accepting.merchantstitle %}</h3>
               <p>{% t accepting.merchantsreceive %} <a href="{{ site.baseurl }}/resources/developer-guides/">{% t accepting.merchdevguides %}</a>. {% t accepting.merchantsreceive1 %}</p>
-              <p>{% t accepting.merchantsint %} <a href="https://github.com/monero-integrations">{% t accepting.merchantsintlink %}</a>.</p>
+              <p>{% t accepting.merchantsint %} <a href="https://github.com/monero-integrations" target="_blank">{% t accepting.merchantsintlink %}</a>.</p>
               <p>{% t accepting.merchantsthirdp %} <a href="{{ site.baseurl }}/resources/tools/#payment-gateways">{% t accepting.merchthirdlink %}</a>. {% t accepting.merchantsthirdp1 %}</p>
           </div>
         </div>                

--- a/get-started/contributing/index.md
+++ b/get-started/contributing/index.md
@@ -26,10 +26,10 @@ meta_descr: meta_descr.contributing
                         <h3>{% t contributing.develop %}</h3>
                         <p>{% t contributing.developp %}</p>
                             <ul class="logo">
-                                <li><a href="https://github.com/monero-project/monero">{% t contributing.cli %}</a> {% t contributing.cli_p %}</li>
-                                <li><a href="https://github.com/monero-project/monero-gui">{% t contributing.gui %}</a> {% t contributing.gui_p %}</li>
-                                <li><a href="https://github.com/monero-project/monero-site">{% t contributing.website %}</a> {% t contributing.website_p %}</li>
-                                <li>{% t contributing.bug %} <a href="https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md">{% t contributing.discl %}</a></li>
+                                <li><a href="https://github.com/monero-project/monero" target="_blank">{% t contributing.cli %}</a> {% t contributing.cli_p %}</li>
+                                <li><a href="https://github.com/monero-project/monero-gui" target="_blank">{% t contributing.gui %}</a> {% t contributing.gui_p %}</li>
+                                <li><a href="https://github.com/monero-project/monero-site" target="_blank">{% t contributing.website %}</a> {% t contributing.website_p %}</li>
+                                <li>{% t contributing.bug %} <a href="https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md" target="_blank">{% t contributing.discl %}</a></li>
                             </ul>
                         <p>{% t contributing.develop_descr %} <a href="{{ site.baseurl }}/community/workgroups/">{% t contributing.develop_wg %}</a></p>
                         <h3>{% t contributing.mine %}</h3>
@@ -92,7 +92,7 @@ meta_descr: meta_descr.contributing
                         <div class="col-xs-12">
                             <h3>{% t contributing.supportdev %}</h3>
                             <p>{% t contributing.supportdev_p %}</p>
-                            <p>{% t contributing.supportdev_p2 %} <a href="https://www.openhub.net/p/monero/contributors/summary">{% t contributing.supportdev_link %}</a>.</p>
+                            <p>{% t contributing.supportdev_p2 %} <a href="https://www.openhub.net/p/monero/contributors/summary" target="_blank">{% t contributing.supportdev_link %}</a>.</p>
                         </div>
                     </div>
                     <div class="row start-xs">

--- a/get-started/faq/index.md
+++ b/get-started/faq/index.md
@@ -87,11 +87,11 @@ meta_descr: faq.intro
                     <p>{% t faq.userguides %}</p>
                 <h3><a href="{{ site.baseurl }}/resources/developer-guides/">{% t titles.developerguides %}</a></h3>
                     <p>{% t faq.devguides %}</p>
-                <h3><a href="https://monero.stackexchange.com/">StackExchange</a></h3>
+                <h3><a href="https://monero.stackexchange.com/" target="_blank">StackExchange</a></h3>
                     <p>{% t faq.stackexchange %}</p>
-                <h3><a href="https://www.reddit.com/r/monerosupport/">r/monerosupport</a></h3>
+                <h3><a href="https://www.reddit.com/r/monerosupport/" target="_blank">r/monerosupport</a></h3>
                     <p>{% t faq.monerosupport %}</p>
-                <h3><a href="https://www.monero.how/">Monero.how</a></h3>
+                <h3><a href="https://www.monero.how/" target="_blank">Monero.how</a></h3>
                     <p>{% t faq.monerohow %}</p>
             </div>
         </div>
@@ -121,7 +121,7 @@ meta_descr: faq.intro
                         <p>{% t faq.acontribute1 %} <a href="https://translate.getmonero.org">Weblate</a>.</p>
                         <p>{% t faq.acontribute2 %} <a href="{{ site.baseurl }}/community/hangouts/">Hangouts</a>.</p>
                         <p>{% t faq.acontribute3 %}</p>
-                        <p>{% t faq.acontribute4 %} <a href="https://www.monerooutreach.org/stories/getting-started-helping-monero.html">Getting started with Monero</a>.</p>
+                        <p>{% t faq.acontribute4 %} <a href="https://www.monerooutreach.org/stories/getting-started-helping-monero.html" target="_blank">Getting started with Monero</a>.</p>
                         <p>{% t faq.additional %} <a href="{{ site.baseurl }}/get-started/contributing/">{% t titles.contributing %}</a></p>
                     </div>
                 </div>

--- a/get-started/mining/index.md
+++ b/get-started/mining/index.md
@@ -44,8 +44,8 @@ meta_descr: meta_descr.mining
                         </div>
                         <p>{% t mining.choosepol %}
                         <ul>
-                            <li><a href="https://miningpoolstats.stream/monero">miningpoolstats.stream</a></li>
-                            <li><a href="https://pools.xmr.wiki">pools.xmr.wiki</a></li>
+                            <li><a href="https://miningpoolstats.stream/monero" target="_blank">miningpoolstats.stream</a></li>
+                            <li><a href="https://pools.xmr.wiki" target="_blank">pools.xmr.wiki</a></li>
                         </ul>
                         </p>
                 </div>
@@ -67,7 +67,7 @@ meta_descr: meta_descr.mining
                                 <li>{% t mining.p2pzeropayout %}</li>
                                 <li>{% t mining.p2pminpayout %}</li>
                             </ul>
-                            <p>{% t mining.p2pmoreinfo %} <a href="https://github.com/SChernykh/p2pool">github.com/SChernykh/p2pool</a></p>
+                            <p>{% t mining.p2pmoreinfo %} <a href="https://github.com/SChernykh/p2pool" target="_blank">github.com/SChernykh/p2pool</a></p>
                 </div>
             </div>
         </div>
@@ -79,8 +79,8 @@ meta_descr: meta_descr.mining
                     <h2>{% t mining.software %}</h2>
                         <p>{% t mining.softwarep %}
                         <ul>
-                            <li><a href="https://github.com/xmrig/xmrig">XMRig</a></li>
-                            <li><a href="https://cryptonote.social/tools/csminer">CSminer</a></li>
+                            <li><a href="https://github.com/xmrig/xmrig" target="_blank">XMRig</a></li>
+                            <li><a href="https://cryptonote.social/tools/csminer" target="_blank">CSminer</a></li>
                         </ul>
                         {% t mining.software_para %}
                         </p>

--- a/library/index.md
+++ b/library/index.md
@@ -17,7 +17,7 @@ meta_descr: library.description
                     <p>{% t library.zerotomonerov2p %}</p>
                 <h3><a href="Zero-to-Monero-1-0-0.pdf">{% t library.zerotomonerov1 %}</a></h3>
                     <p>{% t library.zerotomonerov1p %}</p>
-                <h3><a href="https://masteringmonero.com/free-download.html">Mastering Monero</a></h3>
+                <h3><a href="https://masteringmonero.com/free-download.html" target="_blank">Mastering Monero</a></h3>
                     <p>{% t library.masteringmonerop %}</p> 
             </div>
         </div>

--- a/press-kit/index.md
+++ b/press-kit/index.md
@@ -120,7 +120,7 @@ meta_descr: meta_descr.presskit
   <div class="info-block">
     <h2>{% t press-kit.pressdoc %}</h2>
     <div>
-        <h3><a href="https://www.monerooutreach.org/quick-facts.html">{% t press-kit.quickfacts %}</a></h3>
+        <h3><a href="https://www.monerooutreach.org/quick-facts.html" target="_blank">{% t press-kit.quickfacts %}</a></h3>
         <p>{% t press-kit.quickfactsp %}</p>
     </div>
   </div>
@@ -128,15 +128,15 @@ meta_descr: meta_descr.presskit
   <div class="info-block">
     <h2>{% t press-kit.marketing %}</h2>
     <div>
-      <h3><a href="https://github.com/monero-ecosystem/dont-buy-monero-sticker">{% t press-kit.dontbuysticker %}</a></h3>
+      <h3><a href="https://github.com/monero-ecosystem/dont-buy-monero-sticker" target="_blank">{% t press-kit.dontbuysticker %}</a></h3>
       <p>{% t press-kit.dontbuystickerp %}</p>
     </div>
     <div>
-      <h3><a href="https://www.monerooutreach.org/guerrilla-toolkit.html">{% t press-kit.guerrillakit %}</a></h3>
+      <h3><a href="https://www.monerooutreach.org/guerrilla-toolkit.html" target="_blank">{% t press-kit.guerrillakit %}</a></h3>
       <p>{% t press-kit.guerrillakitp %}</p>
     </div>
     <div>
-      <h3><a href="https://www.themonera.art/2017/09/22/monero-promotional-graphics-badges-and-stickers-for-websites/">{% t press-kit.promographics %}</a></h3>
+      <h3><a href="https://www.themonera.art/2017/09/22/monero-promotional-graphics-badges-and-stickers-for-websites/" target="_blank">{% t press-kit.promographics %}</a></h3>
       <p>{% t press-kit.promographicsp %}</p>
     </div>
   </div>

--- a/resources/about/index.md
+++ b/resources/about/index.md
@@ -18,7 +18,7 @@ meta_descr: meta_descr.about
                         </div>
                     </div>
                     <div>
-                        <p>{% t about.history_para1 %} <a href="https://bitcointalk.org/index.php?topic=563821.0">{% t about.history_para2 %}</a> {% t about.history_para3 %}</p>
+                        <p>{% t about.history_para1 %} <a href="https://bitcointalk.org/index.php?topic=563821.0" target="_blank">{% t about.history_para2 %}</a> {% t about.history_para3 %}</p>
                         <p>{% t about.history_para4 %}</p>
                     </div>
                 </div>
@@ -59,7 +59,7 @@ meta_descr: meta_descr.about
                     <div>
                         <p>{% t specs.intro %} <a href="{{ site.baseurl }}/library/">{% t specs.intro_link %}</a> {% t specs.intro1 %}.</p>
                             <h3>{% t specs.pow_title %}</h3>
-                                <p>{% t specs.pow %}. <a href="https://github.com/tevador/randomx">{% t specs.pow_link %}</a>.</p>
+                                <p>{% t specs.pow %}. <a href="https://github.com/tevador/randomx" target="_blank">{% t specs.pow_link %}</a>.</p>
                             <h3>{% t specs.block_emission_title %}</h3>
                                 <p>{% t specs.block_emission_pre %} {% t specs.block_emission_main %}, {% t specs.block_emission_tail %} (@Tail-Emission).</p>
                             <h3>{% t specs.blocks_title %}</h3>

--- a/resources/developer-guides/index.md
+++ b/resources/developer-guides/index.md
@@ -34,13 +34,13 @@ meta_descr: developer-guides.head
                         </div>
                     </div>
                     <p><i>{% t developer-guides.external_head %}</i></p>
-                    <h3><span class="icon-globe"></span><a href="https://monerodocs.org/">Monerodocs.org</a></h3>
+                    <h3><span class="icon-globe"></span><a href="https://monerodocs.org/" target="_blank">Monerodocs.org</a></h3>
                         <p>{% t developer-guides.monerodocs %}</p>
-                    <h3><a href="https://github.com/moneroexamples"><span class="icon-github"></span>Moneroexamples</a></h3>
+                    <h3><a href="https://github.com/moneroexamples" target="_blank"><span class="icon-github"></span>Moneroexamples</a></h3>
                         <p>{% t developer-guides.moneroexamples %}</p>
-                    <h3><a href="https://github.com/monero-ecosystem"><span class="icon-github"></span>Monero Ecosystem project</a></h3>
+                    <h3><a href="https://github.com/monero-ecosystem" target="_blank"><span class="icon-github"></span>Monero Ecosystem project</a></h3>
                         <p>{% t developer-guides.moneroecosystem %}</p>
-                    <h3><span class="icon-globe"></span><a href="https://monero.stackexchange.com">Monero StackExchange</a></h3>
+                    <h3><span class="icon-globe"></span><a href="https://monero.stackexchange.com" target="_blank">Monero StackExchange</a></h3>
                         <p>{% t developer-guides.monerose %}</p>
                 </div>
             </div>
@@ -49,29 +49,29 @@ meta_descr: developer-guides.head
                     <div class="row center-xs">
                         <h2>{% t developer-guides.libraries %}</h2>
                     </div>
-                    <p>{% t developer-guides.libraries_para %} <a href="https://github.com/monero-project/monero-site/issues">GitHub</a>.</p>
+                    <p>{% t developer-guides.libraries_para %} <a href="https://github.com/monero-project/monero-site/issues" target="_blank">GitHub</a>.</p>
                 <ul class="logo">
                     <h3>Node.js</h3>
-                        <li><a href="https://github.com/monero-ecosystem/monero-javascript">monero-javascript (Monero Ecosystem)</a> - {% t developer-guides.monero-javascript %}</li>
-                        <li><a href="https://github.com/PsychicCat/monero-nodejs">monero-nodejs</a> - {% t developer-guides.monero-nodejs %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/monero-javascript" target="_blank">monero-javascript (Monero Ecosystem)</a> - {% t developer-guides.monero-javascript %}</li>
+                        <li><a href="https://github.com/PsychicCat/monero-nodejs" target="_blank">monero-nodejs</a> - {% t developer-guides.monero-nodejs %}</li>
                     <h3>PHP</h3>
-                        <li><a href="https://github.com/monero-integrations/monerophp">monerophp (Monero Integrations)</a> - {% t developer-guides.monerophp %}</li>
-                        <li><a href="https://github.com/monero-integrations/monerowp">monerowp (Monero Integrations)</a> - {% t developer-guides.monerowp %}</li>
+                        <li><a href="https://github.com/monero-integrations/monerophp" target="_blank">monerophp (Monero Integrations)</a> - {% t developer-guides.monerophp %}</li>
+                        <li><a href="https://github.com/monero-integrations/monerowp" target="_blank">monerowp (Monero Integrations)</a> - {% t developer-guides.monerowp %}</li>
                     <h3>Python</h3>
-                        <li><a href="https://github.com/monero-ecosystem/monero-python">monero-python (Monero Ecosystem)</a> - {% t developer-guides.monero-python %}</li>
-                        <li><a href="https://github.com/monero-ecosystem/moneriote-python">moneriote-python (Monero Ecosystem)</a> - {% t developer-guides.moneriote-python %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/monero-python" target="_blank">monero-python (Monero Ecosystem)</a> - {% t developer-guides.monero-python %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/moneriote-python" target="_blank">moneriote-python (Monero Ecosystem)</a> - {% t developer-guides.moneriote-python %}</li>
                     <h3>Java</h3>
-                        <li><a href="https://github.com/00-matt/monerorpc">monerorpc</a> - {% t developer-guides.monerorpc %}</li>
-                        <li><a href="https://github.com/monero-ecosystem/monero-java">monero-java (Monero Ecosystem)</a> - {% t developer-guides.monero-java %}</li>
+                        <li><a href="https://github.com/00-matt/monerorpc" target="_blank">monerorpc</a> - {% t developer-guides.monerorpc %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/monero-java" target="_blank">monero-java (Monero Ecosystem)</a> - {% t developer-guides.monero-java %}</li>
                     <h3>C++</h3>
-                        <li><a href="https://github.com/monero-ecosystem/monero-cpp">monero-cpp (Monero Ecosystem)</a> - {% t developer-guides.monero-cpp %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/monero-cpp" target="_blank">monero-cpp (Monero Ecosystem)</a> - {% t developer-guides.monero-cpp %}</li>
                     <h3>Golang</h3>
-                        <li><a href="https://github.com/monero-ecosystem/vanity-monero">vanity-monero (Monero Ecosystem)</a> - {% t developer-guides.vanity-monero %}</li>
-                        <li><a href="https://github.com/monero-ecosystem/go-monero-rpc-client">go-monero-rpc-client (Monero Ecosystem)</a> - {% t developer-guides.go-monero-rpc-client %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/vanity-monero" target="_blank">vanity-monero (Monero Ecosystem)</a> - {% t developer-guides.vanity-monero %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/go-monero-rpc-client" target="_blank">go-monero-rpc-client (Monero Ecosystem)</a> - {% t developer-guides.go-monero-rpc-client %}</li>
                     <h3>Rust</h3>
-                        <li><a href="https://github.com/monero-rs/monero-rs">monero-rs</a> - {% t developer-guides.monero-rs %}</li>
+                        <li><a href="https://github.com/monero-rs/monero-rs" target="_blank">monero-rs</a> - {% t developer-guides.monero-rs %}</li>
                     <h3>C#</h3>
-                        <li><a href="https://github.com/monero-ecosystem/csharp-monero-rpc-client">csharp-monero-rpc-client (Monero Ecosystem)</a> - {% t developer-guides.csharp-monero %}</li>
+                        <li><a href="https://github.com/monero-ecosystem/csharp-monero-rpc-client" target="_blank">csharp-monero-rpc-client (Monero Ecosystem)</a> - {% t developer-guides.csharp-monero %}</li>
                 </ul>
                 </div>
             </div>

--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -216,9 +216,9 @@ meta_descr: meta_descr.roadmap
                         <h2>{% t roadmap.future %}</h2>
                             <ul>
                                 <h3 class="months">{% t roadmap.comingsoon %}</h3>
-                                    <li class="ongoing"><a href="https://haveno.exchange">{% t roadmap.haveno %}</a></li>
-                                    <li class="ongoing"><a href="https://github.com/seraphis-migration/strategy/wiki">{% t roadmap.seraphis-jamtis %}</a></li>
-                                    <li class="ongoing"><a href="https://github.com/Rucknium/OSPEAD">{% t roadmap.ospead %}</a></li>
+                                    <li class="ongoing"><a href="https://haveno.exchange" target="_blank">{% t roadmap.haveno %}</a></li>
+                                    <li class="ongoing"><a href="https://github.com/seraphis-migration/strategy/wiki" target="_blank">{% t roadmap.seraphis-jamtis %}</a></li>
+                                    <li class="ongoing"><a href="https://github.com/Rucknium/OSPEAD" target="_blank">{% t roadmap.ospead %}</a></li>
                                     <li class="ongoing">{% t roadmap.ringsize-sera-tryp %}</li>
                                     <li class="ongoing">{% t roadmap.tryptych %}</li>
                                     <li class="ongoing">{% t roadmap.xmr-eth-atomicswaps %}</li>

--- a/resources/tools/index.md
+++ b/resources/tools/index.md
@@ -19,11 +19,11 @@ meta_descr: meta_descr.tools
                 <div class="row">
                     <div class="col">
                         <h2>{% t tools.block-explorers %}</h2>
-                        <p><a href="https://xmrchain.net/">xmrchain.net</a></p>
-                        <p><a href="https://moneroblocks.info">MoneroBlocks</a></p>
-                        <p><a href="https://www.exploremonero.com/">Explore Monero</a></p>
-                        <p><a href="https://monerovision.com">MoneroVision</a></p>
-                        <p><a href="https://p2pool.io/explorer/">P2Pool</a> (<a href="http://yucmgsbw7nknw7oi3bkuwudvc657g2xcqahhbjyewazusyytapqo4xid.onion/explorer/">{% t tools.onion-service %}</a>)</p>
+                        <p><a href="https://xmrchain.net/" target="_blank">xmrchain.net</a></p>
+                        <p><a href="https://moneroblocks.info" target="_blank">MoneroBlocks</a></p>
+                        <p><a href="https://www.exploremonero.com/" target="_blank">Explore Monero</a></p>
+                        <p><a href="https://monerovision.com" target="_blank">MoneroVision</a></p>
+                        <p><a href="https://p2pool.io/explorer/" target="_blank">P2Pool</a> (<a href="http://yucmgsbw7nknw7oi3bkuwudvc657g2xcqahhbjyewazusyytapqo4xid.onion/explorer/" target="_blank">{% t tools.onion-service %}</a>)</p>
                     </div>
                 </div>
             </div>
@@ -33,8 +33,8 @@ meta_descr: meta_descr.tools
                 <div class="row">
                     <div class="col">
                         <h2>{% t tools.address-generators %}</h2>
-                        <p><a href="https://xmr.llcoins.net/">xmr.llcoins.net</a></p>
-                        <p><a href="https://monerotech.info/">monerotech.info</a></p>
+                        <p><a href="https://xmr.llcoins.net/" target="_blank">xmr.llcoins.net</a></p>
+                        <p><a href="https://monerotech.info/" target="_blank">monerotech.info</a></p>
                     </div>
                 </div>
             </div>
@@ -46,12 +46,12 @@ meta_descr: meta_descr.tools
                 <div class="row">
                     <div class="col">
                         <h2>{% t tools.network %}</h2>
-                        <p><a href="https://monerohash.com/nodes-distribution.html">monerohash.com - {% t tools.monerohash-nodes %}</a></p>
-                        <p><a href="https://localmonero.co/blocks/">LocalMonero.co blocks - {% t tools.localmonero-blocks %}</a></p>
-                        <p><a href="https://nownodes.io/nodes/monero-xmr">NOWNodes - {% t tools.nownodes %}</a></p>
-                        <p><a href="https://getblock.io">GetBlock - {% t tools.getblockio %}</a></p>
-                        <p><a href="https://monero.fail/">Monero.fail - {% t tools.monerofail %}</a></p>
-                        <p><a href="https://txstreet.com/v/xmr">TxStreet - {% t tools.txstreet %}</a></p>
+                        <p><a href="https://monerohash.com/nodes-distribution.html" target="_blank">monerohash.com - {% t tools.monerohash-nodes %}</a></p>
+                        <p><a href="https://localmonero.co/blocks/" target="_blank">LocalMonero.co blocks - {% t tools.localmonero-blocks %}</a></p>
+                        <p><a href="https://nownodes.io/nodes/monero-xmr" target="_blank">NOWNodes - {% t tools.nownodes %}</a></p>
+                        <p><a href="https://getblock.io" target="_blank">GetBlock - {% t tools.getblockio %}</a></p>
+                        <p><a href="https://monero.fail/" target="_blank">Monero.fail - {% t tools.monerofail %}</a></p>
+                        <p><a href="https://txstreet.com/v/xmr" target="_blank">TxStreet - {% t tools.txstreet %}</a></p>
                     </div>
                 </div>
             </div>
@@ -61,9 +61,9 @@ meta_descr: meta_descr.tools
                 <div class="row">
                     <div class="col">
                         <h2>{% t tools.market %}</h2>
-                        <p><a href="https://cryptofacile.io">cryptoFacile - {% t tools.cryptofacile %}</a></p>
-                        <p><a href="https://cryptoradar.co/buy-monero">Cryptoradar - {% t tools.cryptoradar %}</a></p>
-                        <p><a href="https://kryptocheck.de">KryptoCheck - {% t tools.kryptocheck %}</a></p>
+                        <p><a href="https://cryptofacile.io" target="_blank">cryptoFacile - {% t tools.cryptofacile %}</a></p>
+                        <p><a href="https://cryptoradar.co/buy-monero" target="_blank">Cryptoradar - {% t tools.cryptoradar %}</a></p>
+                        <p><a href="https://kryptocheck.de" target="_blank">KryptoCheck - {% t tools.kryptocheck %}</a></p>
                     </div>
                 </div>
             </div>
@@ -75,9 +75,9 @@ meta_descr: meta_descr.tools
                 <div class="row">
                     <div class="col">
                         <h2>{% t tools.misc %}</h2>
-                        <p><a href="https://www.monero.how/">Monero.how - {% t tools.monerohow-stats %}</a></p>
-                        <p><a href="https://moneroj.net/sfmodel/">Monero Pro - {% t tools.moneropro %}</a></p>
-                        <p><a href="https://libera.monerologs.net/">MoneroLogs - {% t tools.monerologs %}</a></p>
+                        <p><a href="https://www.monero.how/" target="_blank">Monero.how - {% t tools.monerohow-stats %}</a></p>
+                        <p><a href="https://moneroj.net/sfmodel/" target="_blank">Monero Pro - {% t tools.moneropro %}</a></p>
+                        <p><a href="https://libera.monerologs.net/" target="_blank">MoneroLogs - {% t tools.monerologs %}</a></p>
                     </div>
                 </div>
             </div>
@@ -87,13 +87,13 @@ meta_descr: meta_descr.tools
                 <div class="row">
                     <div class="col">
                         <h2 id="payment-gateways">{% t tools.gateways %}</h2>
-                        <p><a href="https://btcpayserver.org">BTCPay Server</a></p>
-                        <p><a href="https://www.cdpay.eu/">CDPay</a></p>
-                        <p><a href="https://www.coinpayments.net/">CoinPayments</a></p>
-                        <p><a href="https://globee.com/">GloBee</a></p>
-                        <p><a href="https://www.cryptowoo.com/">CryptoWoo Monero Plugin (WooCommerce)</a></p>
-                        <p><a href="https://github.com/monero-integrations/monerowp">Monero WooCommerce Extension (PHP)</a></p>
-                        <p><a href="https://nowpayments.io/">NOWPayments</a></p>
+                        <p><a href="https://btcpayserver.org" target="_blank">BTCPay Server</a></p>
+                        <p><a href="https://www.cdpay.eu/" target="_blank">CDPay</a></p>
+                        <p><a href="https://www.coinpayments.net/" target="_blank">CoinPayments</a></p>
+                        <p><a href="https://globee.com/" target="_blank">GloBee</a></p>
+                        <p><a href="https://www.cryptowoo.com/" target="_blank">CryptoWoo Monero Plugin (WooCommerce)</a></p>
+                        <p><a href="https://github.com/monero-integrations/monerowp" target="_blank">Monero WooCommerce Extension (PHP)</a></p>
+                        <p><a href="https://nowpayments.io/" target="_blank">NOWPayments</a></p>
                     </div>
                 </div>
             </div>

--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -78,7 +78,7 @@ meta_descr: meta_descr.userguides
                         <div class="col">
                             <h2>{% t user-guides.wallets %}</h2>
                             <p><a href="{{site.baseurl}}/resources/user-guides/monero-wallet-cli.html">{% t user-guides.cli-wallet %}</a></p>
-                            <p><a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md">{% t user-guides.guiguide %}</a></p>
+                            <p><a href="https://github.com/monero-ecosystem/monero-GUI-guide/blob/master/monero-GUI-guide.md" target="_blank">{% t user-guides.guiguide %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/change-restore-height.html">{% t user-guides.change-restore-height %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/view_only.html">{% t user-guides.view-only %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/verification-allos-advanced.html">{% t user-guides.verify-allos %}</a></p>
@@ -110,7 +110,7 @@ meta_descr: meta_descr.userguides
                             <p><a href="{{site.baseurl}}/resources/user-guides/tor_wallet.html">{% t user-guides.tor_wallet %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/node-i2p-zero.html">{% t user-guides.node-i2pzero %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html">{% t user-guides.qubes %}</a></p>
-                            <p><a href="http://xmrguide25ibknxgaray5rqksrclddxqku3ggdcnzg4ogdi5qkdkd2yd.onion">{% t user-guides.tailsguide %}</a><img alt="onion logo" class="onion-mid" src="/img/onion-tor.svg" title="Onion link"/></p>
+                            <p><a href="http://xmrguide25ibknxgaray5rqksrclddxqku3ggdcnzg4ogdi5qkdkd2yd.onion" target="_blank">{% t user-guides.tailsguide %}</a><img alt="onion logo" class="onion-mid" src="/img/onion-tor.svg" title="Onion link"/></p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
As discussed in #1921 and #1922, I set the target to `_blank` for links to external sites.

I have only modified links that comply with the css rule applied via `a[href^="https:"]:not([href*="getmonero.org"])` and which therefore display the `external.svg` icon