### PR TITLE
merchants: remove sideshift

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -104,7 +104,6 @@ meta_descr: merchants.descr
         <p>{% t merchants.swappersp %}</p>
         <ul class="logo">
             <li><a href="https://fixedfloat.com/">Fixedfloat</a></li>
-            <li><a href="https://sideshift.ai/">Sideshift.ai</a></li>
             <li><a href="https://simpleswap.io/">SimpleSwap</a></li>
             <li><a href="https://changenow.io/">ChangeNow</a></li>
             <li><a href="https://godex.io/">Godex</a></li>


### PR DESCRIPTION
Removes SideShift since they delisted XMR about half a year ago.