### PR TITLE
Remove dead website communityworkgroup.org

### DIFF
--- a/community/workgroups/index.md
+++ b/community/workgroups/index.md
@@ -43,7 +43,6 @@ meta_descr: meta_descr.workgroups
           <h4>{% t team.contacts %}</h4>
           <ul class="logo">
             <li>{% t team.chat %} <code>#monero-community</code> <a class="chats-img" href="irc://irc.libera.chat/#monero-community"><img class="libera" src="/img/libera.svg" title="libera" alt="libera logo"></a> <a class="chats-img" href="https://matrix.to/#/%23monero-community:monero.social?via=matrix.org&via=monero.social"><img class="matrix" src="/img/matrix-logo.svg" title="Matrix" alt="Matrix logo"></a></li>
-            <li>{% t team.website %} <a href="https://www.communityworkgroup.org/">www.communityworkgroup.org</a></li>
           </ul>
           <div class="row center-xs icons">
             <a class="ext-noicon" href="https://repo.getmonero.org/monero-project/" target="_blank" rel="noreferrer, noopener" aria-label="Gitlab logo"><div class="col social-icon gitlab"></div></a><a class="ext-noicon" href="https://www.reddit.com/r/MoneroCommunity/" target="_blank" rel="noreferrer, noopener" aria-label="Reddit logo"><div class="col social-icon reddit"></div></a>


### PR DESCRIPTION
The linked site is dead. The [last time it was crawled by the Wayback Machine](https://web.archive.org/web/20250421084559/http://communityworkgroup.org/) (April 21, 2025) it was "available for sale".