### PR TITLE
ci download-hashes: pin torrent versions to cli [beta]

### DIFF
--- a/.github/workflows/download-hashes.yml
+++ b/.github/workflows/download-hashes.yml
@@ -264,36 +264,34 @@ jobs:
           CDN_CLI_URL="https://github.com/plowsof/monero-torrent/releases/download/${version_cli}/monero-${version_cli}.torrent"
           CDN_GUI_URL="https://github.com/plowsof/monero-torrent/releases/download/${version_cli}/monero-gui-${version_gui}.torrent"
 
-          CDN_AVAILABLE=true
           if ! wget --spider -q "$CDN_CLI_URL" || ! wget --spider -q "$CDN_GUI_URL"; then
-            echo "::warning title=CDN-Torrents::CDN torrent files not available yet, skipping comparison"
-            CDN_AVAILABLE=false
+            echo "::warning title=CDN-Torrents::CDN torrent files not available yet, unable to verify"
+            exit 1
           fi
 
-          if [ "$CDN_AVAILABLE" = true ]; then
-            wget -q "$CDN_CLI_URL" -O "monero-${version_cli}.torrent"
-            wget -q "$CDN_GUI_URL" -O "monero-gui-${version_gui}.torrent"
+          wget -q "$CDN_CLI_URL" -O "monero-${version_cli}.torrent"
+          wget -q "$CDN_GUI_URL" -O "monero-gui-${version_gui}.torrent"
 
-            CDN_MAGNET_LINK_CLI="$(transmission-show -m "monero-${version_cli}.torrent")"
-            CDN_MAGNET_LINK_GUI="$(transmission-show -m "monero-gui-${version_gui}.torrent")"
+          CDN_MAGNET_LINK_CLI="$(transmission-show -m "monero-${version_cli}.torrent")"
+          CDN_MAGNET_LINK_GUI="$(transmission-show -m "monero-gui-${version_gui}.torrent")"
 
-            # Compare local vs CDN magnets
-            if [ "$MAGNET_LINK_CLI" != "$CDN_MAGNET_LINK_CLI" ]; then
-              echo "CLI torrent magnet mismatch between local build and CDN version" >&2
-              echo "Local: $MAGNET_LINK_CLI" >&2
-              echo "CDN : $CDN_MAGNET_LINK_CLI" >&2
-              exit 1
-            fi
-
-            if [ "$MAGNET_LINK_GUI" != "$CDN_MAGNET_LINK_GUI" ]; then
-              echo "GUI torrent magnet mismatch between local build and CDN version" >&2
-              echo "Local: $MAGNET_LINK_GUI" >&2
-              echo "CDN : $CDN_MAGNET_LINK_GUI" >&2
-              exit 1
-            fi
-
-            echo "Torrent files and magnet links match local build and CDN."
+          # Compare local vs CDN magnets
+          if [ "$MAGNET_LINK_CLI" != "$CDN_MAGNET_LINK_CLI" ]; then
+            echo "CLI torrent magnet mismatch between local build and CDN version" >&2
+            echo "Local: $MAGNET_LINK_CLI" >&2
+            echo "CDN : $CDN_MAGNET_LINK_CLI" >&2
+            exit 1
           fi
+
+          if [ "$MAGNET_LINK_GUI" != "$CDN_MAGNET_LINK_GUI" ]; then
+            echo "GUI torrent magnet mismatch between local build and CDN version" >&2
+            echo "Local: $MAGNET_LINK_GUI" >&2
+            echo "CDN : $CDN_MAGNET_LINK_GUI" >&2
+            exit 1
+          fi
+
+          echo "Torrent files and magnet links match local build and CDN."
+
           echo "magnet_gui=$MAGNET_LINK_GUI" >> $GITHUB_OUTPUT
           echo "magnet_cli=$MAGNET_LINK_CLI" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/download-hashes.yml
+++ b/.github/workflows/download-hashes.yml
@@ -262,7 +262,7 @@ jobs:
 
           # Download torrents from CDN (replace with the monero URLs)
           CDN_CLI_URL="https://github.com/plowsof/monero-torrent/releases/download/${version_cli}/monero-${version_cli}.torrent"
-          CDN_GUI_URL="https://github.com/plowsof/monero-torrent/releases/download/${version_gui}/monero-gui-${version_gui}.torrent"
+          CDN_GUI_URL="https://github.com/plowsof/monero-torrent/releases/download/${version_cli}/monero-gui-${version_gui}.torrent"
 
           CDN_AVAILABLE=true
           if ! wget --spider -q "$CDN_CLI_URL" || ! wget --spider -q "$CDN_GUI_URL"; then


### PR DESCRIPTION
torrent [releases](https://github.com/plowsof/monero-torrent/releases) are tagged using the cli version so for the previous release we have:

https://github.com/plowsof/monero-torrent/releases/download/v0.18.4.6/monero-gui-v0.18.4.7.torrent
https://github.com/plowsof/monero-torrent/releases/download/v0.18.4.6/monero-v0.18.4.6.torrent