### PR TITLE
Fix indices used to check CLI and GUI file names in workflow

### DIFF
--- a/.github/workflows/hashes.yaml
+++ b/.github/workflows/hashes.yaml
@@ -46,18 +46,18 @@ jobs:
               filename="${the_line[$length]}"
               echo "${filename}"
           }
-          # expects cli files between lines 2-13 and gui 14-18 (comments do not count, 1st line = 0)
-          # to add a new file to the cli, $num must be -gt 1 and -lt 15.
-          # gui $num is now -gt 14 and -lt 20 (new line has been added above)
+          # expects cli files between lines 2-14 and gui 15-19 (comments do not count, 1st line = 0)
+          # to add a new file to the cli, $num must be -gt 1 and -lt 16.
+          # gui $num is now -gt 15 and -lt 21 (new line has been added above)
           # a new gui file will only increase the -lt number by 1
           # changes to extensions / new files must be reflected in the cli_files / gui_files lists below
           num=0
           for line in "${lines[@]}"; do
-              if [ $num -gt 1 ] && [ $num -lt 14 ] ; then
+              if [ $num -gt 1 ] && [ $num -lt 15 ] ; then
                   #CLI
                   filename=$(get_filename "${line}")
                   filenames_cli+=("${filename}")
-              elif [ $num -gt 13 ] && [ $num -lt 21 ] ; then
+              elif [ $num -gt 14 ] && [ $num -lt 21 ] ; then
                  #GUI
                   filename=$(get_filename "${line}")
                   filenames_gui+=("${filename}")


### PR DESCRIPTION
Current workflow failed on checking the last CLI file name.
Index between CLI and GUI (14-15) needs to be increased by 1 to accommodate new riscv64 file.