### PR TITLE
moneropedia: append .html to unlocktime deprecated url

### DIFF
--- a/resources/moneropedia/unlocktime.md
+++ b/resources/moneropedia/unlocktime.md
@@ -4,7 +4,7 @@ title: titles.moneropedia
 entry: moneropedia.entries.unlocktime
 warning_title: Deprecated
 warning_body: This feature is set to be deprecated at consensus with FCMP++. See the blog post for more information
-warning_url: https://getmonero.org/2026/05/10/deprecating-unlock-time
+warning_url: https://getmonero.org/2026/05/10/deprecating-unlock-time.html
 warning_url_label: Deprecating Monero's Custom Transaction Unlock Time
 ---
 


### PR DESCRIPTION
*still an issue of .html being stripped. i will circle back to this

it worked fine locally so i assumed it was a problem on netlifys end 