### PR TITLE
Add Monerica to merchant directory

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -17,6 +17,7 @@ meta_descr: merchants.descr
         <p>{% t merchants.dirdescr %}</p>
         <ul class="logo">
           <li><a href="https://cryptwerk.com/pay-with/xmr/">cryptwerk.com</a></li>
+          <li><a href="https://monerica.com">Monerica</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Monerica.com (started in January 2022) is a community maintained directory for Monero businesses and resources. Adding it as a resource to this section is of great value to the Monero community.