### PR TITLE
Add El Capo to Swappers list

### DIFF
--- a/community/merchants/index.md
+++ b/community/merchants/index.md
@@ -131,6 +131,7 @@ meta_descr: merchants.descr
             <li><a href="https://changenow.io/">ChangeNow</a></li>
             <li><a href="https://godex.io/">Godex</a></li>
             <li><a href="https://stealthex.io/">StealthEX</a></li>
+            <li><a href="https://elcapo.io/">El Capo</a></li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
Adds El Capo (https://elcapo.io/) to the Swappers section.

El Capo is a no-KYC, no-registration instant crypto exchange with strong Monero support (BTC, ETH, USDT, SOL and more to/from XMR). No account or personal data required, and a full Tor .onion mirror is available. Same category as the swappers already listed (SimpleSwap, ChangeNow, Godex, StealthEX)