### PR TITLE
ci: optimize CI, create source preparation script [beta]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,8 @@ jobs:
         run: pnpm check
 
   build:
-    name: Build
+    name: Build & Validate
     runs-on: ubuntu-22.04
-    needs: [lint]
 
     steps:
       - uses: actions/checkout@v6
@@ -65,45 +64,24 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-
-      - name: Install production dependencies
-        run: pnpm install --frozen-lockfile --prod
-
-      - name: Build site
-        run: pnpm build
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: site-build
-          path: dist/
-          retention-days: 1
-
-  validate:
-    name: Validate HTML
-    runs-on: ubuntu-22.04
-    needs: [build]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: site-build
-          path: dist/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Prepare source for CI build
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }} # PR target branch
+          BASE_REF: ${{ github.event_name == 'push' && github.event.before || '' }} # previous commit before the push event
+        run: |
+          ARGS="--limit-posts 10 --skip-og --limit-locales"
+          if [ -n "$BASE_BRANCH" ]; then ARGS="$ARGS --base-branch $BASE_BRANCH"; fi
+          if [ -n "$BASE_REF" ]; then ARGS="$ARGS --base-ref $BASE_REF"; fi
+          pnpm prepare-build $ARGS
+
+      - name: Build site
+        env:
+          SKIP_IMAGE_OPTIMIZATION: "true"
+        run: pnpm build
 
       - name: Validate built HTML
         run: pnpm exec htmlhint 'dist/**/*.html'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,13 @@ RUN pnpm install --frozen-lockfile
 
 # Prepare source
 FROM base AS src
-ARG LIMIT_POSTS
-COPY --from=deps /app/node_modules ./node_modules
+ARG PREPARE_BUILD_ARGS
+COPY --from=deps-dev /app/node_modules ./node_modules
 COPY . .
-RUN if [ -n "$LIMIT_POSTS" ]; then \
-      find src/content/blog -maxdepth 1 -name '[^_]*.md' | sort -r | tail -n +$((LIMIT_POSTS + 1)) | while IFS= read -r f; do rm -f "$f"; done; \
+RUN if [ -n "$PREPARE_BUILD_ARGS" ]; then \
+      pnpm prepare-build $PREPARE_BUILD_ARGS; \
     fi
+COPY --from=deps /app/node_modules ./node_modules
 
 # Build the site (static)
 FROM src AS build

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All commands are run from the root of the project:
 | :--------------------- | :----------------------------------------------- |
 | `pnpm install`         | Installs dependencies                            |
 | `pnpm dev`             | Starts local dev server at `localhost:4321`      |
+| `pnpm prepare-build`   | Trim sources before `pnpm build` (see below)     |
 | `pnpm build`           | Build your production site to `./dist/`          |
 | `pnpm preview`         | Preview your build locally, before deploying     |
 | `pnpm lint`            | Run ESLint to check for code issues              |
@@ -50,6 +51,31 @@ All commands are run from the root of the project:
 | `pnpm format`          | Format code using Prettier                       |
 | `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `pnpm astro -- --help` | Get help using the Astro CLI                     |
+
+## Prepare build
+
+It is possible to trim the source code before `pnpm build` to speed up preview deployments (fewer blog posts, fewer locales, no OG image generation).
+
+```bash
+pnpm prepare-build [flags]
+```
+
+Each flag has an env var equivalent, for build environments that don't accept CLI arguments.
+
+| Flag              | Env var              | Description                                               |
+| :---------------- | :------------------- | :-------------------------------------------------------- |
+| `--limit-posts N` | `LIMIT_POSTS=N`      | Keep only the N most recent blog posts                    |
+| `--skip-og`       | `SKIP_OG=true`       | Remove OpenGraph image generation                         |
+| `--limit-locales` | `LIMIT_LOCALES=true` | Build only the default locale (+ locales with PR changes) |
+
+Changed-file detection (pick one):
+
+| Flag                 | Env var            | Description                                              |
+| :------------------- | :----------------- | :------------------------------------------------------- |
+| `--base-branch NAME` | `BASE_BRANCH=NAME` | Branch to diff against via merge-base (for PRs/previews) |
+| `--base-ref SHA`     | `BASE_REF=SHA`     | SHA to diff against directly (for push events)           |
+
+`SKIP_PREPARE_BUILD=true` early-exits the script. Useful if you can't set a per-environment build command in your platform, and have to skip the script in production.
 
 ## Docker
 
@@ -110,13 +136,13 @@ Then open [http://127.0.0.1:4321](http://127.0.0.1:4321).
 
 ### Build args
 
-| Arg                        | Description                                         | Example |
-| :------------------------- | :-------------------------------------------------- | :------ |
-| `LIMIT_POSTS`              | Keep only the N most recent blog posts for previews | `6`     |
-| `SKIP_IMAGE_OPTIMIZATION`  | Disable image processing for faster builds          | `true`  |
+| Arg                        | Description                                          | Example                     |
+| :------------------------- | :--------------------------------------------------- | :-------------------------- |
+| `PREPARE_BUILD_ARGS`       | Flags for the [prepare-build](#prepare-build) script | `--limit-posts 6 --skip-og` |
+| `SKIP_IMAGE_OPTIMIZATION`  | Disable image processing for faster builds          | `true`                      |
 
 ```bash
-docker build --build-arg LIMIT_POSTS=6 --build-arg SKIP_IMAGE_OPTIMIZATION=true --target serve-ssr -t monero-site-ssr .
+docker build --build-arg PREPARE_BUILD_ARGS="--limit-posts 6 --skip-og" --build-arg SKIP_IMAGE_OPTIMIZATION=true --target serve-ssr -t monero-site-ssr .
 ```
 
 ## More

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:css": "stylelint \"src/**/*.{css,astro}\"",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prepare-build": "tsx scripts/prepare-build.ts"
   },
   "dependencies": {
     "@astrojs/node": "^9.5.4",

--- a/scripts/prepare-build.ts
+++ b/scripts/prepare-build.ts
@@ -1,0 +1,174 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+import { parseArgs } from "node:util";
+import { defaultLocale, locales, rtlLocales } from "../src/i18n/config";
+
+if (process.env.SKIP_PREPARE_BUILD === "true") {
+  console.log("Skipping: SKIP_PREPARE_BUILD is set");
+  process.exit(0);
+}
+
+const { values: args } = parseArgs({
+  options: {
+    "limit-posts": { type: "string" },
+    "skip-og": { type: "boolean", default: false },
+    "limit-locales": { type: "boolean", default: false },
+    "base-branch": { type: "string" },
+    "base-ref": { type: "string" },
+  },
+});
+
+const limitPosts = args["limit-posts"] ?? process.env.LIMIT_POSTS;
+const skipOg = args["skip-og"] || process.env.SKIP_OG === "true";
+const limitLocales =
+  args["limit-locales"] || process.env.LIMIT_LOCALES === "true";
+const baseBranch = args["base-branch"] ?? process.env.BASE_BRANCH;
+const baseRefArg = args["base-ref"] ?? process.env.BASE_REF;
+
+if (baseBranch && baseRefArg) {
+  console.error("Cannot use both --base-branch and --base-ref");
+  process.exit(1);
+}
+
+const BLOG_DIR = "src/content/blog";
+const OG_ROUTE = "src/pages/open-graph/[...route].ts";
+const I18N_CONFIG = "src/i18n/config.ts";
+const I18N_DIR = "src/i18n/translations";
+
+function git(...gitArgs: string[]): string {
+  return execFileSync("git", gitArgs, { encoding: "utf-8" }).trim();
+}
+
+function resolveRef(ref: string): string | undefined {
+  try {
+    return git("rev-parse", "--verify", ref);
+  } catch {
+    // ref not found, try fetching
+  }
+
+  const remote = git("remote").split("\n").filter(Boolean)[0];
+  if (!remote) return undefined;
+
+  try {
+    if (git("rev-parse", "--is-shallow-repository") === "true") {
+      git("fetch", "--unshallow", remote);
+    }
+
+    git("fetch", remote, ref);
+    return "FETCH_HEAD";
+  } catch {
+    return undefined;
+  }
+}
+
+function getChangedFiles(
+  ref: string,
+  useMergeBase: boolean,
+  ...dirs: string[]
+): string[] {
+  const resolved = resolveRef(ref);
+  if (!resolved) return [];
+
+  try {
+    return git(
+      "diff",
+      "--name-only",
+      ...(useMergeBase ? ["--merge-base"] : []),
+      resolved,
+      "HEAD",
+      "--",
+      ...dirs,
+    )
+      .split("\n")
+      .filter(Boolean);
+  } catch (e) {
+    console.warn("Could not detect changed files");
+    console.warn(e instanceof Error ? e.message : e);
+    return [];
+  }
+}
+
+function changedFilesUnder(dir: string): string[] {
+  return changed.filter((f) => f.startsWith(dir + "/"));
+}
+
+function serializeI18nConfig(activeLocales: Set<string>): string {
+  const entries = Object.entries(locales)
+    .filter(([key]) => activeLocales.has(key))
+    .map(([key, val]) => `  ${key}: "${val}",`);
+
+  const rtl = rtlLocales.map((l) => `"${l}"`).join(", ");
+
+  return [
+    `export const defaultLocale = "${defaultLocale}";`,
+    "export const locales = {",
+    ...entries,
+    "};",
+    `export const rtlLocales = [${rtl}];`,
+    "",
+  ].join("\n");
+}
+
+const baseRef = baseBranch ?? baseRefArg;
+const useMergeBase = Boolean(baseBranch);
+
+let changed: string[] = [];
+if (baseRef) {
+  const mode = useMergeBase ? "merge-base" : "direct";
+  console.log(`Diff: ${mode} against ${baseRef}`);
+  changed = getChangedFiles(baseRef, useMergeBase, BLOG_DIR, I18N_DIR);
+  console.log(
+    `Diff: ${changed.length} file${changed.length !== 1 ? "s" : ""} changed`,
+  );
+} else {
+  console.log("Diff: skipped");
+}
+
+// Limit blog posts, keeping edited ones
+if (limitPosts) {
+  const limit = Number(limitPosts);
+  if (!Number.isFinite(limit) || limit < 1) {
+    console.error(`Invalid --limit-posts value: ${limitPosts}`);
+    process.exit(1);
+  }
+
+  const isPost = (f: string) => /^\d/.test(f) && f.endsWith(".md");
+
+  const allPosts = readdirSync(BLOG_DIR).filter(isPost).sort().reverse();
+  const keep = new Set(allPosts.slice(0, limit));
+
+  for (const file of changedFilesUnder(BLOG_DIR)) {
+    if (isPost(basename(file))) keep.add(basename(file));
+  }
+
+  let removed = 0;
+  for (const file of allPosts) {
+    if (keep.has(file)) continue;
+    rmSync(join(BLOG_DIR, file));
+    removed++;
+  }
+
+  console.log(
+    `Blog: kept ${allPosts.length - removed} of ${allPosts.length} posts`,
+  );
+}
+
+// Limit locales
+if (limitLocales) {
+  const keepLocales = new Set([defaultLocale]);
+
+  for (const file of changedFilesUnder(I18N_DIR)) {
+    const locale = relative(I18N_DIR, file).split("/")[0];
+    if (locale && locale !== defaultLocale) keepLocales.add(locale);
+  }
+
+  writeFileSync(I18N_CONFIG, serializeI18nConfig(keepLocales));
+  console.log(`Locales: building ${Array.from(keepLocales).join(" ")}`);
+}
+
+// OpenGraph removal
+if (skipOg) {
+  rmSync(OG_ROUTE, { force: true });
+  console.log(`OpenGraph: removed ${OG_ROUTE}`);
+}


### PR DESCRIPTION
Closes #2610 

### Changes
Seperate Build / Validate jobs into a single Build & Validate job, skipping upload step

Run build / lint in parallel to each other

Adds a prepare script that CI uses to do the following:
- Disable OpenGraph thumbnail generation
- Keep up to N recent blog posts (including any edited ones from the past), set to 10 currently
- Only render default + edited locales

CI also additionaly disables image optimization seperately