### PR TITLE
userguides: i2pzero migration

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -705,7 +705,7 @@ user-guides:
   ledger-wallet-cli: How to use a Ledger wallet on Monero CLI
   multisig-messaging-system: Multisig transactions with MMS and CLI wallet
   tor_wallet: How to connect your wallet to your own node over Tor
-  node-i2pzero: How to run a node through I2P with I2P-zero
+  node-tori2p: How to add Tor and I2P to your node
   guiguide: Guide for the Monero GUI wallet
   tailsguide: How to use Monero on Tails
   make-payment: How to make a payment

--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -110,7 +110,7 @@ meta_descr: meta_descr.userguides
                         <div class="col">
                             <h2>{% t user-guides.anonimizationnetworks %}</h2>
                             <p><a href="{{site.baseurl}}/resources/user-guides/tor_wallet.html">{% t user-guides.tor_wallet %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/node-i2p-zero.html">{% t user-guides.node-i2pzero %}</a></p>
+                            <p><a href="https://docs.getmonero.org/running-node/monerod-tori2p">{% t user-guides.node-tori2p %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/cli_wallet_daemon_isolation_qubes_whonix.html">{% t user-guides.qubes %}</a></p>
                             <p><a href="http://xmrguide25ibknxgaray5rqksrclddxqku3ggdcnzg4ogdi5qkdkd2yd.onion">{% t user-guides.tailsguide %}</a><img alt="onion logo" class="onion-mid" src="/img/onion-tor.svg" title="Onion link"/></p>
                         </div>

--- a/resources/user-guides/node-i2p-zero.md
+++ b/resources/user-guides/node-i2p-zero.md
@@ -3,6 +3,7 @@ layout: user-guide
 title: Run a Monero node through I2P with I2P-zero
 permalink: /resources/user-guides/node-i2p-zero.html
 outdated: False
+deprecated_url: https://docs.getmonero.org/running-node/monerod-tori2p/#__tabbed_1_2/
 ---
 
 {% t global.lang_tag %}


### PR DESCRIPTION
- replaces i2pzero guide with i2pd
- Includes tor p2p guide
- link directs to docs.getmonero.org

requires: https://github.com/monero-project/monero-docs/pull/66
closes: https://github.com/monero-project/monero-site/issues/2277