### PR TITLE
Add ZENX to Swappers

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -110,6 +110,7 @@ meta_descr: merchants.descr
             <li><a href="https://majesticbank.sc/">MajesticBank</a></li>
             <li><a href="https://godex.io/">Godex</a></li>
             <li><a href="https://stealthex.io/">StealthEX</a></li>
+            <li><a href="https://zenx.ink/">ZENX</a></li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
Adds ZENX, a privacy-first, no-JavaScript, stateless Monero swap aggregator, to the Swappers section of the Merchants & Exchanges page for future consideration once it meets the community criteria. ZENX is actively operating and listed on other community resources like kycnot.me and Monerica. This PR is to get it on record and ready for inclusion when eligible. https://zenx.ink