### PR TITLE
index: center the mark behind the hero

### DIFF
--- a/src/components/pages/index/Hero.astro
+++ b/src/components/pages/index/Hero.astro
@@ -109,7 +109,9 @@ const { t, localizeHref } = Astro.locals;
 
   .background-logo {
     position: absolute;
-    inset: 0;
+    inset-block-start: 0;
+    inset-inline: 0;
+    block-size: 100dvh;
     display: grid;
     place-items: center;
     pointer-events: none;
@@ -117,16 +119,9 @@ const { t, localizeHref } = Astro.locals;
   }
 
   .logo-box {
-    inline-size: min(100cqw, 100cqh);
+    inline-size: min(100cqw, 85cqh);
     aspect-ratio: 1 / 1;
     position: relative;
-  }
-
-  @supports not (width: 100cqw) {
-    .logo-box {
-      inline-size: min(90vmin, 100%);
-      aspect-ratio: 1 / 1;
-    }
   }
 
   .mask-icon {

--- a/src/components/ui/header/Header.astro
+++ b/src/components/ui/header/Header.astro
@@ -97,6 +97,7 @@ const navItems = navigationItems.map((item) => {
 <style>
   :root {
     --drawer-gap: clamp(5rem, 20vw, 9rem);
+    --header-overlay: var(--header-height);
   }
 
   .header {
@@ -113,6 +114,8 @@ const navItems = navigationItems.map((item) => {
     align-items: center;
     gap: var(--space-sm);
     padding: var(--space-md);
+    box-sizing: border-box;
+    block-size: var(--header-height);
   }
 
   .brand {
@@ -264,6 +267,10 @@ const navItems = navigationItems.map((item) => {
   }
 
   @media (width >= 1200px) and (hover: hover) {
+    :root {
+      --header-overlay: 0px;
+    }
+
     .header {
       position: relative;
       background: unset;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -126,16 +126,6 @@ const { t, localizeHref } = Astro.locals;
 </Layout>
 
 <style>
-  :root {
-    --hero-min-height: calc(75vh + 3rem);
-  }
-
-  @supports (height: 100dvh) {
-    :root {
-      --hero-min-height: calc(75dvh + 3rem);
-    }
-  }
-
   h2 {
     font-size: var(--font-size-3xl);
     color: var(--heading-color);
@@ -162,29 +152,18 @@ const { t, localizeHref } = Astro.locals;
     mask-image: radial-gradient(ellipse at center, black 60%, transparent 100%);
   }
 
-  .main-content {
-    position: relative;
-    margin-top: calc(
-      var(--hero-min-height) - var(--page-top-margin)
-    ) !important;
-  }
-
   .index-hero {
-    position: absolute;
-    top: 3rem;
-    inset-inline: 5rem;
-    min-height: var(--hero-min-height);
+    box-sizing: border-box;
+    margin-block-start: calc(
+      -2 * var(--page-top-margin) - var(--header-height)
+    );
+    min-block-size: 100dvh;
+    padding-block-start: var(--header-overlay);
   }
 
   @media (width <= 1200px) {
     #start-using-monero {
       scroll-margin-top: 4rem;
-    }
-  }
-
-  @media (width <= 600px) {
-    .index-hero {
-      inset-inline: 2rem;
     }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,6 +58,7 @@
 
   /* Layout Spacing */
   --page-top-margin: var(--space-2xl);
+  --header-height: 4.5rem;
   --desktop-padding-inline: 5rem;
   --mobile-padding-inline: var(--space-2xl);
 


### PR DESCRIPTION
Centers the M behind the hero on the window, and gives the hero the whole first screen so the next section is no longer visible before you scroll.

follow-ups:
* Anchor targets each guess how much of the viewport the header covers, and disagree: 6.5rem, 4rem, 4em, 3rem, 2rem and unset across five files. At 414px `#about-monero` and `#get-involved` have no offset at all, so the header hides the top 40px of their headings.
* `main` applies `--page-top-margin` as both a margin and a padding, so it carries 64px of top spacing rather than 32px. That is why the hero's negative margin here subtracts it twice.
* `--header-height` stays a declared constant, since CSS cannot measure the header. `block-size` at least makes it binding rather than a floor.