### PR TITLE
merchants: remove fixedfloat

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -121,7 +121,6 @@ meta_descr: merchants.descr
         <h3>Swappers</h3>
         <p>{% t merchants.swappersp %}</p>
         <ul class="logo">
-            <li><a href="https://fixedfloat.com/">Fixedfloat</a></li>
             <li><a href="https://simpleswap.io/">SimpleSwap</a></li>
             <li><a href="https://changenow.io/">ChangeNow</a></li>
             <li><a href="https://godex.io/">Godex</a></li>


### PR DESCRIPTION
re-considered for listing after their monero swaps are operational again. currently under maintenance. 