### PR TITLE
merchants: remove sideshift.ai

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -103,7 +103,6 @@ meta_descr: merchants.descr
         <p>{% t merchants.swappersp %}</p>
         <ul class="logo">
             <li><a href="https://fixedfloat.com/">Fixedfloat</a></li>
-            <li><a href="https://sideshift.ai/">Sideshift.ai</a></li>
             <li><a href="https://simpleswap.io/">SimpleSwap</a></li>
             <li><a href="https://changenow.io/">ChangeNow</a></li>
             <li><a href="https://godex.io/">Godex</a></li>


### PR DESCRIPTION
This is an alternative to #2183 where only `sideshift.ai` is removed, without replacing it, which can be done later on if needed.