### PR TITLE
ci: confirm dist archive is reproducible [beta]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Prepare source for CI/Release build
         env:
-          BASE_BRANCH: ${{ github.event_name != 'release' && github.event.pull_request.base.ref || '' }}  # PR target branch
+          BASE_BRANCH: ${{ github.event_name != 'release' && github.event.pull_request.base.ref || '' }} # PR target branch
           BASE_REF: ${{ github.event_name == 'push' && github.event.before || '' }} # previous commit before the push event
           LIMIT_POSTS: ${{ github.event_name != 'release' && '10' || '' }}
           SKIP_IMAGE_OPTIMIZATION: ${{ github.event_name != 'release' && 'true' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [beta]
   pull_request:
     branches: [beta]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -12,6 +14,7 @@ permissions:
 jobs:
   lint:
     name: Lint & Format
+    if: github.event_name != 'release' || github.event.release.target_commitish == 'beta'
     runs-on: ubuntu-22.04
 
     steps:
@@ -26,7 +29,7 @@ jobs:
           echo "All set:html usages are safe"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -49,15 +52,22 @@ jobs:
       - name: Type check
         run: pnpm check
 
-  build:
-    name: Build & Validate
+  reproducible-archive:
+    name: Reproducible Archive (Run ${{ matrix.run }})
+    if: github.event_name != 'release' || github.event.release.target_commitish == 'beta'
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        run: [1, 2]
+    outputs:
+      hash-1: ${{ steps.hash.outputs.hash-1 }}
+      hash-2: ${{ steps.hash.outputs.hash-2 }}
 
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -68,20 +78,69 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Prepare source for CI build
+      - name: Prepare source for CI/Release build
         env:
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }} # PR target branch
+          BASE_BRANCH: ${{ github.event_name != 'release' && github.event.pull_request.base.ref || '' }}  # PR target branch
           BASE_REF: ${{ github.event_name == 'push' && github.event.before || '' }} # previous commit before the push event
+          LIMIT_POSTS: ${{ github.event_name != 'release' && '10' || '' }}
+          SKIP_IMAGE_OPTIMIZATION: ${{ github.event_name != 'release' && 'true' || '' }}
+          SKIP_OG: ${{ github.event_name != 'release' && 'true' || '' }}
+          LIMIT_LOCALES: ${{ github.event_name != 'release' && 'true' || '' }}
+        run: pnpm prepare-build && pnpm build
+
+      - name: Create archive
         run: |
-          ARGS="--limit-posts 10 --skip-og --limit-locales"
-          if [ -n "$BASE_BRANCH" ]; then ARGS="$ARGS --base-branch $BASE_BRANCH"; fi
-          if [ -n "$BASE_REF" ]; then ARGS="$ARGS --base-ref $BASE_REF"; fi
-          pnpm prepare-build $ARGS
+          tar \
+            --sort=name \
+            --mtime='@0' \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            --mode='u=rwX,go=rX' \
+            -czf dist.tar.gz dist/
 
-      - name: Build site
-        env:
-          SKIP_IMAGE_OPTIMIZATION: "true"
-        run: pnpm build
+      - name: Hash archive
+        id: hash
+        run: |
+          HASH=$(sha256sum dist.tar.gz | awk '{print $1}')
+          echo "hash-${{ matrix.run }}=$HASH" >> $GITHUB_OUTPUT
 
-      - name: Validate built HTML
-        run: pnpm exec htmlhint 'dist/**/*.html'
+      - name: Upload archive
+        if: github.event_name == 'release' && matrix.run == 1
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-dist-archive
+          path: dist.tar.gz
+
+  compare-archives:
+    name: Compare hashes
+    if: github.event_name != 'release' || github.event.release.target_commitish == 'beta'
+    runs-on: ubuntu-22.04
+    needs: reproducible-archive
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Compare
+        run: |
+          HASH1="${{ needs.reproducible-archive.outputs.hash-1 }}"
+          HASH2="${{ needs.reproducible-archive.outputs.hash-2 }}"
+          if [ "$HASH1" = "$HASH2" ]; then
+            echo "hashes match."
+          else
+            echo "hash mismatch."
+            exit 1
+          fi
+
+      - name: Download release archive
+        if: github.event_name == 'release'
+        uses: actions/download-artifact@v8
+        with:
+          name: deploy-dist-archive
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist.tar.gz


### PR DESCRIPTION
compare zipped archive hash of dist folder between 2 separate workflow runs upload archive on release
use env variables for consistency
bump actions
only run on beta releases

with this the build runs twice in parallel always. for push/pr optimised ENV variables are set as usual. for release these are not set and the dist folder archive is uploaded there as an artifact.
