### PR TITLE
moneropedia: update tail-emission

### DIFF
--- a/_i18n/en/resources/moneropedia/tail-emission.md
+++ b/_i18n/en/resources/moneropedia/tail-emission.md
@@ -7,7 +7,9 @@ summary: "the block reward at the end of the emission curve"
 
 ### The Basics
 
-Monero block rewards will never drop to zero. Block rewards will gradually drop until tail emission commences at the end of May 2022. At this point, rewards will be fixed at 0.6 XMR per block.
+Monero block rewards will never drop to zero. Block rewards gradually dropped until tail emission commenced at the end of May 2022. At this point, rewards will stay fixed at 0.6 XMR or less* per block.
+
+* Due to block size penalties.
 
 ### Why
 


### PR DESCRIPTION
* Update the content by mentioning tail emission is started
* Mention block reward can be less than 0.6 XMR due dynamic block size