### PR TITLE
Add XMR to USDC to swappers list

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -108,6 +108,7 @@ meta_descr: merchants.descr
             <li><a href="https://changenow.io/">ChangeNow</a></li>
             <li><a href="https://godex.io/">Godex</a></li>
             <li><a href="https://stealthex.io/">StealthEX</a></li>
+            <li><a href="https://xmrtousdc.xyz/">XMR to USDC</a></li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
This PR adds xmrtousdc.xyz to the list of cryptocurrency swappers on the Merchants & Services page.

**Service Details:**
- Name: XMR to USDC
- URL: https://xmrtousdc.xyz/
- Service Type: Non-custodial instant exchange
- Supported Pairs: XMR ↔ USDC
- No KYC required
- Fast, automated swaps

This service provides a privacy-focused way for users to exchange Monero for USDC and vice versa.