### PR TITLE
head: fix double slash in og:url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,7 +39,7 @@
     {% endif %}
     {% endcapture %}{{ og_image | strip }}">
     <meta property="og:site_name" content="{% t global.sitename %}">
-    <meta property="og:url" content="{{ site.url }}/{{ page.url }}">
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}">
     <meta property="og:type" content="website">
     <meta http-equiv="onion-location" content="{% include onion.html %}" />
 


### PR DESCRIPTION
As for https://github.com/monero-project/monero-site/pull/2155#issuecomment-1515528330.

Browsers seem to ignore multiple slashes, but the url should be fixed anyway