### PR TITLE
update CCS incident blog post

### DIFF
--- a/_posts/2023-11-04-ccs-wallet-incident.md
+++ b/_posts/2023-11-04-ccs-wallet-incident.md
@@ -8,6 +8,8 @@ author: Monero Core Team
 
 During a routine transfer, we noticed the '[Community Crowdfunding System](https://ccs.getmonero.org/)' (CCS) main wallet was drained of 2,675.73 XMR (the entire balance) on September 1, 2023. The secondary wallet, used for payments to contributors, is untouched; its balance is ~244 XMR. We have thus far not been able to ascertain the source of the breach. An internal investigation is ongoing and further details will be released once we have them.
 
-The General Fund (which remains intact) will be used to cover this loss. Contributors with [in-progress](https://ccs.getmonero.org/work-in-progress/) CCS proposals will remain unaffected. 
+~~The General Fund (which remains intact) will be used to cover this loss. Contributors with [in-progress](https://ccs.getmonero.org/work-in-progress/) CCS proposals will remain unaffected.~~
+
+2023-12-06 Update: The Monero General Fund wallet received 2696.73 XMR from an unknown sender.
 
 Further details and discussion can be found on this [issue on GitHub](https://github.com/monero-project/meta/issues/916).


### PR DESCRIPTION
added information about the Monero General Fund wallet received 2696.73 XMR and strikethroughed the old information