### PR TITLE
.well-known: add flathub verification key for monero-gui

### DIFF
--- a/.well-known/org.flathub.VerifiedApps.txt
+++ b/.well-known/org.flathub.VerifiedApps.txt
@@ -1,0 +1,1 @@
+0a1ae4b2-3a4b-4f2d-bcd7-c9ff261e0f05

--- a/_config.yml
+++ b/_config.yml
@@ -53,3 +53,6 @@ sitemap:
         - "/ietemplates/poll5.xml"
         - "/feed.xml"
         - "/404.html"
+
+include:
+  - .well-known


### PR DESCRIPTION
resolves #2200 

https://deploy-preview-2572--barolo-time-757cf9.netlify.app/.well-known/org.flathub.VerifiedApps.txt

example of other projects key https://bitcoincore.org/.well-known/org.flathub.VerifiedApps.txt

which appears on flathub as https://flathub.org/en/apps/org.bitcoincore.bitcoin-qt

A note / disclaimer can be placed on the monero-gui flathub description to advice users on best practices reg confirming hashes, but this is something to take up in https://github.com/monero-project/monero-gui/pull/4231