### PR TITLE
resources/tools: replace txstreet link

### DIFF
--- a/resources/tools/index.md
+++ b/resources/tools/index.md
@@ -51,7 +51,7 @@ meta_descr: meta_descr.tools
                         <p><a href="https://nownodes.io/nodes/monero-xmr">NOWNodes - {% t tools.nownodes %}</a></p>
                         <p><a href="https://getblock.io">GetBlock - {% t tools.getblockio %}</a></p>
                         <p><a href="https://monero.fail/">Monero.fail - {% t tools.monerofail %}</a></p>
-                        <p><a href="https://txstreet.com/v/xmr">TxStreet - {% t tools.txstreet %}</a></p>
+                        <p><a href="https://tx.town/v/xmr">TxStreet - {% t tools.txstreet %}</a></p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
txstreet now community hosted, replaced the link with working instance.