### PR TITLE
Fix typo

### DIFF
--- a/_i18n/en/resources/user-guides/securely_purchase.md
+++ b/_i18n/en/resources/user-guides/securely_purchase.md
@@ -35,7 +35,7 @@ Whichever method you chose, be sure there's no copy of the Monero wallet left ov
 Option to encrypt an XMR mnemonic seed: https://xmr.llcoins.net/  
 Download the html page and place it on your airgapped computer. Check the part "Encrypt/Decrypt Mnemonic Seed" and make sure you use "CN Add" with a decent password. Thanks manicminer5.
 
-## Step 3: Send your Moneroj to the paper wallet
+## Step 3: Send your Monero to the paper wallet
 
 Now that you have everything you need, you are ready to send your XMR to your paper wallet. Simply send the coins to the wallet address you noted earlier. Make sure the address is correct, even if you copy-pasted it! Remember that if you send the coins to a wrong address, there is no way to have them back!  
 


### PR DESCRIPTION
This patch replaces "Step 3: Send your Moneroj to the paper wallet" with "Step 3: Send your Monero to the paper wallet" in the english version of the "Securely purchasing and storing Monero" page of the website. (See before and after)

Before:
![image](https://github.com/user-attachments/assets/29ed2c6b-02c1-4f27-ab84-e5f9ff4a3c49)

After:
![image](https://github.com/user-attachments/assets/d4446988-ef2f-486f-9092-09a501e5d7db)
