### PR TITLE
ci: bump checkout action to v6

### DIFF
--- a/.github/workflows/auto-updater.yaml
+++ b/.github/workflows/auto-updater.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Validate Auto Updater
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt -y install xvfb libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xkb1 libxcb-shape0 libxkbcommon-x11-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [ '2.7', '3.0.1' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/hashes.yaml
+++ b/.github/workflows/hashes.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Validate Hashes
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get install -y --no-install-recommends curl gpg jq python3-pip zbar-tools


### PR DESCRIPTION
validate hashes has v2 which has some scary warnings about deprecation so bumped em all while we're here
https://github.com/actions/checkout?tab=readme-ov-file#checkout-v6