### PR TITLE
ui/components: add PreviewBanner with commit hash for coolify [beta]

### DIFF
--- a/src/components/ui/PreviewBanner.astro
+++ b/src/components/ui/PreviewBanner.astro
@@ -1,0 +1,35 @@
+---
+const isCoolifyPreview = import.meta.env.COOLIFY_PREVIEW;
+const sourceCommit = import.meta.env.SOURCE_COMMIT;
+const coolifyBranch = import.meta.env.COOLIFY_BRANCH; // "pull/2639/head:pr-2639-coolify",
+const coolifyRepo = import.meta.env.COOLIFY_REPO;
+if (!isCoolifyPreview) return;
+const coolifyPrNum = coolifyBranch.split("/")[1];
+---
+
+<div class="preview-banner">
+  <span class="preview-banner-style">
+    <a href={`${coolifyRepo}/pull/${coolifyPrNum}/changes/${sourceCommit}`}
+      >{sourceCommit.slice(0, 7)}</a
+    > Preview powered by <a href="https://coolify.io/">Coolify</a>
+  </span>
+</div>
+
+<style>
+  .preview-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    z-index: 999;
+  }
+
+  .preview-banner-style {
+    display: inline-block;
+    background: black;
+    color: white;
+    padding: var(--space-2xs) var(--space-md);
+    border-radius: var(--radius-md);
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import PreviewBanner from "@/components/ui/PreviewBanner.astro";
 import Footer from "@/components/ui/Footer.astro";
 import Header from "@/components/ui/header/Header.astro";
 import { locales } from "@/i18n/config";
@@ -130,6 +131,7 @@ const fullTitle = title.includes("|")
       <slot />
     </main>
     <Footer />
+    <PreviewBanner />
   </body>
 </html>
 


### PR DESCRIPTION
coolify sets `SOURCE_COMMIT` env var by default. I have manually set the env `COOLIFY_PREVIEW` to `true` for preview deploys, but not for production

styles can be added e.g. background colour 

the variable can/should be generic?  i seen a nice looking default var called `NODE_ENV` but coolify has this set to `production` in both deploy and previews 

proof of concept to show the commit hash on previews

- linting todo