### PR TITLE
merchants: add ghostswap.io to swappers

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -127,6 +127,7 @@ meta_descr: merchants.descr
         <h3>Swappers</h3>
         <p>{% t merchants.swappersp %}</p>
         <ul class="logo">
+            <li><a href="https://ghostswap.io/">GhostSwap</a></li>
             <li><a href="https://simpleswap.io/">SimpleSwap</a></li>
             <li><a href="https://changenow.io/">ChangeNow</a></li>
             <li><a href="https://godex.io/">Godex</a></li>


### PR DESCRIPTION
Proposing the addition of GhostSwap to the Swappers section of the Merchants & Exchanges page.

GhostSwap is a non-custodial cryptocurrency swap service. Funds route directly between the user's sending wallet and the destination address through aggregated liquidity providers.

Properties relevant to this section:

- No account, email, or KYC required to swap.
- No IP gating or geographic restrictions; usable over Tor and VPN.
- Full XMR support in both directions. BTC↔XMR and ETH↔XMR are among the most-used pairs.
- ZEC and DASH supported in both directions.
- Public API and a Telegram bot are available for users who prefer those interfaces.
- Third-party coverage: CryptoNews, 99Bitcoins, CoinGape, Coinspeaker.

Happy to answer reviewer questions, clarify any of the above, or provide test swap IDs on request.