### PR TITLE
docs: monerodocs.org -> docs.getmonero.org

### DIFF
--- a/_i18n/ar/resources/moneropedia/daemon.md
+++ b/_i18n/ar/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/ar/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/ar/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/de/resources/moneropedia/daemon.md
+++ b/_i18n/de/resources/moneropedia/daemon.md
@@ -14,17 +14,16 @@ einem anderen Gerät läuft, handelt es sich um einen @Remote-Node. Ein
 Remote-) Node aufbauen, um dem Netzwerk Transaktionen zu übermitteln.
 
 Es ist möglich, dem Hintergrunddienst direkt oder via RPC Befehle zu
-senden. Die [Anleitung des Hintergrunddienst-RPCs]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html) enthält eine ausführliche
+senden. Die [Anleitung des Hintergrunddienst-RPCs](docs.getmonero.org/rpc-library/monerod-rpc/) enthält eine ausführliche
 (und mit Beispielen versehene) Erläuterung der verfügbaren RPC-Aufrufe. Für
 detailliertere und fachspezifische Informationen über den Hintergrunddienst
-findet sich unten ein Verweis auf Monerodocs.
+findet sich unten ein Verweis auf Monero Docs.
 
 ---
 
 ##### Zusätzliche Quellen
 
-<sub>1. Der [Monerod-Beitrag auf Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. Der [Monerod-Beitrag auf docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. "Hintergrunddienst"-Artikel [auf Wikipedia](https://de.wikipedia.org/wiki/Daemon)</sub><br>
 

--- a/_i18n/de/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/de/resources/moneropedia/weblate/daemon.po
@@ -43,8 +43,8 @@ msgstr "\"Hintergrunddienst\" ist der allgemeine Ausdruck für eine Software, we
 #
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
-msgstr "Es ist möglich, dem Hintergrunddienst direkt oder via RPC Befehle zu senden. Die [Anleitung des Hintergrunddienst-RPCs]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html) enthält eine ausführliche (und mit Beispielen versehene) Erläuterung der verfügbaren RPC-Aufrufe. Für detailliertere und fachspezifische Informationen über den Hintergrunddienst findet sich unten ein Verweis auf Monerodocs."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
+msgstr "Es ist möglich, dem Hintergrunddienst direkt oder via RPC Befehle zu senden. Die [Anleitung des Hintergrunddienst-RPCs](docs.getmonero.org/rpc-library/monerod-rpc/) enthält eine ausführliche (und mit Beispielen versehene) Erläuterung der verfügbaren RPC-Aufrufe. Für detailliertere und fachspezifische Informationen über den Hintergrunddienst findet sich unten ein Verweis auf Monero Docs."
 
 #. type: Title #####
 #: ../_i18n/en/resources/moneropedia/daemon.md:14
@@ -56,8 +56,8 @@ msgstr "Zusätzliche Quellen"
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
 
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
-msgstr "<sub>1. Der [Monerod-Beitrag auf Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
+msgstr "<sub>1. Der [Monerod-Beitrag auf docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:19

--- a/_i18n/en/resources/moneropedia/daemon.md
+++ b/_i18n/en/resources/moneropedia/daemon.md
@@ -7,13 +7,13 @@ summary: "Background process which runs and controls a Monero node"
 
 'Daemon' is the general term for a piece of software running in the background. In Monero, the Daemon is started through the 'monerod' program. If you run the Daemon locally, you are running a local @node. If the Daemon is running on another device it's a @remote-node. A @wallet, like the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay @transactions to the network.
 
-It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page.
+It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/en/resources/moneropedia/weblate/daemon.pot
+++ b/_i18n/en/resources/moneropedia/weblate/daemon.pot
@@ -43,7 +43,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
 #, markdown-text
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -55,7 +55,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, markdown-text, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/es/resources/moneropedia/daemon.md
+++ b/_i18n/es/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/es/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/es/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/fr/resources/moneropedia/daemon.md
+++ b/_i18n/fr/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/fr/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/fr/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/it/resources/moneropedia/daemon.md
+++ b/_i18n/it/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/it/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/it/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/nb-no/resources/moneropedia/daemon.md
+++ b/_i18n/nb-no/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ trenger å kobles til Daemon (lokalt eller eksternt) for å overbringe
 @transaksjoner til nettverket.
 
 Det er mulig å sende kommandoer til Daemon direkte eller gjennom
-RPC-grensesnittet. Se [Daemon RPC-guiden]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), som inneholder en detaljert
+RPC-grensesnittet. Se [Daemon RPC-guiden](docs.getmonero.org/rpc-library/monerod-rpc/), som inneholder en detaljert
 forklaring (med eksempler) på de tilgjengelige RPC-anropene. For mer
-detaljert og teknisk informasjon om Daemon, kan du se Monerodocs henvisning
+detaljert og teknisk informasjon om Daemon, kan du se Monero Docs henvisning
 nederst på denne siden.
 
 ---
 
 ##### Andre ressurser
 
-<sub>1. [monerods henvisning på Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. [monerods henvisning på docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon'-oppføring [på Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/nb-no/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/nb-no/resources/moneropedia/weblate/daemon.po
@@ -43,8 +43,8 @@ msgstr "'Daemon' er det generelle begrepet for programvare som kjører i bakgrun
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
 #
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
-msgstr "Det er mulig å sende kommandoer til Daemon direkte eller gjennom RPC-grensesnittet. Se [Daemon RPC-guiden]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), som inneholder en detaljert forklaring (med eksempler) på de tilgjengelige RPC-anropene. For mer detaljert og teknisk informasjon om Daemon, kan du se Monerodocs henvisning nederst på denne siden."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
+msgstr "Det er mulig å sende kommandoer til Daemon direkte eller gjennom RPC-grensesnittet. Se [Daemon RPC-guiden](docs.getmonero.org/rpc-library/monerod-rpc/), som inneholder en detaljert forklaring (med eksempler) på de tilgjengelige RPC-anropene. For mer detaljert og teknisk informasjon om Daemon, kan du se Monero Docs henvisning nederst på denne siden."
 
 #. type: Title #####
 #: ../_i18n/en/resources/moneropedia/daemon.md:14
@@ -55,8 +55,8 @@ msgstr "Andre ressurser"
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
-msgstr "<sub>1. [monerods henvisning på Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
+msgstr "<sub>1. [monerods henvisning på docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:19

--- a/_i18n/nl/resources/moneropedia/daemon.md
+++ b/_i18n/nl/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/nl/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/nl/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/pl/resources/moneropedia/daemon.md
+++ b/_i18n/pl/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/pl/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/pl/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/pt-br/resources/moneropedia/daemon.md
+++ b/_i18n/pt-br/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/pt-br/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/pt-br/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/ru/resources/moneropedia/daemon.md
+++ b/_i18n/ru/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/ru/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/ru/resources/moneropedia/weblate/daemon.po
@@ -51,13 +51,13 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 "Команды демону можно отправлять напрямую или через интерфейс RPC. См. ["
 "руководство по интерфейсу RPC демона]({{ site.baseurl_root }}/resources/"
 "developer-guides/daemon-rpc.html), в котором подробно разъясняются, а также "
 "приводятся примеры доступных команд RPC. Более подробную и техническую "
-"информацию по демону можно найти по ссылке Monerodocs внизу этой страницы."
+"информацию по демону можно найти по ссылке Monero Docs внизу этой страницы."
 
 #. type: Title #####
 #: ../_i18n/en/resources/moneropedia/daemon.md:14
@@ -68,10 +68,10 @@ msgstr "Другие источники"
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
-"<sub>1. [Ссылка на страницу monerod на веб-сайте Monerodocs."
-"org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+"<sub>1. [Ссылка на страницу monerod на веб-сайте Monero Docs."
+"org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:19

--- a/_i18n/tr/resources/moneropedia/daemon.md
+++ b/_i18n/tr/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/tr/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/tr/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/zh-cn/resources/moneropedia/daemon.md
+++ b/_i18n/zh-cn/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/zh-cn/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/zh-cn/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/_i18n/zh-tw/resources/moneropedia/daemon.md
+++ b/_i18n/zh-tw/resources/moneropedia/daemon.md
@@ -13,17 +13,16 @@ the CLI or the GUI, needs to connect to a Daemon (local or remote) to relay
 @transactions to the network.
 
 It's possible to send commands to the Daemon directly or through the RPC
-interface. See the [Daemon RPC guide]({{ site.baseurl_root
-}}/resources/developer-guides/daemon-rpc.html), which contains a detailed
+interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed
 explanation (with examples) of the available RPC calls. For more detailed
-and technical information about the Daemon, see the Monerodocs reference at
+and technical information about the Daemon, see the Monero Docs reference at
 the bottom of this page.
 
 ---
 
 ##### Other Resources
 
-<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>
+<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>
 
 <sub>2. 'Daemon' entry [on Wikipedia](https://en.wikipedia.org/wiki/Daemon_(computing))</sub><br>
 

--- a/_i18n/zh-tw/resources/moneropedia/weblate/daemon.po
+++ b/_i18n/zh-tw/resources/moneropedia/weblate/daemon.po
@@ -40,7 +40,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:11
-msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide]({{ site.baseurl_root }}/resources/developer-guides/daemon-rpc.html), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monerodocs reference at the bottom of this page."
+msgid "It's possible to send commands to the Daemon directly or through the RPC interface. See the [Daemon RPC guide](docs.getmonero.org/rpc-library/monerod-rpc/), which contains a detailed explanation (with examples) of the available RPC calls. For more detailed and technical information about the Daemon, see the Monero Docs reference at the bottom of this page."
 msgstr ""
 
 #. type: Title #####
@@ -52,7 +52,7 @@ msgstr ""
 #. type: Plain text
 #: ../_i18n/en/resources/moneropedia/daemon.md:17
 #, no-wrap
-msgid "<sub>1. The [monerod reference on Monerodocs.org](https://monerodocs.org/interacting/monerod-reference/)</sub><br>\n"
+msgid "<sub>1. The [monerod reference on docs.getmonero.org](https://docs.getmonero.org/interacting/monerod-reference/)</sub><br>\n"
 msgstr ""
 
 #. type: Plain text

--- a/resources/developer-guides/index.md
+++ b/resources/developer-guides/index.md
@@ -34,7 +34,7 @@ meta_descr: developer-guides.head
                         </div>
                     </div>
                     <p><i>{% t developer-guides.external_head %}</i></p>
-                    <h3><span class="icon-globe"></span><a href="https://monerodocs.org/">Monerodocs.org</a></h3>
+                    <h3><span class="icon-globe"></span><a href="https://docs.getmonero.org/">Monero Docs</a></h3>
                         <p>{% t developer-guides.monerodocs %}</p>
                     <h3><a href="https://github.com/moneroexamples"><span class="icon-github"></span>Moneroexamples</a></h3>
                         <p>{% t developer-guides.moneroexamples %}</p>


### PR DESCRIPTION
(should) replace all references to monerodocs[.org] with docs.getmonero.org, except for blog post announcement.

didn't use `{{ site.baseurl }}` because docs* isn't a part of this repo (and isnt deployed by netlify. aiui, using the macro would cause bad links on netlify preview.).

resolves: #2459 
related:
- #2514
- #2258 
