### PR TITLE
Safetrade

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -98,6 +98,7 @@ meta_descr: merchants.descr
             <li><a href="https://dvchain.co/">DV Chain (OTC)</a> (USD¹, CAD¹, GBP¹, EUR¹, JPY¹, ...)</li>
             <li><a href="https://www.bitfinex.com/">Bitfinex</a> (USD¹)</li>
             <li><a href="https://bitcoinvn.io?deposit=vnd&settle=xmr">BitcoinVN</a> (VND¹)</li>
+            <li><a href="https://safetrade.com/">Safetrade</a> (USD¹)</li>
           </ul>
           <p>¹ Fiat currency to Monero trading pair (e.g. XMR/USD, XMR/EUR)</p>
           <p>² XMR Unavailable for EEA Users</p>


### PR DESCRIPTION
Safetrade is a non-KYC exchange which has listed Monero for the last 2+ years and privacy coins for the last 7 years.