### PR TITLE
workgroups: remove outreach, add seraphis, remove mattermost

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -190,8 +190,6 @@ team:
   localization_descr: One of the oldest Monero Workgroups, it's formed by contributors working on translating Monero-related software and documentation. It's strongly suggested to contact the workgroup before working on translations.
   localization_start: Contact the workgroup on the chatroom or open an issue on the GitHub repository. You can also start translating immediately using the Weblate platform. Just make sure to read the guide for translators first.
   locplatform: "Localization platform:"
-  outreach_descr: This workgroup is focused on getting Monero out there, gathering artists, writers, and anyone who wishes to make Monero known to the world.
-  outreach_start: The members of the Outreach Workgroup heavily use Telegram for coordination and matrix/freenode in minor part. If you want to help, you can contact the workgroup on one of these channels. It is quite structured, so you'll probably be directed to a coordinator.
   telegram: "Telegram chat:"
   mrl_descr: As the name suggests, the Monero Research Lab is the workgroup focused on Monero-related research. It's formed by scientists finding ways to improve Monero's protocol and features. Most of the protocol improvements that make Monero amazing, like CLSAG and @Bulletproofs, are the result of the efforts of this workgroup.
   mrl_start: Join the chatroom below and state your interests and your skills. Research is always ongoing, and somebody will point you in the right direction.
@@ -204,6 +202,8 @@ team:
   mpwg: Monero Policy Working Group
   mpwg_descr: Monero Policy Working Group is a loosely formed quorum of individuals with an interest in interacting with regulators, policy makers, and the wider financial services sector to ensure broad understanding of Monero’s component technologies, especially with regards to its compatibility with evolving regulatory and compliance requirements.
   mpwg_start: If you would like to take part or follow policy discussions, join Matrix/Libera chatroom.
+  nwlb_descr: The Seraphis wallet workgroup is a group of developers working on implementing Seraphis and Jamtis in Monero, through developing a completely new type of wallet that will improve drastically Monero's privacy capabilities and usability.
+  nwlb_start: The workgroup meets frequently and coordinates in the Matrix room (relayed to IRC). They are always looking for contributors willing to help.
 
 downloads:
   intro: On this page you can find and download the latest version available of the Monero software, as well as hardware, light and mobile wallets.

--- a/community/workgroups/index.md
+++ b/community/workgroups/index.md
@@ -22,7 +22,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.core_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-dev</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-dev"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-dev:monero.social?via=matrix.org&via=monero.social&via=haveno.network"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-dev"></a></li>
+            <li>{% t team.chat %} <code>#monero-dev</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-dev"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-dev:monero.social?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
             <li>Email: <code>dev[at]getmonero[dot]org</code></li>
           </ul>
           <div class="row center-xs icons">
@@ -41,7 +41,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.community_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-community</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-community"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-community:monero.social?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-community"></a></li>
+            <li>{% t team.chat %} <code>#monero-community</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-community"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-community:monero.social?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
             <li>{% t team.website %} <a href="https://www.communityworkgroup.org/">www.communityworkgroup.org</a></li>
           </ul>
           <div class="row center-xs icons">
@@ -60,8 +60,8 @@ permalink: /community/workgroups/index.html
           <p>{% t team.devworkgroup_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chatgeneral %} <code>#monero-dev</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-dev"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-dev:matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-dev"></a></li>
-            <li>{% t team.chatgui %} <code>#monero-gui</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-gui"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-gui:matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-gui"></a></li>
+            <li>{% t team.chatgeneral %} <code>#monero-dev</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-dev"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-dev:monero.social?via=matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
+            <li>{% t team.chatgui %} <code>#monero-gui</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-gui"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-gui:monero.social?via=matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
           </ul>
           <div class="row center-xs icons">
             <a class="ext-noicon" href="https://github.com/monero-project/monero" target="_blank" rel="noreferrer, noopener" aria-label="Github monero logo"><div class="col social-icon github"></div></a>
@@ -80,7 +80,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.web_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-site</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-site"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-site:haveno.network?via=matrix.org&via=monero.social&via=haveno.network"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-site"></a></li>
+            <li>{% t team.chat %} <code>#monero-site</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-site"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-site:monero.social?via=matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
           </ul>
           <div class="row center-xs icons">
             <a class="ext-noicon" href="https://github.com/monero-project/monero-site" target="_blank" rel="noreferrer, noopener" aria-label="GitHub logo"><div class="col social-icon github"></div></a>
@@ -98,7 +98,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.localization_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-translations</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-translations"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-translations:monero.social?via=matrix.org&via=monero.social&via=haveno.network"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-translations"></a></li>
+            <li>{% t team.chat %} <code>#monero-translations</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-translations"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-translations:monero.social?via=matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
             <li>{% t team.locplatform %} <a href="https://translate.getmonero.org">Weblate</a></li>
           </ul>
           <div class="row center-xs icons">
@@ -109,20 +109,18 @@ permalink: /community/workgroups/index.html
       <div class="right half col-lg-6 col-md-6 col-sm-12 col-xs-12">
         <div class="info-block">
           <div class="row center-xs">
-            <h2>Monero Outreach</h2>
+            <h2>Seraphis Wallet Workgroup</h2>
           </div>
           <h4>{% t team.descr %}</h4>
-          <p>{% t team.outreach_descr %}</p>
+          <p>{% t team.nwlb_descr %}</p>
           <h4>{% t team.start %}</h4>
-          <p>{% t team.outreach_start %}</p>
+          <p>{% t team.nwlb_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.telegram %} <a href="https://t.me/monerooutreach">monerooutreach</a></li>
-            <li>{% t team.chat %} <code>#monero-outreach</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-outreach"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-outreach:monero.social?via=matrix.org&via=monero.social&via=haveno.network"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-outreach"></a></li>
+            <li>{% t team.chat %} <code>#no-wallet-left-behind</code> <a class="chats-img" href="https://matrix.to/#/#no-wallet-left-behind:monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a><a class="chats-img" href="irc://irc.libera.chat/#no-wallet-left-behind"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a></li>
           </ul>
           <div class="row center-xs icons">
-            <a class="ext-noicon" href="https://twitter.com/xmroutreach" target="_blank" rel="noreferrer, noopener" aria-label="Twitter logo"><div class="col social-icon twitter"></div></a>
-            <a class="ext-noicon" href="https://github.com/monero-ecosystem/outreach-docs" target="_blank" rel="noreferrer, noopener" aria-label="Github logo"><div class="col social-icon github"></div></a>
+            <a class="ext-noicon" href="https://github.com/seraphis-migration/strategy/wiki/Seraphis-Wallet-Workgroup" target="_blank" rel="noreferrer, noopener" aria-label="Github logo"><div class="col social-icon github"></div></a>
           </div>
         </div>
       </div>
@@ -137,7 +135,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.mrl_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-research-lab</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-research-lab"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-research-lab:matrix.org?via=matrix.org&via=monero.social&via=privacytools.io"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a> <a class="chats-img" href="https://mattermost.getmonero.org/monero/channels/monero-research-lab"></a></li>
+            <li>{% t team.chat %} <code>#monero-research-lab</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-research-lab"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-research-lab:monero.social?via=matrix.org&via=privacytools.io"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
           </ul>
           <div class="row center-xs icons">
             <a class="ext-noicon" href="https://github.com/monero-project/research-lab" target="_blank" rel="noreferrer, noopener" aria-label="GitHub logo"><div class="col social-icon github"></div></a>
@@ -155,7 +153,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.space_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-space</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-space"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-space:monero.social?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
+            <li>{% t team.chat %} <code>#monero-space</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-space"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-space:monero.social?via=matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
             <li>{% t team.website %} <a href="https://monero.space" target="_blank" rel="noreferrer, noopener">monero.space</a></li>
             <li>Flarum: <a href="https://forum.monero.space" target="_blank" rel="noreferrer, noopener">forum.monero.space</a></li>
           </ul>
@@ -175,7 +173,7 @@ permalink: /community/workgroups/index.html
           <p>{% t team.mpwg_start %}</p>
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
-            <li>{% t team.chat %} <code>#monero-policy</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-policy"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-policy:matrix.org?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
+            <li>{% t team.chat %} <code>#monero-policy</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-policy"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/#monero-policy:monero.social?via=matrix.org"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
             <li>Email: <code>policy[at]getmonero[dot]org</code></li>
             <li>{% t team.website %} <a href="https://moneropolicy.org">moneropolicy.org</a></li>
           </ul>


### PR DESCRIPTION
The outreach workgroup has been inactive for more than 2 years. 

edit: Replaced Outreach workgroup with Seraphis workgroup and removed mentions of mattermost, which is not used anymore.

closes #2185