### PR TITLE
_includes/header.html: liquid whitespace control

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -86,15 +86,15 @@
             <div class="topnav">
               <div class="row middle-xs">
                   <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4">
-                    <a href="{% if site.lang == 'en' %}
+                    <a href="{% if site.lang == 'en' -%}
                     
                     {{ site.baseurl_root }}/
                     
-                    {% else %}
+                    {%- else -%}
                     
                     {{ site.baseurl_root }}/{{site.lang}}
                     
-                    {% endif %}"><img src="/img/monero-logo.png" width="500" height="135" alt="Monero Logo" class="monero-logo"></a>
+                    {%- endif %}"><img src="/img/monero-logo.png" width="500" height="135" alt="Monero Logo" class="monero-logo"></a>
                   </div>
                   <div class="col-lg-8 col-md-8 col-sm-8 topnav-list end-xs">
                       <div class="row end-xs middle-xs">
@@ -175,15 +175,15 @@
         <div class="mob bot-nav white-nav">
             <div class="row center-xs middle-xs">
                 <div class="col-xs-6">
-                    <a href="{% if site.lang == 'en' %}
+                    <a href="{% if site.lang == 'en' -%}
                     
                     {{ site.baseurl_root }}/
                     
-                    {% else %}
+                    {%- else -%}
                     
                     {{ site.baseurl_root }}/{{site.lang}}
                     
-                    {% endif %}"><img src="/img/monero-logo.png" width="500" height="135" alt="Monero Logo" class="monero-logo"></a>
+                    {%- endif %}"><img src="/img/monero-logo.png" width="500" height="135" alt="Monero Logo" class="monero-logo"></a>
                 </div>
                 <div class="dropdown col-xs-6 text-center mob-language-change">
                 <input class="burger-checkdropdown" id="moblangdrop" type="checkbox" tabindex="0">


### PR DESCRIPTION
we're putting whitespace into the raw html files due to not using any [whitespace control](https://shopify.github.io/liquid/basics/whitespace/) in the liquid script which decides what locale to add to the homepage url.

This can effect plugins which parse/edit urls such as [jekyll-loading-lazy](https://github.com/monero-project/monero-site/issues/2235#issuecomment-2229061200) which we dont actually need but its just bad practice and could effect other plugins in the future.

if we inspect the monero logo / homepage shortcut in the header at getmonero.org we see:
![Screenshot from 2024-07-16 10-13-09](https://github.com/user-attachments/assets/165e4422-aa80-4c4e-a191-23d974331984)

with this change:
![Screenshot from 2024-07-16 10-29-01](https://github.com/user-attachments/assets/9c27b371-3865-401f-b26c-ce5d5ea40bcd)
