### PR TITLE
newsletters: add revuo monero

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -942,6 +942,8 @@ library:
   zkbasicscheatsheet20220621p: >
     A lightly theoretical interlude (hopefully still gentle, trying to stress concepts more than formalism and selecting the approached topics) to lay the foundations for Bulletproof and other future Zero-Knowledge-related features, if any.
   newsletters: Newsletters
+  revuomonero: >
+    Revuo Monero is a weekly newsletter where you can find the most recent Monero news.
   themonerostandard: >
     Monero Standard is a weekly publication by recanman, providing up-to-date news and information on the Monero protocol.
     In addition to covering the latest developments in the Monero community, The Monero Standard also includes a weekly price chart, mining pool chart, blockchain statistics, and even a Meme of the Week.

--- a/library/index.md
+++ b/library/index.md
@@ -47,10 +47,12 @@ meta_descr: library.description
         <div class="info-block text-adapt">
             <h2>{% t library.newsletters %}</h2>
             <div>
-                <h3><a href="https://localmonero.co/the-monero-standard">The Monero Standard</a></h3>
-                  <p>{% t library.themonerostandard %}</p>
                 <h3><a href="https://monero.observer/tag/blitz/">Monero Observer Blitz</a></h3>
                   <p>{% t library.moneroobserverblitz %}</p>
+                <h3><a href="https://revuo-xmr.com/">Revuo Monero</a></h3>
+                  <p>{% t library.revuomonero %}</p>
+                <h3><a href="https://localmonero.co/the-monero-standard">The Monero Standard</a></h3>
+                  <p>{% t library.themonerostandard %}</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Considering Revuo Monero was initially started by Diego 'rehrar' Salazar in 2019, has been, historically speaking the one newsletter under the Core Workgroup umbrella while he was their liason, more than 100 issues were shared via the 'official' Twitter profile, @monero, archive is found on LocalMonero's website and overall its good standing of audience and content, I think it is appropriate for Revuo Monero to be named and linked as well, keeping things cohesive.