### PR TITLE
Update links to documentation pages (monerod reference)

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -650,6 +650,8 @@ developer-guides:
   daemonrpc_descr: RPC calls for the @daemon. Including input, outputs and examples. In English.
   walletrpc: Wallet RPC
   walletrpc_descr: monero-wallet-rpc calls. Including input, outputs and examples. In English.
+  monerodref: Daemon configuration
+  monerodref_descr: monero daemon (monerod) configuarion reference. In English.
   external: External resources
   external_head: Useful docs and resources maintained by community members.
   monerodocs: Comprehensive resource which aims to organize the technical knowledge about Monero. Some sections might be outdated.

--- a/_i18n/en/resources/moneropedia/daemon.md
+++ b/_i18n/en/resources/moneropedia/daemon.md
@@ -13,7 +13,7 @@ It's possible to send commands to the Daemon directly or through the RPC interfa
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/resources/developer-guides/index.md
+++ b/resources/developer-guides/index.md
@@ -36,8 +36,6 @@ meta_descr: developer-guides.head
                         </div>
                     </div>
                     <p><i>{% t developer-guides.external_head %}</i></p>
-                    <h3><span class="icon-globe"></span><a href="https://monerodocs.org/">Monerodocs.org</a></h3>
-                        <p>{% t developer-guides.monerodocs %}</p>
                     <h3><a href="https://github.com/moneroexamples"><span class="icon-github"></span>Moneroexamples</a></h3>
                         <p>{% t developer-guides.moneroexamples %}</p>
                     <h3><a href="https://github.com/monero-ecosystem"><span class="icon-github"></span>Monero Ecosystem project</a></h3>

--- a/resources/developer-guides/index.md
+++ b/resources/developer-guides/index.md
@@ -24,6 +24,8 @@ meta_descr: developer-guides.head
                         <p>{% t developer-guides.daemonrpc_descr %}</p>
                     <h3><span class="icon-page"></span><a href="https://docs.getmonero.org/rpc-library/wallet-rpc/">{% t developer-guides.walletrpc %}</a></h3>
                         <p>{% t developer-guides.walletrpc_descr %}</p>
+                    <h3><span class="icon-page"></span><a href="https://docs.getmonero.org/interacting/monerod-reference/">{% t developer-guides.monerodref %}</a></h3>
+                        <p>{% t developer-guides.monerodref_descr %}</p>
                 </div>
             </div>
             <div class="right half no-pad-sm col-lg-6 col-md-6 col-sm-12 col-xs-12">


### PR DESCRIPTION
See also https://github.com/monero-project/monero-site/issues/2459 

- I removed the reference to monerodocs.org
- I added a link (in the style of Wallet RPC, ) to the page monerod config reference 
- I fixed the footnode here: https://www.getmonero.org/resources/moneropedia/daemon.html , so that it links to the docs page instead of monerodocs.org.

I hope this is useful, maybe it can be still improved a little by adding a general link to the docs above the "rpc documentation" header.