### PR TITLE
Fix broken link

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -94,7 +94,7 @@ meta_descr: merchants.descr
         <p>{% t merchants.cexp %}</p>
         <ul class="logo">
             <li><a href="https://www.kraken.com/">Kraken</a> (EUR*, USD*, CAD, GBP, JPY, AUD, CHF)</li>
-            <li><a href="https://www.binance.com/trade.html?symbol=XMR_BTC">Binance</a> (USD, EUR, RUB, TRY, NGN, UAH, KZT, INR, ...)</li>
+            <li><a href="https://www.binance.com/">Binance</a> (USD, EUR, RUB, TRY, NGN, UAH, KZT, INR, ...)</li>
             <li><a href="https://dvchain.co/">DV Chain (OTC)</a> (USD*, CAD*, GBP*, EUR*, JPY*, ...)</li>
             <li><a href="https://www.bitfinex.com/">Bitfinex</a> (USD*)</li>
             <li><a href="https://bitcoinvn.io?deposit=vnd&settle=xmr">BitcoinVN</a> (VND)</li>


### PR DESCRIPTION
You could put a link like `https://www.binance.com/en/crypto/buy/EUR/XMR`, but I don't like this approach, because the URL might break again in the future, it forces the English language in the URL, and you have to pick a currency.