### PR TITLE
i18n: remove redundant hodlhodl translations

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -177,10 +177,8 @@ merchants:
   noncustodial: 'Nicht-Custodial (ohne Vormundschaft):'
   depsell: Es kommt auf den Verkäufer an
   locmondescr: Online-P2P-Börse für den Handel von Privat zu Privat.
-  hodlhodldescr: P2P-Handelsplattform mit unpfändbarer Treuhand.
   visitbisq: Besuche Bisq
   visitlocalmonero: Besuche LocalMonero
-  visithodlhodl: Besuche HodlHodl
   cexp: Zentralisierte Börsen, die den Umtausch von Monero gegen nationale Währungen
     und Kryptowährungen anbieten.
   descrp2p: Der beste Weg, Monero gegen andere Währungen zu tauschen (oder umgekehrt),

--- a/_i18n/el.yml
+++ b/_i18n/el.yml
@@ -1331,7 +1331,6 @@ merchants:
   cardbtcfiat: (BTC &#8596; παραστατικό χρήμα εφικτό)
   cardonion: 'Διεύθυνση Onion:'
   noncustodial: 'Non-custodial (χωρίς επιμέλεια):'
-  hodlhodldescr: Πλατφόρμα συναλλαγών P2P με non-custodial (χωρίς επιμέλεια) escrow.
   locmondescr: Διαδικτυακό ανταλλακτήριο P2P που προσφέρει συναλλαγές από άτομο σε
     άτομο.
   depsell: Εξαρτάται από τον πωλητή
@@ -1339,7 +1338,6 @@ merchants:
   simpleswapdescr: Άμεση non-custodial (χωρίς επιμέλεια) συναλλαγή.
   visitbisq: Επισκεφθείτε το Bisq
   visitlocalmonero: Επισκεφθείτε το LocalMonero
-  visithodlhodl: Επισκεφθείτε το HodlHodl
   centrexchanges: Κεντροποιημένα ανταλλακτήρια (CEXs) & Swappers
   cexp: Κεντροποιημένα ανταλλακτήρια που προσφέρουν συναλλαγή Monero με εθνικά νομίσματα
     και κρυπτονομίσματα.

--- a/_i18n/eo.yml
+++ b/_i18n/eo.yml
@@ -188,7 +188,6 @@ merchants:
   cardbtcfiat: '(BTC &#8596; fidmono eblas)'
   cardonion: ".onion-a adreso:"
   noncustodial: "Ne-garda:"
-  hodlhodldescr: 'P2P komercada platformo kun ne-garda depono.'
   locmondescr: 'Reta P2P ŝanĝejo ofertanta interŝanĝojn inter homoj.'
   depsell: 'Dependas de la vendisto'
   locnojs: '(sed ne-JS versio disponebla)'
@@ -196,7 +195,6 @@ merchants:
   disclaimer: |
   visitbisq: 'Vizitu Bisq-n'
   visitlocalmonero: 'Vizitu LocalMonero-n'
-  visithodlhodl: 'Vizitu HodlHodl-n'
   centrexchanges: 'Centraj ŝanĝejoj (CEXs) kaj interŝanĝejoj'
   centrexchangesp: 'Se vi preferas uzi centrajn ŝanĝejojn, jen estas listo de famaj
     centraj ŝanĝejoj kaj interŝanĝistoj. Multaj pli ŝanĝejoj subtenas Moneron, ni

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -187,7 +187,6 @@ merchants:
     siguiente, ofrecemos una lista de plataformas de intercambio Peer-to-Peer que
     soportan Monero.
   depsell: Depende del vendedor
-  visithodlhodl: Visita HodlHodl
   centrexchangesp: Si prefieres utilizar plataformas de intercambio centralizadas,
     aquí está una lista de CEXes e intercambiadores de renombre. Muchas más plataformas
     de intercambio soportan Monero, aquí listamos solo unas cuantas de renombre.
@@ -195,7 +194,6 @@ merchants:
     y criptomonedas.
   locnojs: (pero no hay versión JS disponible)
   noncustodial: 'Sin custodia:'
-  hodlhodldescr: Plataforma de intercambio Peer-to-Peer con fideicomiso sin custodia.
   locmondescr: Plataforma de intercambios Peer to Peer en línea que ofrece intercambios
     de persona a persona.
   simpleswapdescr: Plataforma de intercambio instantánea sin custodia.

--- a/_i18n/fi.yml
+++ b/_i18n/fi.yml
@@ -136,7 +136,6 @@ merchants:
   cardbtcfiat: ''
   cardonion: ""
   noncustodial: ""
-  hodlhodldescr: ''
   locmondescr: ''
   depsell: ''
   locnojs: ''
@@ -144,7 +143,6 @@ merchants:
   disclaimer: |
   visitbisq: ''
   visitlocalmonero: ''
-  visithodlhodl: ''
   centrexchanges: ''
   centrexchangesp: ''
   cexp: ''

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -180,7 +180,6 @@ merchants:
   simpleswapdescr: Plateforme d’échanges décentralisée.
   visitbisq: Visitez Bisq
   visitlocalmonero: Visitez LocalMonero
-  visithodlhodl: Visitez HodlHodl
   centrexchanges: Exchanges centralisés (CEXs) & Swappers
   centrexchangesp: Si vous préférez utiliser des exchanges centralisés, voilà une
     liste des CEXes et swappers renommés. De nombreux autres exchanges supportent
@@ -197,7 +196,6 @@ merchants:
     cesse de croître.
   cardfoss: 'Open source :'
   noncustodial: 'Non custodial:'
-  hodlhodldescr: Plateforme de trading P2P avec escrow non custodial.
   swapsdescr: Une nouvelle manière excitante d'échanger du Monero sont les Atomic
     Swaps, que <a href="https://www.getmonero.org/2021/08/20/atomic-swaps.html">nous
     avons annoncé</a> on Août 2021. Les Atomic Swaps sont une manière complétement

--- a/_i18n/id.yml
+++ b/_i18n/id.yml
@@ -199,7 +199,6 @@ merchants:
   cardbtcfiat: '(BTC &#8596; fiat dimungkinkan)'
   cardonion: "Alamat Onion:"
   noncustodial: "Non-kustodial:"
-  hodlhodldescr: 'Platform perdagangan P2P dengan eskrow non-kustodial.'
   locmondescr: 'Bursa pertukaran P2P Online menawarkan perdagangan pribadi-ke-pribadi.'
   depsell: 'Tergantung oleh penjual'
   locnojs: '(tetapi tidak tersedia versi tanpa-JS / tanpa-javascript)'
@@ -207,7 +206,6 @@ merchants:
   disclaimer: |
   visitbisq: ''
   visitlocalmonero: ''
-  visithodlhodl: ''
   centrexchanges: ''
   centrexchangesp: ''
   cexp: ''

--- a/_i18n/pl.yml
+++ b/_i18n/pl.yml
@@ -194,13 +194,11 @@ merchants:
   cardbtcfiat: (BTC &#8596; państwowe waluty możliwe)
   cardonion: 'Adres onion:'
   noncustodial: 'Bez nadzoru:'
-  hodlhodldescr: Platforma transakcyjna P2P z powiernictwem bez nadzoru.
   locmondescr: Internetowa giełda P2P oferująca transakcje między osobami.
   depsell: Zależy od sprzedającego
   locnojs: (ale jest dostępna wersja bez JS)
   simpleswapdescr: Natychmiastowa giełda bez nadzoru.
   visitbisq: Odwiedź Bisq
-  visithodlhodl: Odwiedź HodlHodl
   centrexchanges: Scentralizowane giełdy (CEXs) i natychmiastowi wymieniacze
   cexp: Scentralizowane giełdy, które oferują wymianę Monero na waluty krajowe i kryptowaluty.
   swappersp: Wymieniacze natychmiastowi pozwalają użytkownikom wymieniać XMR na inne

--- a/_i18n/ro.yml
+++ b/_i18n/ro.yml
@@ -180,13 +180,11 @@ merchants:
     vinde deja XMR pentru BTC folosind acest protocol la
   bisqdescr: Schimb valutar P2P descentralizat bazat pe Bitcoin și Tor.
   cardbtcfiat: (BTC &#8596; fiat posibil)
-  hodlhodldescr: Platformă de tranzacționare P2P cu escrow noncustodial.
   locmondescr: Schimb valutar online P2P care oferă tranzacții de la persoană la persoană.
   locnojs: (dar este disponibilă versiunea fără JS)
   simpleswapdescr: Schimb valutar instantaneu fără custodie.
   visitbisq: Vizitează Bisq
   visitlocalmonero: Vizitează LocalMonero
-  visithodlhodl: Vizitează HodlHodl
   centrexchanges: Schimburi de valută centralizate (CEX) și Swappers
   centrexchangesp: Dacă preferi să utilizezi schimburi valutare centralizate, iată
     o listă de CEX-uri și swappere renumite. Mai multe schimburi valutare acceptă

--- a/_i18n/ru.yml
+++ b/_i18n/ru.yml
@@ -197,13 +197,11 @@ merchants:
   cardbtcfiat: (BTC &#8596; с поддержкой фиатных валют)
   cardonion: 'Onion адрес:'
   noncustodial: 'Некастодиальные:'
-  hodlhodldescr: P2P торговая платформа с условно-некастодиальным депонированием.
   locmondescr: P2P онлайн-обменник, предлагающий проведение индивидуальных сделок.
   depsell: Зависит от продавца
   locnojs: (доступна версия без JS)
   visitbisq: Посетить Bisq
   visitlocalmonero: Посетить LocalMonero
-  visithodlhodl: Посетить HodlHodl
   centrexchanges: Централизованные биржи (CEX) и обменники
   cexp: Централизованные биржи, предлагающие обмен Monero на национальные валюты и
     криптовалюты.

--- a/_i18n/zh-cn.yml
+++ b/_i18n/zh-cn.yml
@@ -116,7 +116,6 @@ merchants:
   cardfoss: 开源：
   cardonion: '暗网地址:'
   noncustodial: '非托管的:'
-  hodlhodldescr: 非托管式点对点交易所
   locmondescr: 线上提供点对点交易的去中心化交易所
   centrexchangesp: 如果你喜欢中心化交易所，下面有一个主流交易所与互换商的列表。很多交易所都支持门罗币，我们在这里只列出一些比较有声誉的。
   cexp: 提供门罗币与其他加密货币或法币的交易的中心化交易所。

--- a/_i18n/zh-tw.yml
+++ b/_i18n/zh-tw.yml
@@ -109,7 +109,6 @@ merchants:
   depsell: 取決於賣家
   visitbisq: 造訪 Bisq
   visitlocalmonero: 造訪 LocalMonero
-  visithodlhodl: 造訪 HodlHodl
 sponsorships:
   intro: 下列商家支持門羅幣專案設立將達成世界金融隱私的目標，我們由衷地感激他們的貢獻。如果你也想要贊助門羅幣專案並被列在本頁清單，請電郵至 dev@getmonero.org。
 


### PR DESCRIPTION
Similar to #2549 but for HodlHodl. 

HodlHodl was delisted in #2426 and it's been 8 months.