### PR TITLE
deps: upgrade to pnpm 11 [beta]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ WORKDIR /app
 
 # Install production dependencies
 FROM base AS deps
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
 # Install all dependencies
 FROM base AS deps-dev
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Prepare source

--- a/docs/how-to-set-up-the-development-environment.md
+++ b/docs/how-to-set-up-the-development-environment.md
@@ -5,13 +5,13 @@ Quick, minimal steps to get the site running locally so you can start contributi
 ## Requirements
 
 - Node.js 22 (LTS) or higher - use a version manager like [fnm](https://fnm.vercel.app/).
-- pnpm (recommended, project uses pnpm@10+) - install with `corepack enable pnpm` or `npm install -g pnpm`.
+- pnpm (recommended, project uses pnpm@11+) - install with `corepack enable pnpm` or `npm install -g pnpm`.
 - Git – for cloning and PRs.
 
 Verify:
 ```bash
 node --version   # 22+
-pnpm --version   # 10+
+pnpm --version   # 11+
 git --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sharp": "^0.34.5",
     "unist-util-visit": "^5.1.0"
   },
-  "packageManager": "pnpm@10.30.1",
+  "packageManager": "pnpm@11.4.0",
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "@eslint/js": "^9.39.3",
@@ -67,10 +67,5 @@
     "typescript-eslint": "^8.56.1",
     "unified": "^11.0.5",
     "vfile": "^6.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sharp": "^0.34.5",
     "unist-util-visit": "^5.1.0"
   },
-  "packageManager": "pnpm@10.30.1",
+  "packageManager": "pnpm@11.1.1",
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "@eslint/js": "^9.39.3",
@@ -67,10 +67,5 @@
     "typescript-eslint": "^8.56.1",
     "unified": "^11.0.5",
     "vfile": "^6.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  lefthook: true
+  esbuild: false
+  "@parcel/watcher": false
+  sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
   lefthook: true
   esbuild: false
-  '@parcel/watcher': false
+  "@parcel/watcher": false
   sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  lefthook: true
+  esbuild: false
+  '@parcel/watcher': false
+  sharp: false


### PR DESCRIPTION
- New versions are quarantined for 24h before being resolved
- Dependencies can no longer pull sub-dependencies from random git or tarball URLs, only the npm registry
- Migrates `onlyBuiltDependencies` -> `allowBuilds` in the new `pnpm-workspace.yaml`