### PR TITLE
user guides: replace outdated how to run node guide

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -688,7 +688,7 @@ user-guides:
   hardwarewallet: Hardware Wallets
   anonimizationnetworks: Anonymizing Networks
   offline-backup: How to make an offline backup (advanced)
-  vps-node: How to run a node on VPS
+  vps-node: How to run a node (systemd)
   import-blockchain: How to import the Monero blockchain (advanced)
   monero-tools: Monero Tools
   purchasing-storing: How to create a Monero paper wallet

--- a/resources/user-guides/index.md
+++ b/resources/user-guides/index.md
@@ -52,7 +52,7 @@ meta_descr: meta_descr.userguides
                             <h2>{% t user-guides.nodesync %}</h2>
                             <p><a href="{{site.baseurl}}/resources/user-guides/remote_node_gui.html">{% t user-guides.remote-node-gui %}</a></p>
                             <p><a href="{{site.baseurl}}/resources/user-guides/importing_blockchain.html">{% t user-guides.import-blockchain %}</a></p>
-                            <p><a href="{{site.baseurl}}/resources/user-guides/vps_run_node.html">{% t user-guides.vps-node %}</a></p>
+                            <p><a href="https://docs.getmonero.org/running-node/monerod-systemd/" target="_blank">{% t user-guides.vps-node %}</a></p>
                         </div>
                     </div>
                 </div>

--- a/resources/user-guides/vps_run_node.md
+++ b/resources/user-guides/vps_run_node.md
@@ -2,7 +2,7 @@
 layout: user-guide
 title: "Monero tools"
 permalink: /resources/user-guides/vps_run_node.html
-outdated: False
+deprecated_url: https://docs.getmonero.org/running-node/monerod-systemd/
 ---
 {% t global.lang_tag %}
 <h1>{% t user-guides.vps-node %}</h1>


### PR DESCRIPTION
replace the outdated how to run guide with newer one at docs.getmonero.org