### PR TITLE
Fix Broken Links

### DIFF
--- a/_i18n/ar/resources/user-guides/tor_wallet.md
+++ b/_i18n/ar/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/ar/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/ar/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/de/resources/user-guides/tor_wallet.md
+++ b/_i18n/de/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ Wir rechnen damit, dass in zukünftigen Versionen des GUI eine direkte Tor/I2P-U
 
 # Zusätzliche Quellen
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/de/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/de/resources/user-guides/weblate/tor_wallet.po
@@ -311,8 +311,8 @@ msgstr "# Zusätzliche Quellen"
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
-msgstr "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
+msgstr "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85

--- a/_i18n/en/resources/user-guides/weblate/tor_wallet.pot
+++ b/_i18n/en/resources/user-guides/weblate/tor_wallet.pot
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/es/resources/user-guides/tor_wallet.md
+++ b/_i18n/es/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/es/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/es/resources/user-guides/weblate/tor_wallet.po
@@ -230,7 +230,7 @@ msgstr "# Recursos adicionales"
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/fr/resources/user-guides/tor_wallet.md
+++ b/_i18n/fr/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/fr/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/fr/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/it/resources/user-guides/tor_wallet.md
+++ b/_i18n/it/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/it/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/it/resources/user-guides/weblate/tor_wallet.po
@@ -214,7 +214,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/nb-no/resources/user-guides/tor_wallet.md
+++ b/_i18n/nb-no/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ I fremtidige versjoner av GUI-en forventer vi å legge til direkte støtte for T
 
 # Flere ressurser
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Hvordan bruke Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/nb-no/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/nb-no/resources/user-guides/weblate/tor_wallet.po
@@ -301,8 +301,8 @@ msgstr "# Flere ressurser"
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
-msgstr "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
+msgstr "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85

--- a/_i18n/nl/resources/user-guides/tor_wallet.md
+++ b/_i18n/nl/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/nl/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/nl/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/pl/resources/user-guides/tor_wallet.md
+++ b/_i18n/pl/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/pl/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/pl/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/pt-br/resources/user-guides/tor_wallet.md
+++ b/_i18n/pt-br/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/pt-br/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/pt-br/resources/user-guides/weblate/tor_wallet.po
@@ -214,7 +214,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/ru/resources/user-guides/tor_wallet.md
+++ b/_i18n/ru/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ torsocks --port 9150 /Applications/monero-wallet-gui.app/Contents/MacOS/monero-w
 
 # Дополнительные ссылки
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Используем Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/ru/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/ru/resources/user-guides/weblate/tor_wallet.po
@@ -311,8 +311,8 @@ msgstr "# Дополнительные ссылки"
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
-msgstr "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
+msgstr "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85

--- a/_i18n/tr/resources/user-guides/tor_wallet.md
+++ b/_i18n/tr/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/tr/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/tr/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/zh-cn/resources/user-guides/tor_wallet.md
+++ b/_i18n/zh-cn/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/zh-cn/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/zh-cn/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/_i18n/zh-tw/resources/user-guides/tor_wallet.md
+++ b/_i18n/zh-tw/resources/user-guides/tor_wallet.md
@@ -81,5 +81,5 @@ In future versions of the GUI, we expect to add direct Tor / I2P support so that
 
 # Additional resources
 
-* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)
+* [ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)
 * [Using Tor](https://github.com/monero-project/monero#using-tor) (Monero README)

--- a/_i18n/zh-tw/resources/user-guides/weblate/tor_wallet.po
+++ b/_i18n/zh-tw/resources/user-guides/weblate/tor_wallet.po
@@ -210,7 +210,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: _i18n/en/resources/user-guides/tor_wallet.md:85
 #, markdown-text
-msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md)"
+msgid "[ANONYMITY_NETWORKS.md](https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md)"
 msgstr ""
 
 #. type: Bullet: '* '


### PR DESCRIPTION
### Summery

In ```tor_wallet.md```, there is a link to ```https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md```. But the file has been moved from the root directory to the doc directory. I have fixed the link in every language.

https://github.com/monero-project/monero/blob/master/ANONYMITY_NETWORKS.md --> https://github.com/monero-project/monero/blob/master/docs/ANONYMITY_NETWORKS.md

### Support my work

These links were found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐