### PR TITLE
refactor: add 'Trezor Safe 3' to HWs that support monero

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -360,6 +360,7 @@ meta_descr: downloads.intro
                                     <td>
                                         <ul>
                                             <li>Model T</li>
+                                            <li>Safe 3</li>
                                         </ul>
                                     </td>
                                     <td>


### PR DESCRIPTION
Hey, I've noticed that in section about hardware wallets that currently support Monero, from Trezor only Model T is mentioned. But the new model that they released called [Trezor Safe 3](https://trezor.io/trezor-safe-3) also supports Monero as you can read here 

<img width="744" alt="image" src="https://github.com/monero-project/monero-site/assets/103599310/c03622b3-3248-431b-9d60-c41c900805f1">

Therefore, I've added new item to the list of Trezor wallets that support Monero, hopefully this small improvement will help people who are searching for this information.