### PR TITLE
i18n: remove redundant localmonero translations

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -176,10 +176,8 @@ merchants:
   cardonion: 'Onion-Adresse:'
   noncustodial: 'Nicht-Custodial (ohne Vormundschaft):'
   depsell: Es kommt auf den Verkäufer an
-  locmondescr: Online-P2P-Börse für den Handel von Privat zu Privat.
   hodlhodldescr: P2P-Handelsplattform mit unpfändbarer Treuhand.
   visitbisq: Besuche Bisq
-  visitlocalmonero: Besuche LocalMonero
   visithodlhodl: Besuche HodlHodl
   cexp: Zentralisierte Börsen, die den Umtausch von Monero gegen nationale Währungen
     und Kryptowährungen anbieten.

--- a/_i18n/el.yml
+++ b/_i18n/el.yml
@@ -1332,13 +1332,10 @@ merchants:
   cardonion: 'Διεύθυνση Onion:'
   noncustodial: 'Non-custodial (χωρίς επιμέλεια):'
   hodlhodldescr: Πλατφόρμα συναλλαγών P2P με non-custodial (χωρίς επιμέλεια) escrow.
-  locmondescr: Διαδικτυακό ανταλλακτήριο P2P που προσφέρει συναλλαγές από άτομο σε
-    άτομο.
   depsell: Εξαρτάται από τον πωλητή
   locnojs: (αλλά δεν υπάρχει διαθέσιμη έκδοση JS)
   simpleswapdescr: Άμεση non-custodial (χωρίς επιμέλεια) συναλλαγή.
   visitbisq: Επισκεφθείτε το Bisq
-  visitlocalmonero: Επισκεφθείτε το LocalMonero
   visithodlhodl: Επισκεφθείτε το HodlHodl
   centrexchanges: Κεντροποιημένα ανταλλακτήρια (CEXs) & Swappers
   cexp: Κεντροποιημένα ανταλλακτήρια που προσφέρουν συναλλαγή Monero με εθνικά νομίσματα
@@ -1816,6 +1813,5 @@ tools:
   misc: Διάφορα
   moneropro: Γραφήματα και μετρικά στοιχεία
   monerobase: Αρχείο ορισμένων παλαιότερων ημερολογίων συνεδριάσεων
-  localmonero-blocks: Εξερευνητής και Στατιστικά
   monerohow-stats: Στατιστικά
   gateways: Πύλες πληρωμής

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -155,7 +155,6 @@ merchants:
   cardonion: "Onion address:"
   cardi2p: "I2P address:"
   noncustodial: "Non-custodial:"
-  locmondescr: Online P2P exchange offering person-to-person trades.
   depsell: Depends by the seller
   locnojs: (but no-JS version available)
   simpleswapdescr: Non-custodial instant exchange.

--- a/_i18n/eo.yml
+++ b/_i18n/eo.yml
@@ -189,13 +189,11 @@ merchants:
   cardonion: ".onion-a adreso:"
   noncustodial: "Ne-garda:"
   hodlhodldescr: 'P2P komercada platformo kun ne-garda depono.'
-  locmondescr: 'Reta P2P ŝanĝejo ofertanta interŝanĝojn inter homoj.'
   depsell: 'Dependas de la vendisto'
   locnojs: '(sed ne-JS versio disponebla)'
   simpleswapdescr: 'Ne-garda tuja ŝanĝejo.'
   disclaimer: |
   visitbisq: 'Vizitu Bisq-n'
-  visitlocalmonero: 'Vizitu LocalMonero-n'
   visithodlhodl: 'Vizitu HodlHodl-n'
   centrexchanges: 'Centraj ŝanĝejoj (CEXs) kaj interŝanĝejoj'
   centrexchangesp: 'Se vi preferas uzi centrajn ŝanĝejojn, jen estas listo de famaj
@@ -1037,7 +1035,6 @@ tools:
 
   network: ''
   monerohash-nodes: ''
-  localmonero-blocks: ''
   nownodes: ''
   getblockio: ''
   monerofail: ''

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -167,7 +167,6 @@ merchants:
   cardkyc: '<b>Sin KYC</b> (Conoce a tu cliente):'
   cardonion: 'Dirección Onion:'
   visitbisq: Visita Bisq
-  visitlocalmonero: Visita LocalMonero
   centrexchanges: Plataformas de intercambio centralizadas (CEXs) e Intercambiadores
   swappersp: Los intercambiadores permiten a los usuarios intercambiar XMR por otras
     criptomonedas.
@@ -196,8 +195,6 @@ merchants:
   locnojs: (pero no hay versión JS disponible)
   noncustodial: 'Sin custodia:'
   hodlhodldescr: Plataforma de intercambio Peer-to-Peer con fideicomiso sin custodia.
-  locmondescr: Plataforma de intercambios Peer to Peer en línea que ofrece intercambios
-    de persona a persona.
   simpleswapdescr: Plataforma de intercambio instantánea sin custodia.
   cardbtcfiat: (es posible BTC &#8596; fiat)
   swapsdescr: Una nueva y emocionante forma de intercambiar Monero son los Intercambios
@@ -1726,7 +1723,6 @@ tools:
   address-generators: Generadores de direcciones
   network: Red
   monerohash-nodes: Mapa de nodos de Monero
-  localmonero-blocks: Explorador y estadísticas
   nownodes: APIs de nodo
   monerofail: Lista de nodos de Monero y mapa de nodos
   txstreet: Visualizador de transacciones y bloques

--- a/_i18n/fi.yml
+++ b/_i18n/fi.yml
@@ -137,13 +137,11 @@ merchants:
   cardonion: ""
   noncustodial: ""
   hodlhodldescr: ''
-  locmondescr: ''
   depsell: ''
   locnojs: ''
   simpleswapdescr: ''
   disclaimer: |
   visitbisq: ''
-  visitlocalmonero: ''
   visithodlhodl: ''
   centrexchanges: ''
   centrexchangesp: ''
@@ -892,7 +890,6 @@ tools:
 
   network: ''
   monerohash-nodes: ''
-  localmonero-blocks: ''
   nownodes: ''
   getblockio: ''
   monerofail: ''

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -174,12 +174,10 @@ merchants:
   cardkyc: '<b>Pas de KYC</b> (Connaissez votre client) :'
   cardbtcfiat: (BTC &#8596; possibilité de fiat)
   cardonion: 'Adresse Onion :'
-  locmondescr: Bourse en ligne P2P offrant des trades de personne-à-personne.
   depsell: Dépend du vendeur
   locnojs: (Mais la version non-JS est disponible)
   simpleswapdescr: Plateforme d’échanges décentralisée.
   visitbisq: Visitez Bisq
-  visitlocalmonero: Visitez LocalMonero
   visithodlhodl: Visitez HodlHodl
   centrexchanges: Exchanges centralisés (CEXs) & Swappers
   centrexchangesp: Si vous préférez utiliser des exchanges centralisés, voilà une
@@ -1838,7 +1836,6 @@ tools:
   misc: Divers
   monerohow-stats: Statistiques
   block-explorers: Explorateurs de blocs
-  localmonero-blocks: Explorateur et statistiques
   nownodes: API de nœuds
   getblockio: Fournisseur de nœuds de blockchain
   txstreet: Visualisation des transactions et des blocs

--- a/_i18n/id.yml
+++ b/_i18n/id.yml
@@ -200,13 +200,11 @@ merchants:
   cardonion: "Alamat Onion:"
   noncustodial: "Non-kustodial:"
   hodlhodldescr: 'Platform perdagangan P2P dengan eskrow non-kustodial.'
-  locmondescr: 'Bursa pertukaran P2P Online menawarkan perdagangan pribadi-ke-pribadi.'
   depsell: 'Tergantung oleh penjual'
   locnojs: '(tetapi tidak tersedia versi tanpa-JS / tanpa-javascript)'
   simpleswapdescr: 'Bursa pertukaran instan non-kustodial.'
   disclaimer: |
   visitbisq: ''
-  visitlocalmonero: ''
   visithodlhodl: ''
   centrexchanges: ''
   centrexchangesp: ''
@@ -985,7 +983,6 @@ tools:
 
   network: ''
   monerohash-nodes: ''
-  localmonero-blocks: ''
   nownodes: ''
   getblockio: ''
   monerofail: ''

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -185,7 +185,6 @@ merchants:
     alcune opzioni. Ricorda sempre di applicare la massima cautela prima di affidare
     loro i tuoi soldi:'
   visitbisq: Visita Bisq
-  visitlocalmonero: Visita LocalMonero
 sponsorships:
   intro: Le seguenti aziende sostengono il progetto Monero nel suo obiettivo di portare
     la privacy finanziaria nel mondo. Non potremmo essere più grati per i loro contributi.

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -175,7 +175,6 @@ merchants:
     i pozwalają ludziom na pełną kontrolę nad swoimi monetami, jeśli są przeprowadzane
     niezależnie, ale zazwyczaj mają mniejszy wolumen niż "tradycyjne" giełdy. W poniższej
     sekcji przedstawiamy listę giełd P2P, które obsługują Monero.
-  visitlocalmonero: Odwiedź LocalMonero
   centrexchangesp: Jeśli wolisz korzystać z scentralizowanych giełd, tutaj znajduje
     się lista renomowanych CEX-ów i natychmiastowych wymieniaczy. Wiele więcej giełd
     wspiera Monero, my wymieniamy tutaj tylko kilka renomowanych.
@@ -195,7 +194,6 @@ merchants:
   cardonion: 'Adres onion:'
   noncustodial: 'Bez nadzoru:'
   hodlhodldescr: Platforma transakcyjna P2P z powiernictwem bez nadzoru.
-  locmondescr: Internetowa giełda P2P oferująca transakcje między osobami.
   depsell: Zależy od sprzedającego
   locnojs: (ale jest dostępna wersja bez JS)
   simpleswapdescr: Natychmiastowa giełda bez nadzoru.
@@ -1676,7 +1674,6 @@ tools:
   monerofail: Lista węzłów Monero i mapa węzłów
   getblockio: Dostawca węzłów Blockchain
   nownodes: interfejsy API węzłów
-  localmonero-blocks: Eksploratory i statystyki
   monerohash-nodes: Mapa węzłów Monero
   network: Sieć
   address-generators: Generatory adresów

--- a/_i18n/ro.yml
+++ b/_i18n/ro.yml
@@ -181,11 +181,9 @@ merchants:
   bisqdescr: Schimb valutar P2P descentralizat bazat pe Bitcoin și Tor.
   cardbtcfiat: (BTC &#8596; fiat posibil)
   hodlhodldescr: Platformă de tranzacționare P2P cu escrow noncustodial.
-  locmondescr: Schimb valutar online P2P care oferă tranzacții de la persoană la persoană.
   locnojs: (dar este disponibilă versiunea fără JS)
   simpleswapdescr: Schimb valutar instantaneu fără custodie.
   visitbisq: Vizitează Bisq
-  visitlocalmonero: Vizitează LocalMonero
   visithodlhodl: Vizitează HodlHodl
   centrexchanges: Schimburi de valută centralizate (CEX) și Swappers
   centrexchangesp: Dacă preferi să utilizezi schimburi valutare centralizate, iată
@@ -984,7 +982,6 @@ tools:
 
   network: ''
   monerohash-nodes: ''
-  localmonero-blocks: ''
   nownodes: ''
   getblockio: ''
   monerofail: ''

--- a/_i18n/ru.yml
+++ b/_i18n/ru.yml
@@ -198,11 +198,9 @@ merchants:
   cardonion: 'Onion адрес:'
   noncustodial: 'Некастодиальные:'
   hodlhodldescr: P2P торговая платформа с условно-некастодиальным депонированием.
-  locmondescr: P2P онлайн-обменник, предлагающий проведение индивидуальных сделок.
   depsell: Зависит от продавца
   locnojs: (доступна версия без JS)
   visitbisq: Посетить Bisq
-  visitlocalmonero: Посетить LocalMonero
   visithodlhodl: Посетить HodlHodl
   centrexchanges: Централизованные биржи (CEX) и обменники
   cexp: Централизованные биржи, предлагающие обмен Monero на национальные валюты и
@@ -1787,7 +1785,6 @@ tools:
   monerofail: Список и карта узлов Monero
   getblockio: Поставщик узлов блокчейна
   nownodes: API узла
-  localmonero-blocks: Проводник и статистика
   monerohash-nodes: Карта узлов Monero
   network: Сеть
   address-generators: Генератор адресов

--- a/_i18n/zh-cn.yml
+++ b/_i18n/zh-cn.yml
@@ -117,7 +117,6 @@ merchants:
   cardonion: '暗网地址:'
   noncustodial: '非托管的:'
   hodlhodldescr: 非托管式点对点交易所
-  locmondescr: 线上提供点对点交易的去中心化交易所
   centrexchangesp: 如果你喜欢中心化交易所，下面有一个主流交易所与互换商的列表。很多交易所都支持门罗币，我们在这里只列出一些比较有声誉的。
   cexp: 提供门罗币与其他加密货币或法币的交易的中心化交易所。
 sponsorships:

--- a/_i18n/zh-tw.yml
+++ b/_i18n/zh-tw.yml
@@ -108,7 +108,6 @@ merchants:
   cardfoss: '開放源碼:'
   depsell: 取決於賣家
   visitbisq: 造訪 Bisq
-  visitlocalmonero: 造訪 LocalMonero
   visithodlhodl: 造訪 HodlHodl
 sponsorships:
   intro: 下列商家支持門羅幣專案設立將達成世界金融隱私的目標，我們由衷地感激他們的貢獻。如果你也想要贊助門羅幣專案並被列在本頁清單，請電郵至 dev@getmonero.org。


### PR DESCRIPTION
They aren't used anymore. Furthermore, I don't see any reason to keep them.

LocalMonero was delisted in #2321 and it's been more than a year.