### PR TITLE
add dedicated meta descriptions

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -45,6 +45,21 @@ titles:
   blogbytag: Blog
   library: Library
 
+meta_descr:
+  whatismonero: A thorough explanation of what is Monero and how to get started
+  accepting: A guide on how to accept a payment in Monero using the GUI wallet
+  contributing: There are many ways to contribute to Monero and for every skillset
+  mining: Information, software and resources about mining Monero
+  blog: News, release notices and communications from the Monero Project and its community
+  workgroups: Find out where the hundreds of volunteers working on Monero meet and coordinate
+  sponsorships: The current and past sponsors of the Monero project.
+  about: History, values and basic structure of the Monero project and technology
+  roadmap: A browsable overview of what Monero achieved since its creation, what is currently being developed and plans for the future
+  mrl: Monero's research corner, with research papers, whitepaper and other research-related information
+  userguides: A collection of guides and manuals to guide you through using Monero and fixing common issues
+  tools: Links to third-party tools, like block explorers, payment gateways and generators to interact with the Monero ecosystem
+  presskit: Logos, marketing material, contacts and press documentation about Monero
+
 navigation:
   getstarted: Get Started
   whatis: What is Monero?
@@ -929,7 +944,7 @@ library:
 
 moneropedia:
   description: >
-    The terminology around Monero can be very complex and technical. The Moneropedia is a tool created by the Monero community to provide an explanation of these terms in a simple way. Listed below you'll find all the Moneropedia entries in alphabetic order. If you wish to edit an existing voice or to add a new one, click the button at the bottom of the page.
+    The terminology around Monero can be very complex and technical. The Moneropedia is a tool created by the Monero community to provide an explanation of these terms in a simple way. Listed below you'll find all the Moneropedia entries in alphabetic order.
   instructions: Instructions for adding a Moneropedia entry are in the
   add_new_text1: If there is an entry you'd like to modify or be added, please
   add_new_link: open an issue on this website's GitHub repository

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,7 @@
   <meta name="description" content="
   {% if page.layout == 'moneropedia' %}{% t global.wikimeta %}
   {% elsif page.summary %}{{ page.summary }}
+  {% elsif page.meta_descr %}{% t page.meta_descr %}
   {% else %}{% t global.titlemeta %}
   {% endif %}">
 	<meta name="keywords" content="{{ site.keywords }}">
@@ -26,6 +27,7 @@
     <meta property="og:description" content="
     {% if page.layout == 'moneropedia' %}{% t global.wikimeta %}
     {% elsif page.summary %}{{ page.summary }}
+    {% elsif page.meta_descr %}{% t page.meta_descr %}
     {% else %}{% t global.titlemeta %}
     {% endif %}">
     <!-- If the page specifies a dedicated image which is not an SVG file, we use that one. Otherwise we use the classic Monero logo -->

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,7 @@
 ---
 layout: custom
 title: titles.blogbytag
+meta_descr: meta_descr.blog
 ---
 
 <div class="blog">

--- a/community/hangouts/index.md
+++ b/community/hangouts/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.hangouts
 permalink: /community/hangouts/index.html
+meta_descr: hangouts.intro
 ---
 
 {% t global.lang_tag %}

--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.merchants
 permalink: /community/merchants/index.html
+meta_descr: merchants.descr
 ---
 {% t global.lang_tag %}
 <section class="container">

--- a/community/sponsorships/index.md
+++ b/community/sponsorships/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.sponsorships
 permalink: /community/sponsorships/index.html
+meta_descr: meta_descr.sponsorships
 ---
 
 {% t global.lang_tag %}

--- a/community/workgroups/index.md
+++ b/community/workgroups/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.workgroups
 permalink: /community/workgroups/index.html
+meta_descr: meta_descr.workgroups
 ---
 
 {% t global.lang_tag %}

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.downloads
 permalink: /downloads/index.html
+meta_descr: downloads.intro
 ---
 
 {% t global.lang_tag %}

--- a/get-started/accepting/index.md
+++ b/get-started/accepting/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.accepting
 permalink: /get-started/accepting/index.html
+meta_descr: meta_descr.accepting
 ---
 {% t global.lang_tag %}
 <section class="container">

--- a/get-started/contributing/index.md
+++ b/get-started/contributing/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.contributing
 permalink: /get-started/contributing/index.html
+meta_descr: meta_descr.contributing
 ---
 {% t global.lang_tag %}
 <div class="text-center container description">

--- a/get-started/faq/index.md
+++ b/get-started/faq/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.faq
 permalink: /get-started/faq/index.html
+meta_descr: faq.intro
 ---
 {% t global.lang_tag %}
 <div class="container description">

--- a/get-started/mining/index.md
+++ b/get-started/mining/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.mining
 permalink: /get-started/mining/index.html
+meta_descr: meta_descr.mining
 ---
 {% t global.lang_tag %}
 <div class="mining">

--- a/get-started/what-is-monero/index.md
+++ b/get-started/what-is-monero/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: titles.whatismonero
 permalink: /get-started/what-is-monero/index.html
+meta_descr: meta_descr.whatismonero
 ---
 {% t global.lang_tag %}
 <div class="site-wrap">

--- a/library/index.md
+++ b/library/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.library
 permalink: /library/index.html
+meta_descr: library.description
 ---
 {% t global.lang_tag %}
 <div class="about-monero">

--- a/press-kit/index.md
+++ b/press-kit/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.presskit
 permalink: /press-kit/index.html
+meta_descr: meta_descr.presskit
 ---
 
 <div class="text-center container description">

--- a/resources/about/index.md
+++ b/resources/about/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.about
 permalink: /resources/about/index.html
+meta_descr: meta_descr.about
 ---
 
 {% t global.lang_tag %}

--- a/resources/developer-guides/index.md
+++ b/resources/developer-guides/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.developerguides
 permalink: /resources/developer-guides/index.html
+meta_descr: developer-guides.head
 ---
 
 {% t global.lang_tag %}

--- a/resources/moneropedia/index.md
+++ b/resources/moneropedia/index.md
@@ -1,6 +1,7 @@
 ---
 layout: custom
 title: titles.moneropedia
+meta_descr: moneropedia.description
 ---
 
 <div class="container description">

--- a/resources/research-lab/index.md
+++ b/resources/research-lab/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.researchlab
 permalink: /resources/research-lab/index.html
+meta_descr: meta_descr.mrl
 ---
 {% t global.lang_tag %}
 <div class="container description">

--- a/resources/roadmap/index.md
+++ b/resources/roadmap/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.roadmap
 permalink: /resources/roadmap/index.html
+meta_descr: meta_descr.roadmap
 ---
 {% t global.lang_tag %}
 <div class="roadmap">

--- a/resources/tools/index.md
+++ b/resources/tools/index.md
@@ -2,6 +2,7 @@
 layout: custom
 title: titles.tools
 permalink: /resources/tools/index.html
+meta_descr: meta_descr.tools
 ---
 
 <div class="text-center container description">

--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -1,6 +1,7 @@
 ---
 layout: custom
 title: titles.userguides
+meta_descr: meta_descr.userguides
 ---
 {% t global.lang_tag %}
 <div class="guides">


### PR DESCRIPTION
posting a link to getmonero on social medias results, except few exceptions, in showing a standard description for all pages. This adds dedicated meta descriptions for every page. It will improve getmonero's seo score and links on social media will look nicer and will be more descriptive

- Once translated, these descriptions will show up in the correct language (for example if somebody links to the French version of the "about" page, the description on social medias will be displayed in French)
- Some pages had already a short description usable for meta descriptions, so i used that. An additional advantage is that some are alread translated, so will show up in the correct language right away

To test the before and after, use https://www.opengraph.xyz/

Example of twitter card for the Spanish version of the Library page (https://deploy-preview-2155--barolo-time-757cf9.netlify.app/es/library/index.html):
![library-es](https://user-images.githubusercontent.com/28106476/233026570-601cd7be-dd74-40af-9266-e01f178017b5.png)

opengraph and meta stuff in general need some love.