### PR TITLE
sitemap_generator: use File.exist? (removed in Ruby 3.2)

### DIFF
--- a/_plugins/sitemap_generator.rb
+++ b/_plugins/sitemap_generator.rb
@@ -126,7 +126,7 @@ module Jekyll
     def fill_pages(site, urlset)
       site.pages.each do |page|
         if !excluded?(site, page.path_to_source)
-          if File.exists?(page.path)
+          if File.exist?(page.path)
             url = fill_url(site, page)
             urlset.add_element(url)
           end


### PR DESCRIPTION
File.exists? has been deprecated since Ruby 2.1 and was removed in Ruby 3.2, causing 'bundle exec jekyll serve' to fail with NoMethodError on any contributor's machine running a current Ruby. The Netlify build is still pinned to Ruby 2.7.1 so production is unaffected, but local development on modern Ruby is broken without this one-character fix.