### PR TITLE
workflows: verify redirect urls in downloads.yml

### DIFF
--- a/.github/workflows/hashes.yaml
+++ b/.github/workflows/hashes.yaml
@@ -119,6 +119,7 @@ jobs:
           grep monero- downloads/hashes.txt | sha256sum -c
       - name: Verify downloads.yml hashes
         run: |
+          mkdir verify_redirects
           yq -r '.[] | .[0].downloads[] | "\(.link)|\(.hash)"' _data/downloads.yml | grep -v github |
               while read line; do
                   [ -z "$line" ] && continue
@@ -151,6 +152,13 @@ jobs:
                   esac
                   filename=$(awk "/${filename}/ {print \$2}" downloads/hashes.txt)
                   echo "$hash  $filename" | sha256sum -c
+                  curl -sLo ./verify_redirects/$filename $url
+                  actual_hash=$(sha256sum verify_redirects/$filename | awk '{print $1}')
+                  if [ "$actual_hash" != "$hash" ]; then
+                      echo "::warning ::Redirect hash mismatch %0A url: $url %0A filename: $filename %0A expected hash: $hash %0A hash: $actual_hash"
+                  else
+                      echo "$url OK"
+                  fi
               done
       - name: Validate source integrity
         run: |


### PR DESCRIPTION
re-download all binaries using their redirect urls and confirm hashes.

displays a warning if files downloaded using the redirect urls do not match the hashes in downloads.yml

if there is a mis-match / or the redirects are not updated to point at the new files yet, the workflow will still be green and only produce warnings.  re-running the workflow manually after site is deployed / redirects pointing to new files will remove the warnings.

example run showing a warning: https://github.com/plowsof/monero-site/actions/runs/6487887488

on `workflow_dispatch:` can be added to make running the workflow manually (if needed)